### PR TITLE
Fix `eksCluster` access modifier

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -213,7 +213,7 @@ export class Cluster extends pulumi.ComponentResource {
     /**
      * The EKS cluster.
      */
-    private readonly eksCluster: aws.eks.Cluster;
+    public readonly eksCluster: aws.eks.Cluster;
 
     /**
      * Create a new EKS cluster with worker nodes, optional storage classes, and deploy the Kubernetes Dashboard if


### PR DESCRIPTION
In PR #31, i added the `eksCluster` property... but as private. 😑
This PR fixes the access modifier to `public`.