### PR TITLE
fix(test): sort subnets before using them in replace-cluster-add-subnets

### DIFF
--- a/nodejs/eks/examples/tests/replace-cluster-add-subnets/index.ts
+++ b/nodejs/eks/examples/tests/replace-cluster-add-subnets/index.ts
@@ -8,9 +8,9 @@ const vpc = new awsx.Network(`${projectName}-net`, {
     numberOfAvailabilityZones: 3,
 });
 
-const publicSubnetIds = vpc.publicSubnetIds;
+const publicSubnetIds = vpc.publicSubnetIds.sort();
 
-// Comment out / remove after init update to repro: https://git.io/fj8cn
+// Remove this line after the init update to repro: https://git.io/fj8cn
 publicSubnetIds.pop();
 
 const cluster = new eks.Cluster(projectName, {

--- a/nodejs/eks/examples/tests/replace-cluster-add-subnets/step1/index.ts
+++ b/nodejs/eks/examples/tests/replace-cluster-add-subnets/step1/index.ts
@@ -8,7 +8,7 @@ const vpc = new awsx.Network(`${projectName}-net`, {
     numberOfAvailabilityZones: 3,
 });
 
-const publicSubnetIds = vpc.publicSubnetIds;
+const publicSubnetIds = vpc.publicSubnetIds.sort();
 
 const cluster = new eks.Cluster(projectName, {
     vpcId: vpc.vpcId,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-eks/issues/199