### PR TITLE
fix(secgroups): do not null out ingress & egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Improvements
 - fix(secgroups): use standalone secgroup rules instead of in-line rules
-  [#108](https://github.com/pulumi/pulumi-eks/pull/108). Note, because we are
+  [#109](https://github.com/pulumi/pulumi-eks/pull/109). Note, because we are
   replacing existing in-line secgroup rules with standalone rules,
   there may be a brief period of outage where the security group rules are
   removed before they get added back. This update happens in a matter of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ### Improvements
 
+- fix(secgroups): do not null out ingress & egress
+  [#128](https://github.com/pulumi/pulumi-eks/pull/128)
+    - Note: This PR reverses the default null values used for the
+      ingress and egress in-line rules of the secgroups, introduced in `v0.18.3`.
+      The null default was required to move to standalone secgroup rules, but it
+      has introduced [issues](https://github.com/pulumi/pulumi-eks/issues/127), and thus is being removed in this PR.
+    - Upgrade Path - This is a breaking change **unless** you do the following steps:
+      - If using >= `v0.18.3`: update using the typical package update path.
+      - If using <= `v0.18.2`:
+        1. First, update your cluster from using your current version to `v0.18.4`.
+        1. Next, update your cluster from `v0.18.4` to `v0.18.5` (or higher) using the typical package update path.
+
 ## 0.18.4 (Release May 02, 2019)
 
 ### Improvements

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -118,8 +118,6 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     const eksClusterSecurityGroup = new aws.ec2.SecurityGroup(`${name}-eksClusterSecurityGroup`, {
         vpcId: vpcId,
         revokeRulesOnDelete: true,
-        ingress: [],
-        egress: [],
         tags: <aws.Tags>{
             "Name": `${name}`,
             ...args.tags,

--- a/nodejs/eks/securitygroup.ts
+++ b/nodejs/eks/securitygroup.ts
@@ -41,8 +41,6 @@ export function createNodeGroupSecurityGroup(name: string, args: NodeGroupSecuri
     const nodeSecurityGroup = new aws.ec2.SecurityGroup(`${name}-nodeSecurityGroup`, {
         vpcId: args.vpcId,
         revokeRulesOnDelete: true,
-        ingress: [],
-        egress: [],
         tags: args.eksCluster.name.apply(n => <aws.Tags>{
             "Name": `${name}`,
             [`kubernetes.io/cluster/${n}`]: "owned",


### PR DESCRIPTION
Fixes #127 

- Note: This PR reverses the default null values used for the
  ingress and egress in-line rules of the secgroups, introduced in `v0.18.3`.
  The null default was required to move to standalone secgroup rules.
- Upgrade Path - This is a breaking change **unless** you do the following steps:
  - If using >= `v0.18.3`: update using the typical package update path.
  - If using <= `v0.18.2`:
    1. First, update your cluster from using your current version to `v0.18.4`.
    1. Next, update your cluster from `v0.18.4` to `v0.18.5` (or higher) using the typical package update path.