### PR TITLE
Allow more granular configuration of kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Improvements
 - fix(cluster): support configuring private and public endpoint access
   [#154](https://github.com/pulumi/pulumi-eks/pull/154)
+- fix(cluster): sllow passing additional arguments to /etc/eks/bootstrap.sh and --kubelet-extra-args
+  [#181](https://github.com/pulumi/pulumi-eks/pull/181)
+
 
 ## 0.18.8 (Released June 19, 2019)
 

--- a/nodejs/eks/examples/nodegroup/index.ts
+++ b/nodejs/eks/examples/nodegroup/index.ts
@@ -54,7 +54,7 @@ const spot = new eks.NodeGroup("example-ng-simple-spot", {
             effect: "NoSchedule",
         },
     },
-    kubeletExtraArgs: ["--alsologtostderr"],
+    kubeletExtraArgs: "--alsologtostderr",
     bootstrapExtraArgs: "--aws-api-retry-attempts 10",
     instanceProfile: instanceProfile0,
 }, {

--- a/nodejs/eks/examples/nodegroup/index.ts
+++ b/nodejs/eks/examples/nodegroup/index.ts
@@ -54,6 +54,8 @@ const spot = new eks.NodeGroup("example-ng-simple-spot", {
             effect: "NoSchedule",
         },
     },
+    kubeletExtraArgs: ["--alsologtostderr"],
+    bootstrapExtraArgs: "--aws-api-retry-attempts 10",
     instanceProfile: instanceProfile0,
 }, {
     providers: { kubernetes: cluster1.provider},

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -130,6 +130,22 @@ export interface NodeGroupBaseOptions {
     taints?: { [key: string]: Taint };
 
     /**
+     * Extra args to pass to the Kubelet.  Corresponds to the options passed in the `--kubeletExtraArgs` flag to
+     * `/etc/eks/bootstrap.sh`.  An array of flags should be provided, such as: ['--port=10251', '--address=0.0.0.0'].
+     * Note that the `labels` and `taints` properties will be applied to this list after to the expicit
+     * `kubeletExtraArgs`.
+     */
+    kubeletExtraArgs?: string[];
+
+    /**
+     * Additional args to pass directly to `/etc/eks/bootstrap.sh`.  Fror details on available options, see:
+     * https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh.  Note that the `--apiserver-endpoint`,
+     * `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration
+     * parameters.
+     */
+    bootstrapExtraArgs?: string;
+
+    /**
      * Whether or not to auto-assign public IP addresses on the EKS worker nodes.
      * If this toggle is set to true, the EKS workers will be
      * auto-assigned public IPs. If false, they will not be auto-assigned
@@ -318,7 +334,7 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
     const awsRegion = pulumi.output(aws.getRegion({}, { parent: parent }));
     const userDataArg = args.nodeUserData || pulumi.output("");
 
-    const kubeletExtraArgs: Array<string> = [];
+    const kubeletExtraArgs: Array<string> = args.kubeletExtraArgs || [];
     if (args.labels) {
         const parts = [];
         for (const key of Object.keys(args.labels)) {
@@ -338,12 +354,12 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
             kubeletExtraArgs.push("--register-with-taints=" + parts.join(","));
         }
     }
-    let bootstrapExtraArgs = "";
+    let bootstrapExtraArgs = (" " + args.bootstrapExtraArgs) || "";
     if (kubeletExtraArgs.length === 1) {
         // For backward compatibility with previous versions of this package, don't wrap a single argument with `''`.
-        bootstrapExtraArgs = ` --kubelet-extra-args ${kubeletExtraArgs[0]}`;
+        bootstrapExtraArgs += ` --kubelet-extra-args ${kubeletExtraArgs[0]}`;
     } else if (kubeletExtraArgs.length > 1) {
-        bootstrapExtraArgs = ` --kubelet-extra-args '${kubeletExtraArgs.join(" ")}'`;
+        bootstrapExtraArgs += ` --kubelet-extra-args '${kubeletExtraArgs.join(" ")}'`;
     }
 
     const userdata = pulumi.all([awsRegion, eksCluster.name, eksCluster.endpoint, eksCluster.certificateAuthority, cfnStackName, userDataArg])

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -356,7 +356,7 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
             kubeletExtraArgs.push("--register-with-taints=" + parts.join(","));
         }
     }
-    let bootstrapExtraArgs = (" " + args.bootstrapExtraArgs) || "";
+    let bootstrapExtraArgs = args.bootstrapExtraArgs ? (" " + args.bootstrapExtraArgs) : "";
     if (kubeletExtraArgs.length === 1) {
         // For backward compatibility with previous versions of this package, don't wrap a single argument with `''`.
         bootstrapExtraArgs += ` --kubelet-extra-args ${kubeletExtraArgs[0]}`;

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -120,22 +120,24 @@ export interface NodeGroupBaseOptions {
     amiId?: pulumi.Input<string>;
 
     /**
-     * Custom k8s node labels to be attached to each woker node
+     * Custom k8s node labels to be attached to each woker node.  Adds the given key/value pairs to the `--node-labels`
+     * kubelet argument.
      */
     labels?: { [key: string]: string };
 
     /**
-     * Custom k8s node taints to be attached to each worker node
+     * Custom k8s node taints to be attached to each worker node.  Adds the given taints to the `--register-with-taints`
+     * kubelet argument.
      */
     taints?: { [key: string]: Taint };
 
     /**
      * Extra args to pass to the Kubelet.  Corresponds to the options passed in the `--kubeletExtraArgs` flag to
-     * `/etc/eks/bootstrap.sh`.  An array of flags should be provided, such as: ['--port=10251', '--address=0.0.0.0'].
-     * Note that the `labels` and `taints` properties will be applied to this list after to the expicit
-     * `kubeletExtraArgs`.
+     * `/etc/eks/bootstrap.sh`.  For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints`
+     * properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after
+     * to the expicit `kubeletExtraArgs`.
      */
-    kubeletExtraArgs?: string[];
+    kubeletExtraArgs?: string;
 
     /**
      * Additional args to pass directly to `/etc/eks/bootstrap.sh`.  Fror details on available options, see:
@@ -334,7 +336,7 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
     const awsRegion = pulumi.output(aws.getRegion({}, { parent: parent }));
     const userDataArg = args.nodeUserData || pulumi.output("");
 
-    const kubeletExtraArgs: Array<string> = args.kubeletExtraArgs || [];
+    const kubeletExtraArgs = args.kubeletExtraArgs ? args.kubeletExtraArgs.split(" ") : [];
     if (args.labels) {
         const parts = [];
         for (const key of Object.keys(args.labels)) {


### PR DESCRIPTION
Allow passing through additional arguments to `/etc/eks/bootstrap.sh` and `--kubelet-extra-args`.

Fixes #180.
