### PR TITLE
Fix `deprecated` tag

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -640,7 +640,7 @@ export interface ClusterOptions {
     instanceRoles?: pulumi.Input<pulumi.Input<aws.iam.Role>[]>;
 
     /**
-     * @deprecated: This option has been replaced with the use of
+     * @deprecated This option has been replaced with the use of
      * `instanceRole` or `instanceRoles`. The role provided to either option
      * should already include all required policies.
      *


### PR DESCRIPTION
`tsdocgen` already has support for not including APIs tagged as `deprecated` in generated docs. For `@pulumi/eks`, the [`deployDashboard`](https://github.com/pulumi/pulumi-eks/blob/053bf81053c260398597e1946bd924241f06ff73/nodejs/eks/cluster.ts#L756) property on `ClusterOptions` is already being removed, but the trailing `:` after `@deprecated` on `customInstanceRolePolicy` is preventing it from being removed.

Fixes https://github.com/pulumi/docs/issues/1536