### PR TITLE
Fix API doc markdown rendering issue

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -459,6 +459,7 @@ export interface ClusterOptions {
     /**
      * Whether or not to deploy the Kubernetes dashboard to the cluster. If the dashboard is deployed, it can be
      * accessed as follows:
+     *
      * 1. Retrieve an authentication token for the dashboard by running the following and copying the value of `token`
      *   from the output of the last command:
      *


### PR DESCRIPTION
Hugo's markdown renderer requires a blank line before lists in order for them to render correctly.

Follow-up from https://github.com/pulumi/docs/pull/1106 so we don't regress next time we generate the docs.