### PR TITLE
refactor(nodeSecurityGroup): expose creation, and consolidate rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## Unreleased
 
 ### Improvements
+
+- refactor(secgroup): export createNodeGroupSecurityGroup & consolidate rules
+  [#183](https://github.com/pulumi/pulumi-eks/pull/183)
+- wait for EKS cluster endpoint to be available
+  [#193](https://github.com/pulumi/pulumi-eks/pull/193)
 - fix(cluster): support configuring private and public endpoint access
   [#154](https://github.com/pulumi/pulumi-eks/pull/154)
 - fix(cluster): support passing additional arguments to /etc/eks/bootstrap.sh and --kubelet-extra-args
   [#181](https://github.com/pulumi/pulumi-eks/pull/181)
-
 
 ## 0.18.8 (Released June 19, 2019)
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -634,7 +634,7 @@ export class Cluster extends pulumi.ComponentResource {
         this.instanceRoles = core.instanceRoles;
 
         // create default security group for nodegroup
-        this.nodeSecurityGroup = createNodeGroupSecurityGroup(name, {
+        [this.nodeSecurityGroup, this.eksClusterIngressRule] = createNodeGroupSecurityGroup(name, {
             vpcId: core.vpcId,
             clusterSecurityGroup: core.clusterSecurityGroup,
             eksCluster: core.cluster,
@@ -647,16 +647,6 @@ export class Cluster extends pulumi.ComponentResource {
             })),
         }, this);
         core.nodeSecurityGroup = this.nodeSecurityGroup;
-
-        this.eksClusterIngressRule = new aws.ec2.SecurityGroupRule(`${name}-eksClusterIngressRule`, {
-            description: "Allow pods to communicate with the cluster API Server",
-            type: "ingress",
-            fromPort: 443,
-            toPort: 443,
-            protocol: "tcp",
-            securityGroupId: core.clusterSecurityGroup.id,
-            sourceSecurityGroupId: this.nodeSecurityGroup.id,
-        }, { parent: this });
 
         const configDeps = [core.kubeconfig];
         if (!args.skipDefaultNodeGroup) {

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -15,5 +15,6 @@
 export { Cluster, ClusterOptions, ClusterNodeGroupOptions, CoreData, RoleMapping, UserMapping } from "./cluster";
 export { NodeGroup, NodeGroupOptions, NodeGroupData } from "./nodegroup";
 export { VpcCni, VpcCniOptions } from "./cni";
+export { createNodeGroupSecurityGroup } from "./securitygroup";
 export { StorageClass, EBSVolumeType, createStorageClass } from "./storageclass";
 export { InputTags } from "./utils";

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -293,7 +293,7 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
             throw new Error(`invalid args for node group ${name}, clusterIngressRule is required when nodeSecurityGroup is manually specified`);
         }
     } else {
-        nodeSecurityGroup = createNodeGroupSecurityGroup(name, {
+        [nodeSecurityGroup, eksClusterIngressRule] = createNodeGroupSecurityGroup(name, {
             vpcId: core.vpcId,
             clusterSecurityGroup: core.clusterSecurityGroup,
             eksCluster: eksCluster,
@@ -305,15 +305,6 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
                 ...tags,
             })),
         }, parent);
-        eksClusterIngressRule = new aws.ec2.SecurityGroupRule(`${name}-eksClusterIngressRule`, {
-            description: "Allow pods to communicate with the cluster API Server",
-            type: "ingress",
-            fromPort: 443,
-            toPort: 443,
-            protocol: "tcp",
-            securityGroupId: core.clusterSecurityGroup.id,
-            sourceSecurityGroupId: nodeSecurityGroup.id,
-        }, { parent: parent });
     }
 
     // This apply is necessary in s.t. the launchConfiguration picks up a

--- a/nodejs/eks/securitygroup.ts
+++ b/nodejs/eks/securitygroup.ts
@@ -39,7 +39,12 @@ export interface NodeGroupSecurityGroupOptions {
     eksCluster: aws.eks.Cluster;
 }
 
-export function createNodeGroupSecurityGroup(name: string, args: NodeGroupSecurityGroupOptions, parent: pulumi.ComponentResource): aws.ec2.SecurityGroup {
+/**
+ * createNodeGroupSecurityGroup creates a security group for node groups with the
+ * default ingress & egress rules required to connect and work with the EKS
+ * cluster security group.
+ */
+export function createNodeGroupSecurityGroup(name: string, args: NodeGroupSecurityGroupOptions, parent: pulumi.ComponentResource): [aws.ec2.SecurityGroup, aws.ec2.SecurityGroupRule] {
     const nodeSecurityGroup = new aws.ec2.SecurityGroup(`${name}-nodeSecurityGroup`, {
         vpcId: args.vpcId,
         revokeRulesOnDelete: true,
@@ -93,5 +98,15 @@ export function createNodeGroupSecurityGroup(name: string, args: NodeGroupSecuri
         securityGroupId: nodeSecurityGroup.id,
     }, { parent: parent });
 
-    return nodeSecurityGroup;
+    const eksClusterIngressRule = new aws.ec2.SecurityGroupRule(`${name}-eksClusterIngressRule`, {
+        description: "Allow pods to communicate with the cluster API Server",
+        type: "ingress",
+        fromPort: 443,
+        toPort: 443,
+        protocol: "tcp",
+        securityGroupId: args.clusterSecurityGroup.id,
+        sourceSecurityGroupId: nodeSecurityGroup.id,
+    }, { parent: parent });
+
+    return [nodeSecurityGroup, eksClusterIngressRule];
 }


### PR DESCRIPTION
This PR:
- Publicly exposes `createNodeSecurityGroup()` in the API for external use.
- Refactors `createNodeSecurityGroup()` to create the `eksClusterIngressRule` alongside the rest of the secgroup rules, and consolidate all rule creation.