### PR TITLE
[WIP] Refactor VPC CNI code to use provider replace

### DIFF
--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as k8stypes from "@pulumi/kubernetes/types/input";
 import * as pulumi from "@pulumi/pulumi";
-import * as childProcess from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as jsyaml from "js-yaml";
 import * as path from "path";
-import * as process from "process";
-import * as tmp from "tmp";
-import which = require("which");
 
 /**
  * VpcCniOptions describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes.
@@ -75,13 +72,13 @@ interface VpcCniInputs {
     warmIpTarget?: number;
 }
 
-function computeVpcCniYaml(yamlPath: string, args: VpcCniInputs): string {
+function computeVpcCniYaml(yamlPath: string, args: VpcCniInputs): k8stypes.apps.v1.DaemonSet {
     // Read the CNI YAML. The original source for this YAML is
     // https://github.com/aws/amazon-vpc-cni-k8s/tree/master/config.
     const cniYamlText = fs.readFileSync(yamlPath).toString();
     const cniYaml = jsyaml.safeLoadAll(cniYamlText);
 
-    // Rewrite the envvars for the CNI daemon set as per the inputs.
+    // Rewrite the envvars for the CNI DaemonSet as per the inputs.
     const daemonSet = cniYaml.filter(o => o.kind === "DaemonSet")[0];
     const env = daemonSet.spec.template.spec.containers[0].env;
     if (args.nodePortSupport !== undefined) {
@@ -100,37 +97,20 @@ function computeVpcCniYaml(yamlPath: string, args: VpcCniInputs): string {
         env.push({name: "WARM_IP_TARGET", value: args.warmIpTarget.toString()});
     }
     // Return the computed YAML.
-    return cniYaml.map(o => `---\n${jsyaml.safeDump(o)}`).join("");
+    return daemonSet;
 }
 
 function applyVpcCniYaml(yamlPath: string, args: VpcCniInputs) {
-    // Dump the kubeconfig to a file.
-    const tmpKubeconfig = tmp.fileSync();
-    fs.writeFileSync(tmpKubeconfig.fd, args.kubeconfig);
-
-    // Compute the required CNI YAML and dump it to a file.
-    const tmpYaml = tmp.fileSync();
-    fs.writeFileSync(tmpYaml.fd, computeVpcCniYaml(yamlPath, args));
-
-    // Call kubectl to apply the YAML.
-    childProcess.execSync(`kubectl apply -f ${tmpYaml.name}`, {
-        env: { ...process.env, "KUBECONFIG": tmpKubeconfig.name },
-    });
+    const daemonSet = computeVpcCniYaml(yamlPath, args);
+    const replaced = pulumi.runtime.invoke("kubernetes:kubernetes:kubectlReplace", daemonSet);
 }
 
 /**
  * VpcCni manages the configuration of the Amazon VPC CNI plugin for Kubernetes by applying its YAML chart. Once Pulumi is
- * able to programatically manage existing infrastructure, we can replace this with a real k8s resource.
+ * able to programmatically manage existing infrastructure, we can replace this with a real k8s resource.
  */
 export class VpcCni extends pulumi.dynamic.Resource {
     constructor(name: string, kubeconfig: pulumi.Input<any>, args?: VpcCniOptions, opts?: pulumi.CustomResourceOptions) {
-        // Check to ensure that kubectl is installed, as we'll need it in order to deploy k8s resources below.
-        try {
-            which.sync("kubectl");
-        } catch (err) {
-            throw new Error("Could not set VPC CNI options: kubectl is missing. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for installation instructions.");
-        }
-
         const yamlPath = path.join(__dirname, "cni", "aws-k8s-cni.yaml");
 
         const provider = {


### PR DESCRIPTION
The k8s provider recently added an undocumented
invoke replace command, which we use here instead
of shelling out to kubectl.

Fixes #160 

Edit: This approach isn't working out. Apparently it's not possible to make resource provider calls from the environment where dynamic providers execute.