### PR TITLE
fix(examples): typos, readme desc, and rm dupe tags of asg & cf

### DIFF
--- a/nodejs/eks/Makefile
+++ b/nodejs/eks/Makefile
@@ -9,7 +9,7 @@ export PATH := $(shell yarn bin 2>/dev/null):$(PATH)
 TESTPARALLELISM := 20
 
 # Enable debugging output and logs
-export PULUMI_TEST_DEBUG_LOG_LEVEL = 2
+export PULUMI_TEST_DEBUG_LOG_LEVEL = 9
 export PULUMI_TEST_DEBUG_UPDATES = true
 
 build::

--- a/nodejs/eks/examples/cluster/README.md
+++ b/nodejs/eks/examples/cluster/README.md
@@ -1,4 +1,3 @@
 # examples/cluster
 
-Creates an EKS cluster in the default VPC with two t2.medium nodes, a "gp2"-backed StorageClass, and a deployment of
-the Kubernetes dashboard.
+Creates an EKS cluster in the default VPC with two t2.medium nodes.

--- a/nodejs/eks/examples/private-workers/README.md
+++ b/nodejs/eks/examples/private-workers/README.md
@@ -1,3 +1,3 @@
-# examples/private-cluster
+# examples/private-workers
 
-Creates an EKS cluster in a VPC that uses private subnets for workers, with two t2.medium nodes, and a "gp2"-backed StorageClass.
+Creates an EKS cluster in a VPC that uses private subnets for workers, with two t2.medium nodes.

--- a/nodejs/eks/examples/tags/README.md
+++ b/nodejs/eks/examples/tags/README.md
@@ -1,11 +1,8 @@
 # examples/tags
 
-Demonstrates how to use cluster and resource tags in differnt ways with Node Groups.
+Demonstrates how to use AWS resource tags.
 
-For each case, it will create an EKS cluster in the default VPC without worker nodes.
+We'll create and configure the following clusters:
 
-Then, create the following clusters:
-* Simple case - apply tags to all cluster managed resources, as well as apply specific resource tags.
-* Advanced case:
-  * ondemand node group on the Cluster, using node group specific resource tags.
-  * spot price node group, using the Cluster, and node group specific resource tags.
+* Default cluster with no node groups and resource tags.
+* Cluster with many node groups and resource tags.

--- a/nodejs/eks/examples/tags/index.ts
+++ b/nodejs/eks/examples/tags/index.ts
@@ -47,7 +47,6 @@ cluster2.createNodeGroup("example-ng-tags-ondemand", {
     maxSize: 2,
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile0,
-    autoScalingGroupTags: { "myAutoScalingGroupTag2": "true" },
     cloudFormationTags: { "myCloudFormationTag2": "true" },
 });
 
@@ -73,7 +72,6 @@ const spot = new eks.NodeGroup("example-ng-tags-spot", {
         "k8s.io/cluster-autoscaler/enabled": "true",
         [`k8s.io/cluster-autoscaler/${clusterName}`]: "true",
     })),
-    cloudFormationTags: { "myCloudFormationTag3": "true" },
 }, {
     providers: { kubernetes: cluster2.provider},
 });


### PR DESCRIPTION
### Proposed changes

- fix(examples): typos, readme desc, and rm dupe tags of asg & cf
- test(makefile): bump up debug logging verbosity from level 2 -> 9
