### PR TITLE
fix(cni): modify CNI filepath to store the relative path only in state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- fix(cni): modify CNI filepath to store the relative path only in state
+  [#201](https://github.com/pulumi/pulumi-eks/pull/201)
 - feat(storage-classes): export all user created storage classes
   [#172](https://github.com/pulumi/pulumi-eks/pull/172)
 - update(eks): add example of migrating node groups with zero downtime

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -78,6 +78,9 @@ interface VpcCniInputs {
 function computeVpcCniYaml(yamlPath: string, args: VpcCniInputs): string {
     // Read the CNI YAML. The original source for this YAML is
     // https://github.com/aws/amazon-vpc-cni-k8s/tree/master/config.
+
+    // Form the absolute CNI YAML file path.
+    yamlPath = path.resolve("./", yamlPath);
     const cniYamlText = fs.readFileSync(yamlPath).toString();
     const cniYaml = jsyaml.safeLoadAll(cniYamlText);
 
@@ -131,7 +134,10 @@ export class VpcCni extends pulumi.dynamic.Resource {
             throw new Error("Could not set VPC CNI options: kubectl is missing. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for installation instructions.");
         }
 
-        const yamlPath = path.join(__dirname, "cni", "aws-k8s-cni.yaml");
+        // Form the relative CNI YAML file path.
+        const projectPath = __dirname.substring(0, __dirname.indexOf("node_modules"));
+        const relativeClassDir = __dirname.replace(projectPath, "");
+        const yamlPath = path.join(relativeClassDir, "cni/aws-k8s-cni.yaml");
 
         const provider = {
             check: (state: any, inputs: any) => Promise.resolve({inputs: inputs, failedChecks: []}),


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-eks/issues/149

This fix gets around the absolute path being inserted into the state for
the dynamic provider, by only storing the relative path for the CNI YAML
file.

The absolute path has now been pushed out to be formed and resolved in
`computeVpcCniYaml()` before the file is opened, instead of the
depending on the full path from the `applyVpcCniYaml()` caller.