### PR TITLE
Add publicSubnetIds and privateSubnetIds cluster opts. Update tests to use new awsx.ec2.Vpc API and new subnet opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Add new publicSubnetIds and privateSubnetIds cluster options. Also, update
+  tests to use new awsx.ec2.Vpc API and new subnet options
+  [#238](https://github.com/pulumi/pulumi-eks/pull/238)
 - fix(iam): improve YAML error handling & reporting in IAM ops
   [#231](https://github.com/pulumi/pulumi-eks/pull/231)
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -84,6 +84,8 @@ export interface CoreData {
     cluster: aws.eks.Cluster;
     vpcId: pulumi.Output<string>;
     subnetIds: pulumi.Output<string[]>;
+    publicSubnetIds: pulumi.Output<string[]>;
+    privateSubnetIds: pulumi.Output<string[]>;
     clusterSecurityGroup: aws.ec2.SecurityGroup;
     provider: k8s.Provider;
     instanceRoles: pulumi.Output<aws.iam.Role[]>;
@@ -223,14 +225,38 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         throw new Error("instanceRole and instanceRoles are mutually exclusive, and cannot both be set.");
     }
 
-    // If no VPC was specified, use the default VPC.
+    if (args.subnetIds && (args.publicSubnetIds || args.privateSubnetIds)) {
+        throw new Error("subnetIds, and the use of publicSubnetIds and/or privateSubnetIds are mutually exclusive. Choose a single approach.");
+    }
+
+    // Configure default networking architecture.
     let vpcId: pulumi.Input<string> = args.vpcId!;
     let subnetIds: pulumi.Input<pulumi.Input<string>[]> = args.subnetIds!;
-    if (args.vpcId === undefined) {
+    const publicSubnetIds: pulumi.Input<pulumi.Input<string>[]> = args.publicSubnetIds!;
+    const privateSubnetIds: pulumi.Input<pulumi.Input<string>[]> = args.privateSubnetIds!;
+    let clusterSubnetIds: pulumi.Input<pulumi.Input<string>[]> = [];
+
+    // If no VPC is set, use the default VPC's subnets.
+    if (!args.vpcId) {
         const invokeOpts = { parent: parent };
         const vpc = aws.ec2.getVpc({ default: true }, invokeOpts);
         vpcId = vpc.then(v => v.id);
         subnetIds = vpc.then(v => aws.ec2.getSubnetIds({ vpcId: v.id }, invokeOpts)).then(subnets => subnets.ids);
+        clusterSubnetIds = subnetIds;
+    }
+
+    // Form the subnetIds to use on the cluster from either:
+    //  - subnetIds
+    //  - A combination of privateSubnetIds and/or publicSubnetIds.
+    if (args.subnetIds) {
+        clusterSubnetIds = subnetIds;
+    } else if (args.publicSubnetIds || args.privateSubnetIds) {
+        clusterSubnetIds = pulumi.all([
+            args.publicSubnetIds || [],
+            args.privateSubnetIds || [],
+        ]).apply(([publicIds, privateIds]) => {
+            return [...publicIds, ...privateIds];
+        });
     }
 
     // Create the EKS service role
@@ -282,7 +308,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         roleArn: eksRole.apply(r => r.arn),
         vpcConfig: {
             securityGroupIds: [eksClusterSecurityGroup.id],
-            subnetIds: subnetIds,
+            subnetIds: clusterSubnetIds,
             endpointPrivateAccess: args.endpointPrivateAccess,
             endpointPublicAccess: args.endpointPublicAccess,
         },
@@ -447,6 +473,8 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     return {
         vpcId: pulumi.output(vpcId),
         subnetIds: pulumi.output(subnetIds),
+        publicSubnetIds: pulumi.output(publicSubnetIds),
+        privateSubnetIds: pulumi.output(privateSubnetIds),
         clusterSecurityGroup: eksClusterSecurityGroup,
         cluster: eksCluster,
         kubeconfig: kubeconfig,
@@ -484,12 +512,81 @@ export interface ClusterOptions {
     vpcId?: pulumi.Input<string>;
 
     /**
-     * The subnets to attach to the EKS cluster. If either vpcId or subnetIds is unset, the cluster will use the
-     * default VPC's subnets. If the list of subnets includes both public and private subnets, the Kubernetes API
-     * server and the worker nodes will only be attached to the private subnets. See
-     * https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html for more details.
+     * The set of subnets to use on the EKS cluster.
+     * These subnets are automatically tagged by EKS for Kubernetes purposes.
+     *
+     * Note, `vpcId` must be set. If not, then the cluster will use the AWS
+     * account's default VPC subnets.
+     *
+     * If the list of subnets includes both public and private subnets, the worker
+     * nodes will only be attached to the private subnets, and the public
+     * subnets will be used for internet-facing load balancers.
+     *
+     * See for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.
+     *
+     * Note, the use of `subnetIds`, and the combination of `publicSubnetIds`
+     * and/or `privateSubnetIds` is mutually exclusive. The former is the
+     * current implementation, and the latter combination
+     * is newer functionality.
      */
     subnetIds?: pulumi.Input<pulumi.Input<string>[]>;
+
+    /**
+     * The set of public subnets to use on the cluster. These subnets
+     * are used as the default public subnets for the worker node groups, and
+     * are automatically tagged by EKS for Kubernetes purposes.
+     *
+     * Note, `vpcId` must be set. If not, then the cluster will use the AWS
+     * account's default VPC subnets.
+     *
+     * Network architecture options:
+     *  - Private-only: Only set `privateSubnetIds`.
+     *    - Default workers to run in a private subnet and Kubernetes cannot create internet-facing load
+     *  balancers for your pods.
+     *  - Public-only: Only set `publicSubnetIds`.
+     *    - Default workers to run in a public subnet, including your worker nodes.
+     *  - Mixed (recommended): Set both `privateSubnetIds` and `publicSubnetIds`.
+     *    - Default all worker nodes to run in private subnets, and use the public subnets
+     *  for internet-facing load balancers.
+     *
+     * See for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.
+     *
+     * Note, the use of `subnetIds`, and the combination of `publicSubnetIds`
+     * and/or `privateSubnetIds` is mutually exclusive. The former is the
+     * current implementation, and the latter combination
+     * is newer functionality.
+     */
+    publicSubnetIds?: pulumi.Input<pulumi.Input<string>[]>;
+
+    /*
+     * The set of private subnets to use on the cluster. These subnets
+     * are used as the default private subnets for the worker node groups, and
+     * are automatically tagged by EKS for Kubernetes purposes.
+     *
+     * Note, `vpcId` must be set. If not, then the cluster will use the AWS
+     * account's default VPC subnets.
+     *
+     * Network architecture options:
+     *  - Private-only: Only set `privateSubnetIds`.
+     *    - Default workers to run in a private subnet and Kubernetes cannot create internet-facing load
+     *  balancers for your pods.
+     *  - Public-only: Only set `publicSubnetIds`.
+     *    - Default workers to run in a public subnet, including your worker nodes.
+     *  - Mixed (recommended): Set both `privateSubnetIds` and `publicSubnetIds`.
+     *    - Default all worker nodes to run in private subnets, and use the public subnets
+     *  for internet-facing load balancers.
+     *
+     * See for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.
+     *
+     * Note, the use of `subnetIds`, and the combination of `publicSubnetIds`
+     * and/or `privateSubnetIds` is mutually exclusive. The former is the
+     * current implementation, and the latter combination
+     * is newer functionality.
+     *
+     * Also consider setting `nodeAssociatePublicIpAddress: true` for
+     * fully private workers.
+    */
+    privateSubnetIds?: pulumi.Input<pulumi.Input<string>[]>;
 
     /**
      * Whether or not to auto-assign the EKS worker nodes public IP addresses.

--- a/nodejs/eks/examples/all_test.go
+++ b/nodejs/eks/examples/all_test.go
@@ -95,6 +95,23 @@ func Test_AllTests(t *testing.T) {
 			},
 		}),
 		{
+			Dir: path.Join(cwd, "tests", "awsx-network-and-subnetIds"),
+			Config: map[string]string{
+				"aws:region": region,
+			},
+			Dependencies: []string{
+				"@pulumi/eks",
+			},
+			ExpectRefreshChanges: true,
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig1"],
+					info.Outputs["kubeconfig2"],
+				)
+			},
+		},
+		{
 			Dir: path.Join(cwd, "tests", "migrate-nodegroups"),
 			Config: map[string]string{
 				"aws:region": region,

--- a/nodejs/eks/examples/cluster/README.md
+++ b/nodejs/eks/examples/cluster/README.md
@@ -1,3 +1,5 @@
 # examples/cluster
 
-Creates an EKS cluster in the default VPC with two t2.medium nodes.
+Creates two EKS clusters in the default VPC with two t2.medium nodes.
+- One cluster uses the default configuration.
+- One cluster uses a non-default configuration.

--- a/nodejs/eks/examples/cluster/index.ts
+++ b/nodejs/eks/examples/cluster/index.ts
@@ -1,14 +1,20 @@
+import * as pulumi from "@pulumi/pulumi";
 import * as awsx from "@pulumi/awsx";
 import * as eks from "@pulumi/eks";
 
-// Create an EKS cluster with the default configuration.
-const cluster1 = new eks.Cluster("example-cluster1");
+const projectName = pulumi.getProject();
 
-// Create an EKS cluster with non-default configuration
-const vpc = new awsx.Network("example-cluster2-vpc", { usePrivateSubnets: true });
-const cluster2 = new eks.Cluster("example-cluster2", {
-    vpcId: vpc.vpcId,
-    subnetIds: vpc.subnetIds,
+// Create an EKS cluster with the default configuration.
+const cluster1 = new eks.Cluster(`${projectName}-1`);
+
+// Create an EKS cluster with a non-default configuration.
+const vpc = new awsx.ec2.Vpc(`${projectName}-2`, {
+    tags: { "Name": `${projectName}-2` },
+});
+
+const cluster2 = new eks.Cluster(`${projectName}-2`, {
+    vpcId: vpc.id,
+    publicSubnetIds: vpc.publicSubnetIds,
     desiredCapacity: 2,
     minSize: 2,
     maxSize: 2,

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/Pulumi.yaml
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-awsx-network-and-subnetIds
+description: EKS cluster examples using the previous awsx.Network API and cluster network setups.
+runtime: nodejs

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/README.md
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/README.md
@@ -1,0 +1,7 @@
+# test-awsx-network-and-subnetIds
+
+EKS cluster examples using the previous `awsx.Network` API and cluster network setups.
+
+Tests two types of clusters that use the previous network API setup:
+- One cluster uses a VPC from the `awsx.Network` API, and cluster `subnetIds`.
+- One cluster uses a VPC from the `awsx.Network` API, cluster `subnetIds`, and a node group with the `nodeSubnetIds` override option.

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/iam.ts
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/iam.ts
@@ -1,0 +1,27 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attaches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/index.ts
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/index.ts
@@ -1,0 +1,40 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as iam from "./iam";
+
+const projectName = pulumi.getProject();
+
+// Create an EKS cluster with awsx.Network VPC and cluster subnetIds.
+const vpc1 = new awsx.Network(`${projectName}-1`);
+const cluster1 = new eks.Cluster(`${projectName}-1`, {
+    vpcId: vpc1.vpcId,
+    subnetIds: vpc1.subnetIds,
+    deployDashboard: false,
+});
+
+const role = iam.createRole("role");
+const instanceProfile = new aws.iam.InstanceProfile("instanceProfile", {role: role});
+
+// Create an EKS cluster with awsx.Network VPC and a nodegroup with
+// nodeSubnetIds overrides.
+const vpc2 = new awsx.Network(`${projectName}-2`);
+const cluster2 = new eks.Cluster(`${projectName}-2`, {
+    vpcId: vpc2.vpcId,
+    subnetIds: vpc2.subnetIds,
+    deployDashboard: false,
+    instanceRole: role,
+});
+
+// Create the node group with the nodeSubnetIds override option.
+const ng = new eks.NodeGroup(`${projectName}-2-ng`, {
+    cluster: cluster2,
+    nodeSubnetIds: vpc2.publicSubnetIds,
+}, {
+    providers: { kubernetes: cluster2.provider},
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig1 = cluster1.kubeconfig;
+export const kubeconfig2 = cluster2.kubeconfig;

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/package.json
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "test-awsx-network-and-subnetIds",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0-beta",
+        "@pulumi/aws": "^1.0.0-beta",
+        "@pulumi/awsx": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/package.json
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/package.json
@@ -5,11 +5,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0-beta",
-        "@pulumi/aws": "^1.0.0-beta",
-        "@pulumi/awsx": "latest"
-    },
-    "peerDependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/awsx": "latest",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/awsx-network-and-subnetIds/tsconfig.json
+++ b/nodejs/eks/examples/tests/awsx-network-and-subnetIds/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/examples/tests/replace-cluster-add-subnets/index.ts
+++ b/nodejs/eks/examples/tests/replace-cluster-add-subnets/index.ts
@@ -4,8 +4,11 @@ import * as pulumi from "@pulumi/pulumi";
 
 const projectName = pulumi.getProject();
 
-const vpc = new awsx.Network(`${projectName}-net`, {
+// Allocate a new VPC with custom settings, and a public & private subnet per AZ.
+const vpc = new awsx.ec2.Vpc(`${projectName}`, {
+    cidrBlock: "172.16.0.0/16",
     numberOfAvailabilityZones: 3,
+    tags: { "Name": `${projectName}` },
 });
 
 const publicSubnetIds = vpc.publicSubnetIds;
@@ -13,9 +16,9 @@ const publicSubnetIds = vpc.publicSubnetIds;
 // Remove this line after the init update to repro: https://git.io/fj8cn
 publicSubnetIds.pop();
 
-const cluster = new eks.Cluster(projectName, {
-    vpcId: vpc.vpcId,
-    subnetIds: publicSubnetIds,
+const cluster = new eks.Cluster(`${projectName}`, {
+    vpcId: vpc.id,
+    publicSubnetIds: publicSubnetIds,
     deployDashboard: false,
 });
 

--- a/nodejs/eks/examples/tests/replace-cluster-add-subnets/step1/index.ts
+++ b/nodejs/eks/examples/tests/replace-cluster-add-subnets/step1/index.ts
@@ -4,15 +4,18 @@ import * as pulumi from "@pulumi/pulumi";
 
 const projectName = pulumi.getProject();
 
-const vpc = new awsx.Network(`${projectName}-net`, {
+// Allocate a new VPC with custom settings, and a public & private subnet per AZ.
+const vpc = new awsx.ec2.Vpc(`${projectName}`, {
+    cidrBlock: "172.16.0.0/16",
     numberOfAvailabilityZones: 3,
+    tags: { "Name": `${projectName}` },
 });
 
-const publicSubnetIds = vpc.publicSubnetIds.sort();
+const publicSubnetIds = vpc.publicSubnetIds;
 
-const cluster = new eks.Cluster(projectName, {
-    vpcId: vpc.vpcId,
-    subnetIds: publicSubnetIds,
+const cluster = new eks.Cluster(`${projectName}`, {
+    vpcId: vpc.id,
+    publicSubnetIds: publicSubnetIds,
     deployDashboard: false,
 });
 

--- a/nodejs/eks/examples/tests/replace-secgroup/step1/index.ts
+++ b/nodejs/eks/examples/tests/replace-secgroup/step1/index.ts
@@ -10,10 +10,14 @@ const projectName = pulumi.getProject();
 // Create an EKS cluster with non-default configuration
 const role = iam.createRole(`${projectName}-role`);
 const instanceProfile = new aws.iam.InstanceProfile(`${projectName}-instanceProfile`, {role: role});
-const vpc = new awsx.Network(`${projectName}-vpc`, { usePrivateSubnets: true });
+const vpc = new awsx.ec2.Vpc(`${projectName}`, {
+    cidrBlock: "172.16.0.0/16",
+    tags: { "Name": `${projectName}` },
+});
+
 const testCluster = new eks.Cluster(`${projectName}`, {
-    vpcId: vpc.vpcId,
-    subnetIds: vpc.subnetIds,
+    vpcId: vpc.id,
+    publicSubnetIds: vpc.publicSubnetIds,
     skipDefaultNodeGroup: true,
     instanceRole: role,
 });

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -44,9 +44,16 @@ export interface Taint {
 export interface NodeGroupBaseOptions {
 
     /**
-     * The IDs of the explicit node subnets to attach to the worker node group.
+     * The explicit subnet IDs to use for the worker node group.
      *
-     * This option overrides clusterSubnetIds option.
+     * The IDs used must be a subset, or the whole set of IDs passed to the
+     * `Cluster` specified by either:
+     *  - `subnetIds`, or
+     *  - A combination of `publicSubnetIds` and/or `privateSubnetIds`.
+     *
+     * Setting this option overrides which subnets to use for the worker node
+     * group, regardless if the cluster's `subnetIds` exist for auto-discovery,
+     * or if a combination of `publicSubnetIds` and/or `privateSubnetIds` were set.
      */
     nodeSubnetIds?: pulumi.Input<pulumi.Input<string>[]>;
 
@@ -448,7 +455,26 @@ ${customUserData}
         userData: userdata,
     }, { parent: parent, ignoreChanges: ignoreChanges });
 
-    const workerSubnetIds = args.nodeSubnetIds ? pulumi.output(args.nodeSubnetIds) : pulumi.output(core.subnetIds).apply(ids => computeWorkerSubnets(parent, ids));
+    // Compute the worker node group subnets to use from the various approaches.
+    let workerSubnetIds: pulumi.Output<string[]> = pulumi.output([]);
+    workerSubnetIds = pulumi.all([
+        args.nodeSubnetIds,
+        core.privateSubnetIds,
+        core.publicSubnetIds,
+        core.subnetIds,
+    ]).apply(([overrideIds, privateIds, publicIds, subnetIds]) => {
+        if (overrideIds) { // Use the specified override subnetIds.
+            return pulumi.output(overrideIds);
+        } else if (privateIds) { // Use the specified private subnetIds.
+            return pulumi.output(privateIds);
+        } else if (publicIds) { // Use the specified public subnetIds.
+            return pulumi.output(publicIds);
+        }
+        // Use subnetIds from the cluster. Compute / auto-discover the private worker subnetIds from this set.
+        return pulumi.output(subnetIds).apply(ids => computeWorkerSubnets(parent, ids));
+    });
+
+    // Configure the settings for the autoscaling group.
     if (args.desiredCapacity === undefined) {
         args.desiredCapacity = 2;
     }
@@ -462,7 +488,6 @@ ${customUserData}
     if (args.spotPrice) {
         minInstancesInService = 0;
     }
-
     const autoScalingGroupTags: InputTags = pulumi.all([
         eksCluster.name,
         args.autoScalingGroupTags,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes


**\*It helps to review this PR by going through each commit separately.**\*

1. **feat(subnetIds): add new opts: publicSubnetIds and privateSubnetIds**

    This change intends to tackle 2 cases:
    - Simplifying cluster subnet defintion by explicitly accepting both
    public and private subnets, and
    - To properly build the cluster dependency graph w.r.t. the subnets used by the
    cluster. This should produce expected results for nodegroup subnet definition
    between initial updates and proceeding empty preview steps.

    Cluster worker subnet definition benefits from having individual `publicSubnetIds`
    and `privateSubnetIds` options, as they are:
    - Explicit in defintion of which subnets are being used for a given subnet class.
    - Inline with user practice, and
    - `computeWorkerSubnets()` in the NodeGroup class is an approximation
    of the which subnets belong to which class, and it can occassionaly experience
    non-deterministic issues.
1. **fix(tests): update awsx.Network -> awsx.ec2.Vpc & use specific subnetIds**
    - Update tests that use VPCs created with `awsx.Network` to the newer
    `awsx.ec2.Vpc` API.
    - Remove any `awsx.ec2.Vpc` settings already set by defaults.
    - Update EKS cluster definitions that used the `eks.Cluster.subnetIds` to
    now use the new subnet options: `eks.Cluster.publicSubnetIds` and `eks.Cluster.privateSubnetIds`.
1. **test(awsx-network-and-subnetIds): add test of older VPC & network setup**
    Add new test which creates EKS clusters using the previous `awsx.Network` API
    and related cluster network setups.

    This test creates two types of clusters that use the previous network API setup:
    - One cluster uses a VPC from the `awsx.Network` API, and cluster `subnetIds`.
    - One cluster uses a VPC from the `awsx.Network` API, cluster
    `subnetIds`, and a node group with the `nodeSubnetIds` override option.
### Related issues

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes https://github.com/pulumi/pulumi-eks/issues/199
Closes https://github.com/pulumi/pulumi-eks/issues/179