### PR TITLE
Update link to aws-iam-authenticator install documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ or `yarn`:
 
 
 This package requires `aws-iam-authenticator` for Amazon EKS in order to deploy resources to EKS clusters. Install this
-tool using the [official instructions](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-prereqs)
-under "To install aws-iam-authenticator for Amazon EKS".
+tool using the [official instructions](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html).
 
 `kubectl` is also required if any VPC CNI options are configured; installation instructions are [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
 


### PR DESCRIPTION
The old link was pointing at a page AWS had updated which did not have
a section on this step. This link goes directly to the page about how
to install `aws-iam-authenticator`