### PR TITLE
Don't fail if packages have already been published

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
-if: branch = master OR branch =~ ^release/ OR tag IS present
+if: branch = master OR branch =~ ^features/ OR branch =~ ^release/ OR tag IS present
 language: go
 go: 1.12.1
 sudo: true # give us 7.5GB and >2 bursted cores.

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -18,15 +18,43 @@ publish() {
 
     NPM_TAG="dev"
 
+    # We use the "features/" prefix on branches that we want to build and publish for doing
+    # cross repo work. But in this case, we don't want to publish over "dev", since the bits
+    # could be totally busted and the dev tag tracks master.
+    if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
+        NPM_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|feature-|g')
+    fi
+
+    PKG_NAME=$(jq -r .name < package.json)
+    PKG_VERSION=$(jq -r .version < package.json)
+
     # If the package doesn't have a pre-release tag, use the tag of latest instead of
     # dev. NPM uses this tag as the default version to add, so we want it to mean
     # the newest released version.
-    if [[ $(jq -r .version < package.json) != *-* ]]; then
+    if [[ "${PKG_VERSION}" != *-* ]]; then
         NPM_TAG="latest"
     fi
 
-    # Now, perform the publish.
-    npm publish -tag ${NPM_TAG}
+    # Now, perform the publish. The logic here is a little goofy because npm provides
+    # no way to say "if the package already exists, don't fail" but we want these
+    # semantics (so, for example, we can restart builds which may have failed after
+    # publishing, or so two builds can run concurrently, which is the case for when we
+    # tag master right after pushing a new commit and the push and tag travis jobs both
+    # get the same version.
+    #
+    # We exploit the fact that `npm info <package-name>@<package-version>` has no output
+    # when the package does not exist.
+    if [ "$(npm info ${PKG_NAME}@${PKG_VERSION})" == "" ]; then
+        if ! npm publish -tag "${NPM_TAG}"; then
+	    # if we get here, we have a TOCTOU issue, so check again
+	    # to see if it published. If it didn't bail out.
+	    if [ "$(npm info ${PKG_NAME}@${PKG_VERSION})" == "" ]; then
+		echo "NPM publishing failed, aborting"
+		exit 1
+	    fi
+
+	fi
+    fi
     npm info 2>/dev/null
 
     # And finally restore the original package.json.


### PR DESCRIPTION
This is https://github.com/pulumi/scripts/pull/84 but for pulumi/eks
(which doesn't use the shared script because it is not a provider)