### PR TITLE
chore(cluster): de-dupe creation of nodeSecurityGroup & ingress rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## Unreleased
-- feat(control plane logging): Enable control plane logging to cloudwatch.
-  [#100](https://github.com/pulumi/pulumi-eks/pull/117).
 
 ### Improvements
 
+- chore(cluster): de-dupe creation of nodeSecurityGroup & ingress rule
+  [#121](https://github.com/pulumi/pulumi-eks/pull/121).
+  - Note, any existing cluster that used the `nodeSecurityGroup` created in the
+  `Cluster` class, will have this security group replaced with the new one
+  created in the `NodeGroup` class. This may cause some tiny window of
+  interruption, but it is practically instantaneous.
+- feat(control plane logging): Enable control plane logging to cloudwatch.
+  [#100](https://github.com/pulumi/pulumi-eks/pull/117).
 - fix(ami): only apply AMI smart-default selection on creation
   [#114](https://github.com/pulumi/pulumi-eks/pull/114)
 


### PR DESCRIPTION
In general, the `nodeSecurityGroup` and `eksClusterIngressRule` resources are
better suited to live and be managed in the `NodeGroup` class instead of
also in the `Cluster` class, and minimizing the areas to configure these
resources is better in the long-run.

The `nodeSecurityGroup` and its related `eksClusterIngressRule` are **being
removed** from the `Cluster` class, as these steps are [duplicated and handled](https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/nodegroup.ts#L245-L260)
in the `NodeGroup` class already, if a user does not supply them.

Further examples:

  - The user could expect to provide the tags in either the `Cluster` or
  `NodeGroup` class, and this could cause confusion.
  - If the user sets `skipDefaultNodeGroup: true`, uses the `Cluster` API method
  `eks.Cluster.createNodeGroup()`, and supplies the `nodeSecurityGroup` tags
  through the API call, these tags will not be applied.
  This is because the cluster's `nodeSecurityGroup` is being created in the
  `Cluster` class, and passed as an arg to the `NodeGroup` using the API call in
  `eks.Cluster.createNodeGroup()`. And we can't tag the
  `nodeSecurityGroup` as its a ref with `.tags` set to `readonly`.

By removing both of these resources from the `Cluster` class, we'll simplify
working with the `nodeSecurityGroup` and its related rules, and make the
`NodeGroup` path and its specific resources more straight-forward.