### PR TITLE
Fix and improve migrate-nodegroup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- Fix and improve migrate-nodegroup test (bump CNI from `v1.5.0` -> `v1.5.2`)
+  [#214](https://github.com/pulumi/pulumi-eks/pull/214)
 - fix(asgName): check 'NodeGroup' CFStack output key exists
   [#213](https://github.com/pulumi/pulumi-eks/pull/213)
 - chore(cluster): add deprecation for kube-dashboard, customInstanceRolePolicy

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -87,6 +87,14 @@ spec:
             - containerPort: 61678
               name: metrics
           name: aws-node
+          readinessProbe:
+            exec:
+              command: ["/app/grpc_health_probe", "-addr=:50051"]
+            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command: ["/app/grpc_health_probe", "-addr=:50051"]
+            initialDelaySeconds: 5
           env:
             - name: AWS_VPC_K8S_CNI_LOGLEVEL
               value: DEBUG

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -81,7 +81,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.0
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.2
           imagePullPolicy: Always
           ports:
             - containerPort: 61678
@@ -90,6 +90,8 @@ spec:
           env:
             - name: AWS_VPC_K8S_CNI_LOGLEVEL
               value: DEBUG
+            - name: AWS_VPC_K8S_CNI_LOG_FILE
+              value: stdout
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/nodejs/eks/examples/all_test.go
+++ b/nodejs/eks/examples/all_test.go
@@ -136,8 +136,7 @@ func Test_AllTests(t *testing.T) {
 				},
 				// Migrate NGINX from the 2xlarge to the 4xlarge node group by
 				// changing its nodeSelector values, which forces migration via rolling update.
-				// Then, wait & verify all deployments are up and running.
-				// Lastly, kubectl drain & delete the unused 2xlarge node group.
+				// Then, wait & verify all resources are up and running.
 				{
 					Dir:      path.Join(cwd, "tests", "migrate-nodegroups", "steps", "step2"),
 					Additive: true,
@@ -148,6 +147,30 @@ func Test_AllTests(t *testing.T) {
 							return assert.NotEmpty(t, body, "Body should not be empty")
 						})
 
+						// Create kubeconfig clients from kubeconfig.
+						kubeconfig, err := json.Marshal(stack.Outputs["kubeconfig"])
+						assert.NoError(t, err, "expected kubeconfig JSON marshalling to not error: %v", err)
+						kubeAccess, err := utils.KubeconfigToKubeAccess(kubeconfig)
+						assert.NoError(t, err, "expected kubeconfig clients to be created: %v", err)
+
+						// Give it time for the new NGINX Deployment to
+						// migrate, and for its previous Pods to terminate.
+						time.Sleep(5 * time.Minute)
+
+						// Assert all resources, across all namespaces are still ready after migration.
+						utils.AssertKindInAllNamespacesReady(t, kubeAccess.Clientset, "replicasets")
+						utils.AssertKindInAllNamespacesReady(t, kubeAccess.Clientset, "deployments")
+					},
+				},
+				// Remove the workload namespace, and the aws-cni DaemonSet.
+				// In validation step, kubectl drain & delete the unused 2xlarge node group.
+				{
+					Dir:      path.Join(cwd, "tests", "migrate-nodegroups", "steps", "step3"),
+					Additive: true,
+					ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+						// Give it time for the workload namespace to delete.
+						time.Sleep(1 * time.Minute)
+
 						var err error
 						var out []byte
 						scriptsDir := path.Join(cwd, "tests", "migrate-nodegroups", "scripts")
@@ -155,23 +178,14 @@ func Test_AllTests(t *testing.T) {
 						// Create kubeconfig clients from kubeconfig.
 						kubeconfig, err := json.Marshal(stack.Outputs["kubeconfig"])
 						assert.NoError(t, err, "expected kubeconfig JSON marshalling to not error: %v", err)
-						kubeAccess, err := utils.KubeconfigToKubeAccess(kubeconfig)
-						assert.NoError(t, err, "expected kubeconfig clients to be created: %v", err)
-
-						// Give it a little time for the new NGINX ReplicaSet to start up and be
-						// retrievable by client-go sync loop.
-						time.Sleep(10 * time.Second)
-
-						// Assert all resources, across all namespaces are still ready after migration.
-						utils.AssertKindInAllNamespacesReady(t, kubeAccess.Clientset, "replicasets")
-						utils.AssertKindInAllNamespacesReady(t, kubeAccess.Clientset, "deployments")
 
 						// Drain & delete t3.2xlarge node group.
 
 						// TODO(metral): look into draining & deleting using
 						// client-go instead of shell'ing out to kubectl
 
-						// Write kubeconfig to temp file & export for use with kubectl drain & delete.
+						// Write kubeconfig to temp file & export it for use
+						// with kubectl.
 						kubeconfigFile, err := ioutil.TempFile(os.TempDir(), "kubeconfig-*.json")
 						assert.NoError(t, err, "expected tempfile to be created: %v", err)
 						defer os.Remove(kubeconfigFile.Name())
@@ -181,12 +195,20 @@ func Test_AllTests(t *testing.T) {
 						assert.NoError(t, err, "expected kubeconfig file to close with no error: %v", err)
 						os.Setenv("KUBECONFIG", kubeconfigFile.Name())
 
-						// Exec kubectl drain
+						// Exec kubectl delete aws-cni DaemonSet.
+						out, err = exec.Command("/bin/bash", path.Join(scriptsDir, "delete-aws-node-ds.sh")).Output()
+						assert.NoError(t, err, "expected no errors during kubectl delete ds/aws-node: %v", err)
+						utils.PrintAndLog(fmt.Sprintf("kubectl delete ds/aws-node output: %s\n", out), t)
+
+						// Give it time for the aws-cni removal to clear in AWS.
+						time.Sleep(1 * time.Minute)
+
+						// Exec kubectl drain 2xlarge nodes.
 						out, err = exec.Command("/bin/bash", path.Join(scriptsDir, "drain-t3.2xlarge-nodes.sh")).Output()
 						assert.NoError(t, err, "expected no errors during kubectl drain: %v", err)
 						utils.PrintAndLog(fmt.Sprintf("kubectl drain output: %s\n", out), t)
 
-						// Exec kubectl delete
+						// Exec kubectl delete 2xlarge nodes.
 						out, err = exec.Command("/bin/bash", path.Join(scriptsDir, "delete-t3.2xlarge-nodes.sh")).Output()
 						assert.NoError(t, err, "expected no errors during kubectl delete: %v", err)
 						utils.PrintAndLog(fmt.Sprintf("kubectl delete output: %s\n", out), t)
@@ -194,31 +216,13 @@ func Test_AllTests(t *testing.T) {
 				},
 				// Scale down the 2xlarge node group to a desired capacity of 0 workers.
 				{
-					Dir:      path.Join(cwd, "tests", "migrate-nodegroups", "steps", "step3"),
+					Dir:      path.Join(cwd, "tests", "migrate-nodegroups", "steps", "step4"),
 					Additive: true,
-					ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-						endpoint := fmt.Sprintf("%s/echoserver", stack.Outputs["nginxServiceUrl"].(string))
-						headers := map[string]string{
-							"Host": "apps.example.com",
-						}
-						utils.AssertHTTPResultWithRetry(t, endpoint, headers, 10*time.Minute, func(body string) bool {
-							return assert.NotEmpty(t, body, "Body should not be empty")
-						})
-					},
 				},
 				// Remove the unused 2xlarge node group.
 				{
-					Dir:      path.Join(cwd, "tests", "migrate-nodegroups", "steps", "step4"),
+					Dir:      path.Join(cwd, "tests", "migrate-nodegroups", "steps", "step5"),
 					Additive: true,
-					ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-						endpoint := fmt.Sprintf("%s/echoserver", stack.Outputs["nginxServiceUrl"].(string))
-						headers := map[string]string{
-							"Host": "apps.example.com",
-						}
-						utils.AssertHTTPResultWithRetry(t, endpoint, headers, 10*time.Minute, func(body string) bool {
-							return assert.NotEmpty(t, body, "Body should not be empty")
-						})
-					},
 				},
 			},
 		},

