### PR TITLE
fix(vpc-cni): allow logLevel & logFile to be set, or defaulted if not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- fix(vpc-cni): allow logLevel & logFile to be set, or defaulted if not
+  [#274](https://github.com/pulumi/pulumi-eks/pull/274)
 - Update pulumi to 1.4.0
   [#270](https://github.com/pulumi/pulumi-eks/pull/270)
 

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -123,9 +123,13 @@ function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
     }
     if (args.logLevel) {
         env.push({name: "AWS_VPC_K8S_CNI_LOGLEVEL", value: args.logLevel.toString()});
+    } else {
+        env.push({name: "AWS_VPC_K8S_CNI_LOGLEVEL", value: "DEBUG"});
     }
     if (args.logFile) {
         env.push({name: "AWS_VPC_K8S_CNI_LOG_FILE", value: args.logFile.toString()});
+    } else {
+        env.push({name: "AWS_VPC_K8S_CNI_LOG_FILE", value: "stdout"});
     }
     if (args.image) {
         daemonSet.spec.template.spec.containers[0].image = args.image.toString();

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -96,10 +96,6 @@ spec:
               command: ["/app/grpc_health_probe", "-addr=:50051"]
             initialDelaySeconds: 5
           env:
-            - name: AWS_VPC_K8S_CNI_LOGLEVEL
-              value: DEBUG
-            - name: AWS_VPC_K8S_CNI_LOG_FILE
-              value: stdout
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- fix(vpc-cni): allow logLevel & logFile to be set, or defaulted if not

Removing both settings from the raw YAML manifest, and defaulting its
values to what upstream uses allows for proper configuration
of the settings, rather than trying to retroactively patch the YAML.

Note, the [YAML file](https://github.com/pulumi/pulumi-eks/pull/274/files#diff-b93cd73137a80af2edbb707b9de3146a) is intact with [upstream](https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.6/config/v1.5/aws-k8s-cni.yaml) with the exception of the changes in this PR. Other than this change, we should not drift from upstream to maintain parity.

### Related issues (optional)

Fixes https://github.com/pulumi/pulumi-eks/issues/273
