### PR TITLE
Expose the AutoScalingGroup on NodeGroups

### DIFF
--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 export { Cluster, ClusterOptions, ClusterNodeGroupOptions, CoreData, RoleMapping, UserMapping } from "./cluster";
-export { NodeGroup, NodeGroupOptions } from "./nodegroup";
+export { NodeGroup, NodeGroupOptions, NodeGroupData } from "./nodegroup";
 export { VpcCni, VpcCniOptions } from "./cni";
 export { StorageClass, EBSVolumeType, createStorageClass } from "./storageclass";


### PR DESCRIPTION
Also expose the defaultNodeGroup (if not skipped) from the Cluster.

Fixes #52.