### PR TITLE
feat: Automatically setup OIDC provider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- feat(iam): Automatically setup OIDC provider
+
 ## 0.18.16 (Released November 7, 2019)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 - feat(iam): Automatically setup OIDC provider
+  [#281](https://github.com/pulumi/pulumi-eks/pull/281)
 
 ## 0.18.16 (Released November 7, 2019)
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -492,6 +492,12 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         data: nodeAccessData,
     }, { parent: parent, provider: provider });
 
+    const oidcProvider = new aws.iam.OpenIdConnectProvider(`${name}-oidcProvider`, {
+      clientIdLists: ["sts.amazonaws.com"],
+      url: eksCluster.identities[0].oidcs[0].issuer,
+      thumbprintLists: ["9E99A48A9960B14926BB7F3B02E22DA2B0AB7280"], // Amazon root CA thumbprint
+    }, { parent: parent });
+
     return {
         vpcId: pulumi.output(vpcId),
         subnetIds: args.subnetIds ? pulumi.output(args.subnetIds): pulumi.output(clusterSubnetIds),


### PR DESCRIPTION
### Proposed changes

Addition of an `aws.iam.OpenIdConnectProvider` resource for the cluster.  This is necessary to
take advantage of the new IAM service account feature: https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-adds-support-to-assign-iam-permissions-to-kubernetes-service-accounts/.

When creating a cluster in the AWS console UI, this is done by default.  Proposing doing that here as well.

Some more details: https://medium.com/@marcincuber/amazon-eks-with-oidc-provider-iam-roles-for-kubernetes-services-accounts-59015d15cb0c
