### PR TITLE
Adopt newest versions of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## 0.16.7 (Unreleased)
+## 0.17.0 (Release March 6th, 2019)
 
 ### Improvements
 

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -11,9 +11,9 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
-        "@pulumi/aws": "^0.16.0",
-        "@pulumi/kubernetes": "^0.20.3",
-        "@pulumi/pulumi": "^0.16.15",
+        "@pulumi/aws": "^0.17.0",
+        "@pulumi/kubernetes": "^0.21.0",
+        "@pulumi/pulumi": "^0.17.0",
         "which": "^1.3.1"
     },
     "devDependencies": {


### PR DESCRIPTION
After this is in, I will tag this as 0.17.0, to align with rest of the 0.17.0 releases we are doing.