--- a/nodejs/eks/examples/tests/migrate-nodegroups/config.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/config.ts
@@ -4,4 +4,5 @@ export const config = {
     createNodeGroup4xlarge: false,
     desiredCapacity4xlarge: 0,
     nginxNodeSelectorTermValues: ["t3.2xlarge"],
+    deployWorkload: true,
 };

--- a/nodejs/eks/examples/tests/migrate-nodegroups/scripts/delete-aws-node-ds.sh
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/scripts/delete-aws-node-ds.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl delete ds/aws-node -n kube-system

--- a/nodejs/eks/examples/tests/migrate-nodegroups/scripts/delete-workload.sh
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/scripts/delete-workload.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl delete namespace $1

--- a/nodejs/eks/examples/tests/migrate-nodegroups/steps/step1/config.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/steps/step1/config.ts
@@ -1,8 +1,9 @@
-// Enable the creation of the 4xlarge node group.
+// Create the 4xlarge node group.
 export const config = {
     createNodeGroup2xlarge: true,
     desiredCapacity2xlarge: 3,
     createNodeGroup4xlarge: true,
     desiredCapacity4xlarge: 5,
     nginxNodeSelectorTermValues: ["t3.2xlarge"],
+    deployWorkload: true,
 };

--- a/nodejs/eks/examples/tests/migrate-nodegroups/steps/step2/config.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/steps/step2/config.ts
@@ -1,8 +1,9 @@
-// Enable the migration of NGINX from the 2xlarge -> 4xlarge node group.
+// Migrate NGINX from the 2xlarge -> 4xlarge node group.
 export const config = {
     createNodeGroup2xlarge: true,
     desiredCapacity2xlarge: 3,
     createNodeGroup4xlarge: true,
     desiredCapacity4xlarge: 5,
     nginxNodeSelectorTermValues: ["c5.4xlarge"],
+    deployWorkload: true,
 };

