### PR TITLE
Reflect change to aws.iam.InstanceProfile::role typing

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -74,6 +74,7 @@ export interface CoreData {
     subnetIds: pulumi.Output<string[]>;
     clusterSecurityGroup: aws.ec2.SecurityGroup;
     provider: k8s.Provider;
+    instanceRole: pulumi.Output<aws.iam.Role>;
     instanceProfile: aws.iam.InstanceProfile;
     eksNodeAccess?: k8s.core.v1.ConfigMap;
     kubeconfig?: pulumi.Output<any>;
@@ -252,6 +253,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         kubeconfig: kubeconfig,
         provider: provider,
         vpcCni: vpcCni,
+        instanceRole: instanceRole,
         instanceProfile: instanceProfile,
         eksNodeAccess: eksNodeAccess,
     };
@@ -476,7 +478,7 @@ export class Cluster extends pulumi.ComponentResource {
         this.core = core;
         this.clusterSecurityGroup = core.clusterSecurityGroup;
         this.eksCluster = core.cluster;
-        this.instanceRole = core.instanceProfile.role;
+        this.instanceRole = core.instanceRole;
 
         // create default security group for nodegroup
         this.nodeSecurityGroup = createNodeGroupSecurityGroup(name, {

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -12,7 +12,7 @@
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
         "@pulumi/pulumi": "^0.17.1",
-        "@pulumi/aws": "^0.17.0",
+        "@pulumi/aws": "^0.18.0",
         "@pulumi/kubernetes": "^0.21.0",
         "which": "^1.3.1"
     },


### PR DESCRIPTION
This change is required because of pulumi/pulumi-aws#506 - we can no longer access the role definition through the instance profile, so instead pass it out of createCore explicitly.

The dev package is pinned because the changes are already on `master`, and need to be removed before merging after 0.18.0 of `pulumi-aws` is released.