### PR TITLE
Add support for AWS Managed NodeGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- feat(nodes): add createManagedNodeGroup(), and ManagedNodeGroup resource
+  [#280](https://github.com/pulumi/pulumi-eks/pull/280)
+
 ## 0.18.16 (Released November 7, 2019)
 
 ### Improvements

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -15,14 +15,11 @@
 import * as aws from "@pulumi/aws";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-import * as fs from "fs";
 import * as https from "https";
 import * as jsyaml from "js-yaml";
 import fetch from "node-fetch";
-import * as tmp from "tmp";
 import * as which from "which";
 
-import * as childProcess from "child_process";
 import { VpcCni, VpcCniOptions } from "./cni";
 import { createDashboard } from "./dashboard";
 import { createNodeGroup, NodeGroup, NodeGroupBaseOptions, NodeGroupData } from "./nodegroup";
@@ -93,6 +90,7 @@ export interface CoreData {
     nodeGroupOptions: ClusterNodeGroupOptions;
     publicSubnetIds?: pulumi.Output<string[]>;
     privateSubnetIds?: pulumi.Output<string[]>;
+    eksNodeAccess?: k8s.core.v1.ConfigMap;
     storageClasses?: UserStorageClasses;
     kubeconfig?: pulumi.Output<any>;
     vpcCni?: VpcCni;
@@ -485,55 +483,14 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
             return mappingYaml;
         });
     }
