### PR TITLE
Consume the build-package-docs script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ include build/common.mk
 publish_packages:
 	$(call STEP_MESSAGE)
 	./scripts/publish_packages.sh
+	$$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh eks
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Use this script to automatically regenerate the package documentation on
each new release.