### PR TITLE
add optional arg to create EKS cluster with IAM role entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   [#154](https://github.com/pulumi/pulumi-eks/pull/154)
 - fix(cluster): support passing additional arguments to /etc/eks/bootstrap.sh and --kubelet-extra-args
   [#181](https://github.com/pulumi/pulumi-eks/pull/181)
+- feat(cluster): Allow creating EKS cluster with IAM Role Entity
+  [#184](https://github.com/pulumi/pulumi-eks/pull/184)
 
 
 ## 0.18.8 (Released June 19, 2019)


### PR DESCRIPTION
Addresses issue: https://github.com/pulumi/pulumi-eks/issues/140

This fixes the issue of multiple AWS IAM users not being able to manage an EKS cluster within the same stack, this is due to the way EKS initially allows authentication only to the IAM entity which created the cluster (User or Role).

Creating a role and using that for the AWS provider which creates the EKS cluster makes the initial entity an IAM role that others can assume to mange the Kube resources that the Cluster deploys (RBAC ConfigMap, Dashboard, CNI Daemonset)