### PR TITLE
Make VPN-only subnets private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [#175](https://github.com/pulumi/pulumi-eks/pull/175)
 - fix(tags): rm ASG tag dupes, and consider tag inheritance for all tags
   [#162](https://github.com/pulumi/pulumi-eks/pull/162)
+- fix(nodegroup): make VPN-only subnets private
+  [#163](https://github.com/pulumi/pulumi-eks/pull/163)
 
 ## 0.18.7 (Released June 12, 2019)
 

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -14,9 +14,11 @@
         "@pulumi/aws": "^0.18.3",
         "@pulumi/kubernetes": "^0.24.0",
         "@pulumi/pulumi": "^0.17.8",
+        "netmask": "^1.0.6",
         "which": "^1.3.1"
     },
     "devDependencies": {
+        "@types/netmask": "^1.0.30",
         "@types/node": "^8.0.26",
         "@types/which": "^1.3.1",
         "tslint": "^5.7.0",


### PR DESCRIPTION
The previous logic did not properly detect VPN-only subnets,
and erroneously assigned them to the public group. This fix
properly detects if the CIDR block is in a private range, and
adds that subnet to the private list.

Fixes #151 