### PR TITLE
Prepare for 0.17.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Improvements
 
+## 0.17.2 (Release March 19, 2019)
+
+- Re-cut 0.17.1 as 0.17.2, due to a broken master branch caused by a pushed tag
+publishing the NPM package before master was able to.
+
 ## 0.17.1 (Release March 19, 2019)
 
 - Support for `taints` on `NodeGroups`. [#63](https://github.com/pulumi/pulumi-eks/pull/63)


### PR DESCRIPTION
Re-cut 0.17.1 as 0.17.2, due to a broken master branch caused by a
pushed tag publishing the NPM package before master was able to.

See travis logs:
- tag build: https://travis-ci.com/pulumi/pulumi-eks/builds/105026077
- master build: https://travis-ci.com/pulumi/pulumi-eks/builds/105026009