### PR TITLE
fix(tags): change map types used in all tags to pulumi.Inputs of the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- fix(tags): change map types used in all tags to pulumi.Inputs of the map
+  [#157](https://github.com/pulumi/pulumi-eks/pull/157)
 - fix(cluster): expose instanceRoles
   [#155](https://github.com/pulumi/pulumi-eks/pull/155)
 - tests(cluster): enable test to replace cluster by adding more subnets

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -24,6 +24,7 @@ import { createNodeGroup, NodeGroup, NodeGroupBaseOptions, NodeGroupData } from 
 import { createNodeGroupSecurityGroup } from "./securitygroup";
 import { ServiceRole } from "./servicerole";
 import { createStorageClass, EBSVolumeType, StorageClass } from "./storageclass";
+import { InputTags } from "./utils";
 
 /**
  * RoleMapping describes a mapping from an AWS IAM role to a Kubernetes user and groups.
@@ -79,9 +80,9 @@ export interface CoreData {
     eksNodeAccess?: k8s.core.v1.ConfigMap;
     kubeconfig?: pulumi.Output<any>;
     vpcCni?: VpcCni;
-    tags?: { [key: string]: string };
+    tags?: InputTags;
     nodeSecurityGroup?: aws.ec2.SecurityGroup;
-    nodeSecurityGroupTags?: { [key: string]: string };
+    nodeSecurityGroupTags?: InputTags;
 }
 
 export function createCore(name: string, args: ClusterOptions, parent: pulumi.ComponentResource): CoreData {
@@ -121,11 +122,14 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     const eksClusterSecurityGroup = new aws.ec2.SecurityGroup(`${name}-eksClusterSecurityGroup`, {
         vpcId: vpcId,
         revokeRulesOnDelete: true,
-        tags: <aws.Tags>{
+        tags: pulumi.all([
+            args.tags,
+            args.clusterSecurityGroupTags,
+        ]).apply(([tags, clusterSecurityGroupTags]) => (<aws.Tags>{
             "Name": `${name}-eksClusterSecurityGroup`,
-            ...args.tags,
-            ...args.clusterSecurityGroupTags,
-        },
+            ...tags,
+            ...clusterSecurityGroupTags,
+        })),
     }, { parent: parent });
 
     const eksClusterInternetEgressRule = new aws.ec2.SecurityGroupRule(`${name}-eksClusterInternetEgressRule`, {
@@ -406,7 +410,7 @@ export interface ClusterOptions {
     /**
      * The tags to apply to the cluster security group.
      */
-    clusterSecurityGroupTags?: { [key: string]: string };
+    clusterSecurityGroupTags?: InputTags;
 
     /**
      * The tags to apply to the default `nodeSecurityGroup` created by the cluster.
@@ -414,7 +418,7 @@ export interface ClusterOptions {
      * Note: The `nodeSecurityGroupTags` option and the node group option
      * `nodeSecurityGroup` are mutually exclusive.
      */
-    nodeSecurityGroupTags?: { [key: string]: string };
+    nodeSecurityGroupTags?: InputTags;
 
     /**
      * The size in GiB of a cluster node's root volume. Defaults to 20.
@@ -482,7 +486,7 @@ export interface ClusterOptions {
      * Key-value mapping of tags that are automatically applied to all AWS
      * resources directly under management with this cluster, which support tagging.
     */
-    tags?: { [key: string]: string };
+    tags?: InputTags;
 
     /**
      * Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
@@ -584,7 +588,13 @@ export class Cluster extends pulumi.ComponentResource {
             vpcId: core.vpcId,
             clusterSecurityGroup: core.clusterSecurityGroup,
             eksCluster: core.cluster,
-            tags: <aws.Tags>{...args.tags, ...args.nodeSecurityGroupTags},
+            tags: pulumi.all([
+                args.tags,
+                args.nodeSecurityGroupTags,
+            ]).apply(([tags, nodeSecurityGroupTags]) => (<aws.Tags>{
+                ...tags,
+                ...nodeSecurityGroupTags,
+            })),
         }, this);
         core.nodeSecurityGroup = this.nodeSecurityGroup;
 

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/dashboard.ts
+++ b/nodejs/eks/dashboard.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/examples/all_test.go
+++ b/nodejs/eks/examples/all_test.go
@@ -84,6 +84,22 @@ func Test_AllTests(t *testing.T) {
 				},
 			},
 		},
+		{
+			Dir: path.Join(cwd, "tests", "tag-input-types"),
+			Config: map[string]string{
+				"aws:region": region,
+			},
+			Dependencies: []string{
+				"@pulumi/eks",
+			},
+			ExpectRefreshChanges: true,
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		},
 	}
 
 	longTests := []integration.ProgramTestOptions{}

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/examples/tags/index.ts
+++ b/nodejs/eks/examples/tags/index.ts
@@ -51,7 +51,8 @@ cluster2.createNodeGroup("example-ng-tags-ondemand", {
     cloudFormationTags: { "myCloudFormationTag2": "true" },
 });
 
-// Create the second node group using a spot price instance and resource tags.
+// Create the second node group using a spot price instance, resource tags, and
+// specialized resource tags such as the autoScalingGroupTags.
 const spot = new eks.NodeGroup("example-ng-tags-spot", {
     cluster: cluster2,
     instanceType: "t2.medium",
@@ -67,7 +68,11 @@ const spot = new eks.NodeGroup("example-ng-tags-spot", {
             effect: "NoSchedule",
         },
     },
-    autoScalingGroupTags: { "myAutoScalingGroupTag3": "true" },
+    autoScalingGroupTags: cluster2.core.cluster.name.apply(clusterName => ({
+        "myAutoScalingGroupTag3": "true",
+        "k8s.io/cluster-autoscaler/enabled": "true",
+        [`k8s.io/cluster-autoscaler/${clusterName}`]: "true",
+    })),
     cloudFormationTags: { "myCloudFormationTag3": "true" },
 }, {
     providers: { kubernetes: cluster2.provider},

--- a/nodejs/eks/examples/tests/tag-input-types/Pulumi.yaml
+++ b/nodejs/eks/examples/tests/tag-input-types/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: tag-input-types
+description: EKS cluster example of various, specialized resource tags
+runtime: nodejs

--- a/nodejs/eks/examples/tests/tag-input-types/README.md
+++ b/nodejs/eks/examples/tests/tag-input-types/README.md
@@ -1,0 +1,4 @@
+# tests/tag-input-types
+
+Creates an EKS cluster with various AWS Tags input types to test passing in
+various forms of tags.

--- a/nodejs/eks/examples/tests/tag-input-types/iam.ts
+++ b/nodejs/eks/examples/tests/tag-input-types/iam.ts
@@ -1,0 +1,27 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/nodejs/eks/examples/tests/tag-input-types/index.ts
+++ b/nodejs/eks/examples/tests/tag-input-types/index.ts
@@ -1,0 +1,46 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+import * as iam from "./iam";
+
+// Create example IAM roles and profiles.
+const role0 = iam.createRole("myrole0");
+const instanceProfile0 = new aws.iam.InstanceProfile("instanceProfile0", {role: role0});
+
+// Create an EKS cluster with varying, specialized resource tags.
+const clusterSecurityGroupTags: pulumi.Input<{ [key: string]: string }> = pulumi.output("foobar").apply(out => ({
+    [out]: "myClusterSecurityGroupTag1",
+}));
+const nodeSecurityGroupTags: { [key: string]: pulumi.Input<string> } = {
+    "myNodeSecurityGroupTag1": pulumi.output("barfoo").apply(output => output),
+};
+const cluster1 = new eks.Cluster("test-tag-input-types", {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    instanceRole: role0,
+    tags: {
+        "project": "foo",
+        "org": "bar",
+    },
+    clusterSecurityGroupTags: clusterSecurityGroupTags,
+    nodeSecurityGroupTags: nodeSecurityGroupTags,
+});
+const cluster1Name = cluster1.core.cluster.name;
+
+// Create a node group with the following autoScalingGroupTags.
+const autoScalingGroupTags: pulumi.Input<{ [key: string]: pulumi.Input<string> }> = cluster1Name.apply(clusterName => ({
+    "myAutoScalingGroupTag1": "true",
+    "myOtherAutoScalingGroupTag2": clusterName,
+    [`k8s.io/cluster-autoscaler/${clusterName}`]: "true",
+    "k8s.io/cluster-autoscaler/enabled": "true",
+}));
+const ng = new eks.NodeGroup("test-tag-input-types-ondemand", {
+    cluster: cluster1,
+    instanceProfile: instanceProfile0,
+    autoScalingGroupTags: autoScalingGroupTags,
+    cloudFormationTags: { "myCloudFormationTag1": "true" },
+}, {
+    providers: { kubernetes: cluster1.provider},
+});
+
+export const kubeconfig = cluster1.kubeconfig;

--- a/nodejs/eks/examples/tests/tag-input-types/package.json
+++ b/nodejs/eks/examples/tests/tag-input-types/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "cluster",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/awsx": "latest",
+        "@pulumi/aws": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/tests/tag-input-types/tsconfig.json
+++ b/nodejs/eks/examples/tests/tag-input-types/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/securitygroup.ts
+++ b/nodejs/eks/securitygroup.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/servicerole.ts
+++ b/nodejs/eks/servicerole.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/storageclass.ts
+++ b/nodejs/eks/storageclass.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/transform.ts
+++ b/nodejs/eks/transform.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/eks/utils.ts
+++ b/nodejs/eks/utils.ts
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { Cluster, ClusterOptions, ClusterNodeGroupOptions, CoreData, RoleMapping, UserMapping } from "./cluster";
-export { NodeGroup, NodeGroupOptions, NodeGroupData } from "./nodegroup";
-export { VpcCni, VpcCniOptions } from "./cni";
-export { StorageClass, EBSVolumeType, createStorageClass } from "./storageclass";
-export { InputTags } from "./utils";
+import * as pulumi from "@pulumi/pulumi";
+
+/**
+ * InputTags represents an Input map type that can leverage dynamic string k/v
+ * for use on types that expect a k/v type with possible computed runtime values,
+ * such as special CloudFormation Tags. See
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html.
+ */
+export type InputTags = pulumi.Input<{ [key: string]: pulumi.Input<string> }>;

--- a/nodejs/tslint.json
+++ b/nodejs/tslint.json
@@ -15,7 +15,7 @@
         "eofline": true,
         "file-header": [
             true,
-            "Copyright 2016-2018, Pulumi Corporation."
+            "Copyright 2016-2019, Pulumi Corporation."
         ],
         "forin": true,
         "indent": [


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-eks/issues/146.

As showcased in the update `examples/tags/index.ts`, one can now supply `pulumi.Inputs` of the `map` types expected for the various resource tags. For example:

```
...
autoScalingGroupTags: cluster1.core.cluster.name.apply(clusterName => ({
    "myAutoScalingGroupTag1": "true",
    "myOtherAutoScalingGroupTag2": clusterName,
    [`k8s.io/cluster-autoscaler/${clusterName}`]: "true",
    "k8s.io/cluster-autoscaler/enabled": "true",
}));
```