### PR TITLE
feat(storage-classes): export all user created storage classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- feat(storage-classes): export all user created storage classes
+  [#172](https://github.com/pulumi/pulumi-eks/pull/172)
 - update(eks): add example of migrating node groups with zero downtime
   [#195](https://github.com/pulumi/pulumi-eks/pull/195)
 

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -106,6 +106,23 @@ func Test_Examples(t *testing.T) {
 				)
 			},
 		},
+		{
+			Dir: path.Join(cwd, "storage-classes"),
+			Config: map[string]string{
+				"aws:region": region,
+			},
+			Dependencies: []string{
+				"@pulumi/eks",
+			},
+			ExpectRefreshChanges: true,
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig1"],
+					info.Outputs["kubeconfig2"],
+				)
+			},
+		},
 	}
 
 	longTests := []integration.ProgramTestOptions{}

--- a/nodejs/eks/examples/storage-classes/Pulumi.yaml
+++ b/nodejs/eks/examples/storage-classes/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: example-storage-classes
+description: Creates an EKS cluster with storage classes, and showcases how to use them.
+runtime: nodejs

--- a/nodejs/eks/examples/storage-classes/README.md
+++ b/nodejs/eks/examples/storage-classes/README.md
@@ -1,0 +1,3 @@
+# examples/storage-classes
+
+Creates an EKS cluster with storage classes, and showcases how to use them.

--- a/nodejs/eks/examples/storage-classes/index.ts
+++ b/nodejs/eks/examples/storage-classes/index.ts
@@ -1,0 +1,62 @@
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+
+const projectName = pulumi.getProject();
+
+// Create an EKS cluster with a single storage class as a string.
+const cluster1 = new eks.Cluster(`${projectName}-1`, {
+    deployDashboard: false,
+    storageClasses: "io1",
+});
+
+if (cluster1.core.storageClasses) {
+    // Use a single storage class.
+    if ("io1" in cluster1.core.storageClasses) {
+        cluster1.core.storageClasses["io1"].apply(sc => {
+            sc.metadata.name.apply(n => {
+                if (n) {
+                    console.log(n);
+                }
+            });
+        });
+    }
+}
+export const kubeconfig1 = cluster1.kubeconfig;
+
+// Create an EKS cluster with many storage classes as a map.
+const cluster2 = new eks.Cluster(`${projectName}-2`, {
+    deployDashboard: false,
+    storageClasses: {
+        "mygp2": {
+            type: "gp2",
+            default: true,
+            encrypted: true,
+        },
+        "mysc1": {
+            type: "sc1",
+        },
+    },
+});
+
+if (cluster2.core.storageClasses) {
+    // Use many storage classes.
+    if ("mygp2" in cluster2.core.storageClasses) {
+        cluster2.core.storageClasses["mygp2"].apply(sc => {
+            sc.metadata.name.apply(n => {
+                if (n) {
+                    console.log(n);
+                }
+            });
+        });
+    }
+    if ("mysc1" in cluster2.core.storageClasses) {
+        cluster2.core.storageClasses["mysc1"].apply(sc => {
+            sc.metadata.name.apply(n => {
+                if (n) {
+                    console.log(n);
+                }
+            });
+        });
+    }
+}
+export const kubeconfig2 = cluster2.kubeconfig;

--- a/nodejs/eks/examples/storage-classes/package.json
+++ b/nodejs/eks/examples/storage-classes/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "example-storage-classes",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/kubernetes": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/storage-classes/tsconfig.json
+++ b/nodejs/eks/examples/storage-classes/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -17,4 +17,4 @@ export { NodeGroup, NodeGroupOptions, NodeGroupData } from "./nodegroup";
 export { VpcCni, VpcCniOptions } from "./cni";
 export { createNodeGroupSecurityGroup } from "./securitygroup";
 export { StorageClass, EBSVolumeType, createStorageClass } from "./storageclass";
-export { InputTags } from "./utils";
+export { InputTags, UserStorageClasses } from "./utils";

--- a/nodejs/eks/utils.ts
+++ b/nodejs/eks/utils.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 
 /**
@@ -21,3 +22,14 @@ import * as pulumi from "@pulumi/pulumi";
  * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html.
  */
 export type InputTags = pulumi.Input<{ [key: string]: pulumi.Input<string> }>;
+
+/**
+ * UserStorageClasses represents a map of an Output type to a
+ * k8s StorageClass to capture all of the *user-created* storage classes. This
+ * map does not include the default `gp2` automatically added by EKS.
+ *
+ * Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will
+ * always be created automatically for the cluster by the EKS service. See
+ * https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
+ */
+export type UserStorageClasses = pulumi.Output<{ [key: string]: k8s.storage.v1.StorageClass }>;


### PR DESCRIPTION
- Closes https://github.com/pulumi/pulumi-eks/issues/139 feat request.
- Fixes https://github.com/pulumi/pulumi-eks/issues/141 by exporting `StorageClasses` names that can be used, for example, to pass into Helm charts.