### PR TITLE
Only use the smart default for AMI at creation time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- fix(ami): only apply AMI smart-default selection on creation
+  [#114](https://github.com/pulumi/pulumi-eks/pull/114)
+
 ## 0.18.3 (Release April 25, 2019)
 
 ### Improvements

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -11,9 +11,9 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
-        "@pulumi/aws": "^0.18.0",
+        "@pulumi/aws": "dev",
         "@pulumi/kubernetes": "^0.21.0",
-        "@pulumi/pulumi": "^0.17.4",
+        "@pulumi/pulumi": "^0.17.8",
         "which": "^1.3.1"
     },
     "devDependencies": {

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -11,7 +11,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
-        "@pulumi/aws": "dev",
+        "@pulumi/aws": "^0.18.3",
         "@pulumi/kubernetes": "^0.21.0",
         "@pulumi/pulumi": "^0.17.8",
         "which": "^1.3.1"


### PR DESCRIPTION
When we use the "smart default" to pick the most recent EKS-optimized AMI, we now also mark the image as `ignoreChanges` to ensure that we do not pick up new "smart defaults" later.  Users can still explicitly specify an `amiID`, and if they do this will also remove the `ignoreChanges` annotation so that the change will be applied.

Fixes #88.