### PR TITLE
update(aws-k8s-cni): move from 1.3.0 -> 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- update(aws-k8s-cni): move from 1.3.0 -> 1.4.1 
+  [#134](https://github.com/pulumi/pulumi-eks/pull/134)
 - fix(cluster): export missing instanceRoles in the cluster's CoreData
   [#133](https://github.com/pulumi/pulumi-eks/pull/133)
 

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -44,7 +44,8 @@ subjects:
   namespace: kube-system
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
+# kubernetes versions before 1.9.0 should use extensions/v1beta1
 metadata:
   name: aws-node
   namespace: kube-system
@@ -68,7 +69,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.3.0
+      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.4.1
         imagePullPolicy: Always
         ports:
         - containerPort: 61678
@@ -120,9 +121,11 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
-


### PR DESCRIPTION
Based on: https://git.io/fj8fD

This bumps the version of CNI used (v1.3.0 was 6+ months old).

We should look to bump to [v1.5.0](https://github.com/aws/amazon-vpc-cni-k8s/milestone/6) when possible, as it includes a [fix](https://github.com/aws/amazon-vpc-cni-k8s/pull/461) that aims to improve ENI Pod IP + CNI management, and failure + retry logic - both seem like welcomed additions, in the face of a week with an uptick in service timeouts. (Update: being tracked in #135)