### PR TITLE
fix(nodeSecurityGroupTags): only expose option through Cluster class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- fix(nodeSecurityGroupTags): only expose option through Cluster class
+  [#126](https://github.com/pulumi/pulumi-eks/pull/126)
 - fix(secgroups): do not null out ingress & egress
   [#128](https://github.com/pulumi/pulumi-eks/pull/128)
     - Note: This PR reverses the default null values used for the

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -121,7 +121,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         vpcId: vpcId,
         revokeRulesOnDelete: true,
         tags: <aws.Tags>{
-            "Name": `${name}`,
+            "Name": `${name}-eksClusterSecurityGroup`,
             ...args.tags,
             ...args.clusterSecurityGroupTags,
         },

--- a/nodejs/eks/examples/tags/index.ts
+++ b/nodejs/eks/examples/tags/index.ts
@@ -13,6 +13,7 @@ const cluster1 = new eks.Cluster("tags-cluster1", {
         "org": "barfoo",
     },
     clusterSecurityGroupTags: { "myClusterSecurityGroupTag1": "true" },
+    nodeSecurityGroupTags: { "myNodeSecurityGroupTag1": "true" },
     deployDashboard: false,
 });
 
@@ -31,6 +32,7 @@ const cluster2 = new eks.Cluster("tags-cluster2", {
         "org": "bar",
     },
     clusterSecurityGroupTags: { "myClusterSecurityGroupTag2": "true" },
+    nodeSecurityGroupTags: { "myNodeSecurityGroupTag2": "true" },
 });
 
 // There are two approaches that can be used to add additional NodeGroups.
@@ -45,7 +47,6 @@ cluster2.createNodeGroup("ng-tags-ondemand", {
     maxSize: 2,
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile0,
-    nodeSecurityGroupTags: { "myNodeSecurityGroupTag2": "true" },
     autoScalingGroupTags: { "myAutoScalingGroupTag2": "true" },
     cloudFormationTags: { "myCloudFormationTag2": "true" },
 });
@@ -66,7 +67,6 @@ const spot = new eks.NodeGroup("ng-tags-spot", {
             effect: "NoSchedule",
         },
     },
-    nodeSecurityGroupTags: { "myNodeSecurityGroupTag3": "true" },
     autoScalingGroupTags: { "myAutoScalingGroupTag3": "true" },
     cloudFormationTags: { "myCloudFormationTag3": "true" },
 }, {

--- a/nodejs/eks/securitygroup.ts
+++ b/nodejs/eks/securitygroup.ts
@@ -42,7 +42,7 @@ export function createNodeGroupSecurityGroup(name: string, args: NodeGroupSecuri
         vpcId: args.vpcId,
         revokeRulesOnDelete: true,
         tags: args.eksCluster.name.apply(n => <aws.Tags>{
-            "Name": `${name}`,
+            "Name": `${name}-nodeSecurityGroup`,
             [`kubernetes.io/cluster/${n}`]: "owned",
             ...args.tags,
         }),


### PR DESCRIPTION
Fixes #125.
Related #122.

Update for the new tag opts (based on orig in #122):
- New options per class:
  - `Cluster` class:
    - `.tags` - A map of tags that is applied to all AWS resources under management by a `pulumi/eks` cluster. Currently applied to: `eksClusterSecurityGroup`, `nodeSecurityGroup`, the Worker AutoScalingGroup (ASG), and cloudFormation stack.
    - `.clusterSecurityGroupTags` - A map of tags applied to the EKS Cluster security group
    - `.nodeSecurityGroupTags` - A map of tags applied to the Worker Nodes security group
  - `NodeGroup` class:
    - `.cloudFormationTags` - A map of tags applied to the CloudFormation Stack of Worker Nodes
    - `.autoScalingGroupTags` - A map of tags applied to the Worker NodeGroup ASG & Instances
    - Note:
      - If you create & pass in an external `nodeSecurityGroup`, you can tag it by manually setting the tags during its external creation, and before it is used in the NodeGroup.