--- a/nodejs/eks/examples/tests/migrate-nodegroups/steps/step3/config.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/steps/step3/config.ts
@@ -1,8 +1,8 @@
-// Scale down the 2xlarge node group to a desired capacity of 0 workers.
+// Remove the NGINX & echoserver workload.
 export const config = {
     createNodeGroup2xlarge: true,
-    desiredCapacity2xlarge: 0,
+    desiredCapacity2xlarge: 3,
     createNodeGroup4xlarge: true,
     desiredCapacity4xlarge: 5,
-    nginxNodeSelectorTermValues: ["c5.4xlarge"],
+    deployWorkload: false,
 };

--- a/nodejs/eks/examples/tests/migrate-nodegroups/steps/step5/config.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/steps/step5/config.ts
@@ -1,6 +1,6 @@
-// Scale down the 2xlarge node group to a desired capacity of 0 workers.
+// Remove the 2xlarge node group.
 export const config = {
-    createNodeGroup2xlarge: true,
+    createNodeGroup2xlarge: false,
     desiredCapacity2xlarge: 0,
     createNodeGroup4xlarge: true,
     desiredCapacity4xlarge: 5,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-eks/issues/194.

The changes in this fix resolve a leaked ENI that lead to a dependency violation on tear down. It was resolved by bumping up `aws-cni` to v1.5.2 that was recently [released](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.5.2) [1]. We now also:
 - Wait 5 min after the migration step to ensure it completes,
 - Delete the workload Namespace, and `aws-cni` DaemonSet to ensure these get explicitly torn down.

This fix was tested across 70+ runs of the `migrate-nodegroup` test, and no run hit issue #194.

Additionally, `logLevel`, `logFile`, and `image` have been added as options to `VpcCniOptions`, and defaults for logging have been adjusted to be verbose, and be produced for the `aws-cni` Pods.

---

[1] - The specific fixes in `aws-cni` v1.5.2 were:
  - [Detach ENI before deleting.](https://github.com/aws/amazon-vpc-cni-k8s/pull/538)
  - The addition of a `healthz` endpoint: https://github.com/aws/amazon-vpc-cni-k8s/pull/548 and https://github.com/aws/amazon-vpc-cni-k8s/pull/553. The `healthz` endpoint is used in the readiness & liveness probes of the DaemonSet.