### PR TITLE
Update to CNI 1.3

### DIFF
--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -68,10 +68,10 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.2.1
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.3.0
         imagePullPolicy: Always
         ports:
-        - containerPort: 60000
+        - containerPort: 61678
           name: metrics
         name: aws-node
         env:
@@ -122,7 +122,6 @@ spec:
   group: crd.k8s.amazonaws.com
   version: v1alpha1
   names:
-    scope: Cluster
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig


### PR DESCRIPTION
Use the latest CNI version by default.

Picked up from https://github.com/aws/amazon-vpc-cni-k8s/blob/7216b940f6787327a622f5a17a3a9f52ff621ea0/config/v1.3/aws-k8s-cni.yaml.