### PR TITLE
Fix CI OOM errors in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ check_clean_worktree:
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all
 travis_push: only_build check_clean_worktree only_test publish_packages
-travis_pull_request: only_build check_clean_worktree only_test_fast
+travis_pull_request: all
 travis_api: all

--- a/build/common.mk
+++ b/build/common.mk
@@ -106,8 +106,8 @@ endif
 PULUMI_BIN          := $(PULUMI_ROOT)/bin
 PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules
 
-GO_TEST_FAST = PATH=$(PULUMI_BIN):$(PATH) go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
-GO_TEST = PATH=$(PULUMI_BIN):$(PATH) go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
+GO_TEST_FAST = PATH=$(PULUMI_BIN):$(PATH) GOGC=25 go test -short -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
+GO_TEST = PATH=$(PULUMI_BIN):$(PATH) GOGC=25 go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
 GOPROXY = 'https://proxy.golang.org'
 
 .PHONY: default all ensure only_build only_test only_test_fast build lint install test_all core


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR aims to test **all tests** on all future feature branch PRs to catch errors before they hit master, and adjust the Go Garbage Collector to clean up the heap when its at 25% of its size:

- fix(makefile): run all tests on PRs to properly test merging into master
- fix(build/make): set GOGC before invoking Go tests to fix OOM errors in CI

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes https://github.com/pulumi/pulumi-eks/issues/243
