### PR TITLE
Default to a node AMI that matches the cluster version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- Default to a node AMI that matches the cluster version
+  [#175](https://github.com/pulumi/pulumi-eks/pull/175)
 - fix(tags): rm ASG tag dupes, and consider tag inheritance for all tags
   [#162](https://github.com/pulumi/pulumi-eks/pull/162)
 


### PR DESCRIPTION
When the user provides neither a specific Node AMI or a specific Node version, default to using the same version as the cluster control plane.

Fixes #173.