-    /*
-    * We must kubectl apply the aws-auth configmap since the creation of an
-    * AWS managed node group automatically triggers AWS to create the aws-auth
-    * configmap for us.
-    *
-    * For managed nodegroups:
-    *   To properly create aws-auth, we need to kubectl apply the configmap
-    *   instead of kubectl create it, if not it will fail with an existing
-    *   resource error message.
-    *
-    * For self-managed nodegroups:
-    *   We continue to always create the aws-auth configmap.
-    *
-    * As a work around, we'll kubectl apply to satisfy both node group cases.
-    *
-    * TODO(metral)
-    * When https://git.io/JeXom is resolved, we can move away from kubectl
-    * shell out.
-    */
-    pulumi.all([
-        kubeconfig,
-        nodeAccessData,
-    ]).apply(([kc, accessData]) => {
-        const tmpKubeconfig = tmp.fileSync();
-        const tmpJson = tmp.fileSync();
-
-        // Dump the kubeconfig to a file.
-        fs.writeFileSync(tmpKubeconfig.fd, JSON.stringify(kc));
-
-        // Compute the required aws-auth JSON manifest and dump it to a file.
-        fs.writeFileSync(tmpJson.fd, `{
-"apiVersion": "v1",
-"kind": "ConfigMap",
-"metadata": {
-  "name": "aws-auth",
-  "namespace": "kube-system",
-  "labels": {
-    "app.kubernetes.io/managed-by": "pulumi"
-  }
-},
-"data": ${JSON.stringify(accessData)}
-}`);
-
-        // Call kubectl to apply the aws-auth manifest.
-        childProcess.execSync(`kubectl apply -f ${tmpJson.name}`, {
-            stdio: "ignore",
-            env: { ...process.env, "KUBECONFIG": tmpKubeconfig.name },
-        });
-    });
+    const eksNodeAccess = new k8s.core.v1.ConfigMap(`${name}-nodeAccess`, {
+        apiVersion: "v1",
+        metadata: {
+            name: `aws-auth`,
+            namespace: "kube-system",
+        },
+        data: nodeAccessData,
+    }, { parent: parent, provider: provider });
 
     return {
         vpcId: pulumi.output(vpcId),
@@ -547,6 +504,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         provider: provider,
         vpcCni: vpcCni,
         instanceRoles: instanceRoles,
+        eksNodeAccess: eksNodeAccess,
         tags: args.tags,
         nodeSecurityGroupTags: args.nodeSecurityGroupTags,
         storageClasses: userStorageClasses,

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -62,6 +62,21 @@ func TestAccNodeGroup(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccManagedNodeGroup(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "managed-nodegroups"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccTags(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/nodejs/eks/examples/managed-nodegroups/Pulumi.yaml
+++ b/nodejs/eks/examples/managed-nodegroups/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: example-managed-nodegroups
+description: EKS managed nodegroups with IAM examples
+runtime: nodejs

--- a/nodejs/eks/examples/managed-nodegroups/README.md
+++ b/nodejs/eks/examples/managed-nodegroups/README.md
@@ -1,0 +1,3 @@
+# examples/managed-nodegroups
+
+Demonstrates how to use AWS Managed Node Groups.

--- a/nodejs/eks/examples/managed-nodegroups/iam.ts
+++ b/nodejs/eks/examples/managed-nodegroups/iam.ts
@@ -1,0 +1,27 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/nodejs/eks/examples/managed-nodegroups/index.ts
+++ b/nodejs/eks/examples/managed-nodegroups/index.ts
@@ -1,0 +1,42 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as iam from "./iam";
+
+// IAM roles for the node groups.
+const role1 = iam.createRole("example-role1");
+const role2 = iam.createRole("example-role2");
+
+// Create an EKS cluster.
+const cluster = new eks.Cluster("example-managed-nodegroups", {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    instanceRoles: [role1, role2],
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a simple AWS managed node group using a cluster as input.
+const managedNodeGroup1 = eks.createManagedNodeGroup("example-managed-ng1", {
+    cluster: cluster,
+    nodeGroupName: "aws-managed-ng1",
+    nodeRoleArn: role1.arn,
+});
+
+// Create an explicit AWS managed node group using a cluster as input.
+const managedNodeGroup2 = eks.createManagedNodeGroup("example-managed-ng2", {
+    cluster: cluster,
+    nodeGroupName: "aws-managed-ng2",
+    nodeRoleArn: role2.arn,
+    scalingConfig: {
+        desiredSize: 1,
+        minSize: 1,
+        maxSize: 2,
+    },
+    diskSize: 20,
+    instanceTypes: "t2.medium",
+    labels: {"ondemand": "true"},
+    releaseVersion: "1.14.7-20190927",
+    tags: {"org": "pulumi"},
+    version: "1.14",
+});

--- a/nodejs/eks/examples/managed-nodegroups/index.ts
+++ b/nodejs/eks/examples/managed-nodegroups/index.ts
@@ -21,7 +21,7 @@ const managedNodeGroup1 = eks.createManagedNodeGroup("example-managed-ng1", {
     cluster: cluster,
     nodeGroupName: "aws-managed-ng1",
     nodeRoleArn: role1.arn,
-});
+}, cluster);
 
 // Create an explicit AWS managed node group using a cluster as input.
 const managedNodeGroup2 = eks.createManagedNodeGroup("example-managed-ng2", {
@@ -39,4 +39,4 @@ const managedNodeGroup2 = eks.createManagedNodeGroup("example-managed-ng2", {
     releaseVersion: "1.14.7-20190927",
     tags: {"org": "pulumi"},
     version: "1.14",
-});
+}, cluster);

--- a/nodejs/eks/examples/managed-nodegroups/package.json
+++ b/nodejs/eks/examples/managed-nodegroups/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "example-nodegroup",
+    "name": "example-managed-nodegroups",
     "devDependencies": {
         "typescript": "^3.0.0",
         "@types/node": "latest"

--- a/nodejs/eks/examples/managed-nodegroups/tsconfig.json
+++ b/nodejs/eks/examples/managed-nodegroups/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/examples/nodegroup/index.ts
+++ b/nodejs/eks/examples/nodegroup/index.ts
@@ -111,6 +111,5 @@ const spot2 = new eks.NodeGroup("example-ng-advanced-spot", {
     providers: { kubernetes: cluster2.provider},
 });
 
-
 // Export the cluster's kubeconfig.
 export const kubeconfig2 = cluster2.kubeconfig;

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 export { Cluster, ClusterOptions, ClusterNodeGroupOptions, CoreData, RoleMapping, UserMapping, CreationRoleProvider, getRoleProvider } from "./cluster";
-export { NodeGroup, NodeGroupOptions, NodeGroupData } from "./nodegroup";
+export { NodeGroup, NodeGroupOptions, NodeGroupData, createManagedNodeGroup } from "./nodegroup";
 export { VpcCni, VpcCniOptions } from "./cni";
 export { createNodeGroupSecurityGroup } from "./securitygroup";
 export { StorageClass, EBSVolumeType, createStorageClass } from "./storageclass";

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -24,6 +24,6 @@
         "@types/axios": "^0.14.0",
         "@types/which": "^1.3.1",
         "tslint": "^5.7.0",
-        "typescript": "^2.6.2"
+        "typescript": "^3.7.0"
     }
 }

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -11,11 +11,11 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
-        "@pulumi/aws": "^1.0.0-beta",
+        "@pulumi/aws": "^1.11.0",
         "@pulumi/kubernetes": "^1.0.0-beta",
         "@pulumi/pulumi": "^1.0.0-beta",
-        "netmask": "^1.0.6",
         "axios": "^0.19.0",
+        "netmask": "^1.0.6",
         "which": "^1.3.1"
     },
     "devDependencies": {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- feat(nodes): add eks.createManagedNodeGroup()

PR includes new examples/test: `examples/managed-nodegroups`.

---

**Support Details:**
(compared to original self-managed node groups)

* Security Groups
    * > Amazon EKS clusters beginning with Kubernetes version 1.14 and platform version eks.3 create a cluster security group as part of cluster creation (or when a cluster is upgraded to this Kubernetes version and platform version). This security group is designed to allow all traffic from the control plane and managed node groups to flow freely between each other
    * > Amazon EKS managed node groups are automatically configured to use the cluster security group.
    * Users cannot provide their own security group, or ingress rules for use with the cluster
    * Users can only provide their own security group for remote configuration for Node SSH access.
* SSH Key
    * Only key pair name can be provided.
* Cluster Attributes
    * Only k8s labels and AWS tags on the managed node groups are supported.
    * `kubelet-extra-args` is not supported.
        * Taints are not supported.
    * > AWS handles node updates and terminations to gracefully drain nodes
* Instance Type
    * TF allows `instance_types` (plural) to be a set, but EKS appears to only accept a single, string value.
        * The Pulumi support is mapped to a `pulumi.Output<string>`, which is inline with EKS support
        * The variable in Pulumi is `instanceTypes` (plural per the TF provider), even though its value is singular.
* AMI ID
    * > Instances in a managed node group use the latest version of the Amazon EKS-optimized Amazon Linux 2 AMI for its cluster's Kubernetes version. You can choose between standard and GPU variants of the Amazon EKS-optimized Amazon Linux 2 AMI.

References:

- https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html
- https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html
- https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
- https://www.terraform.io/docs/providers/aws/r/eks_node_group.html

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/278