### PR TITLE
Support Fargate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- feat(nodes): add support for Fargate
+  [#283](https://github.com/pulumi/pulumi-eks/pull/283)
+
 ## 0.18.17 (Released December 3, 2019)
 
 ### Improvements

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -390,50 +390,6 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
             return config;
         });
 
-    let fargateProfile: aws.eks.FargateProfile | undefined;
-    if (args.fargate) {
-        const fargate = args.fargate !== true ? args.fargate : {};
-        const podExecutionRoleArn = fargate.podExecutionRoleArn || (new ServiceRole(`${name}-podExecutionRole`, {
-            service: "eks-fargate-pods.amazonaws.com",
-            managedPolicyArns: [
-                "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy",
-            ],
-        }, { parent: parent })).role.apply(r => r.arn);
-        const selectors = fargate.selectors || [
-            // For `fargate: true`, default to including the `default` namespaces and
-            // `kube-system` namespaces so that all pods by default run in Fargate.
-            { namespace: "default" },
-            { namespace: "kube-system" },
-        ];
-        fargateProfile = new aws.eks.FargateProfile(`${name}-fargateProfile`, {
-            clusterName: eksCluster.name,
-            podExecutionRoleArn: podExecutionRoleArn,
-            selectors: selectors,
-            subnetIds: pulumi.output(clusterSubnetIds).apply(subnets => computeWorkerSubnets(parent, subnets)),
-        }, { parent: parent });
-
-        // Once the FargateProfile has been created, try to patch CoreDNS if needed.  See
-        // https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html#fargate-gs-coredns.
-        pulumi.all([fargateProfile.id, selectors, kubeconfig]).apply(([_, sels, kconfig]) => {
-            // Only patch CoreDNS if there is a selector in the FargateProfile which causes
-            // `kube-system` pods to launch in Fargate.
-            if (sels.findIndex(s => s.namespace === "kube-system") !== -1) {
-                // Only do the imperative patching during deployments, not previews.
-                if (!pulumi.runtime.isDryRun()) {
-                    // Write the kubeconfig to a tmp file and use it to patch the `coredns`
-                    // deployment that AWS deployed already as part of cluster creation.
-                    const tmpKubeconfig = tmp.fileSync();
-                    fs.writeFileSync(tmpKubeconfig.fd, JSON.stringify(kconfig));
-                    const cmd = `kubectl patch deployment coredns -n kube-system --type json `
-                        + `-p='[{"op": "remove", "path": "/spec/template/metadata/annotations/eks.amazonaws.com~1compute-type"}]'`;
-                    childProcess.execSync(cmd, {
-                        env: { ...process.env, "KUBECONFIG": tmpKubeconfig.name },
-                    });
-                }
-            }
-        });
-    }
-
     const provider = new k8s.Provider(`${name}-eks-k8s`, {
         kubeconfig: kubeconfig.apply(JSON.stringify),
     }, { parent: parent });
@@ -543,6 +499,54 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         },
         data: nodeAccessData,
     }, { parent: parent, provider: provider });
+
+    let fargateProfile: aws.eks.FargateProfile | undefined;
+    if (args.fargate) {
+        const fargate = args.fargate !== true ? args.fargate : {};
+        const podExecutionRoleArn = fargate.podExecutionRoleArn || (new ServiceRole(`${name}-podExecutionRole`, {
+            service: "eks-fargate-pods.amazonaws.com",
+            managedPolicyArns: [
+                "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy",
+            ],
+        }, { parent: parent })).role.apply(r => r.arn);
+        const selectors = fargate.selectors || [
+            // For `fargate: true`, default to including the `default` namespaces and
+            // `kube-system` namespaces so that all pods by default run in Fargate.
+            { namespace: "default" },
+            { namespace: "kube-system" },
+        ];
+        fargateProfile = new aws.eks.FargateProfile(`${name}-fargateProfile`, {
+            clusterName: eksCluster.name,
+            podExecutionRoleArn: podExecutionRoleArn,
+            selectors: selectors,
+            subnetIds: pulumi.output(clusterSubnetIds).apply(subnets => computeWorkerSubnets(parent, subnets)),
+        }, { parent: parent, dependsOn: [eksNodeAccess] });
+
+        // Once the FargateProfile has been created, try to patch CoreDNS if needed.  See
+        // https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html#fargate-gs-coredns.
+        pulumi.all([fargateProfile.id, selectors, kubeconfig]).apply(([_, sels, kconfig]) => {
+            // Only patch CoreDNS if there is a selector in the FargateProfile which causes
+            // `kube-system` pods to launch in Fargate.
+            if (sels.findIndex(s => s.namespace === "kube-system") !== -1) {
+                // Only do the imperative patching during deployments, not previews.
+                if (!pulumi.runtime.isDryRun()) {
+                    // Write the kubeconfig to a tmp file and use it to patch the `coredns`
+                    // deployment that AWS deployed already as part of cluster creation.
+                    const tmpKubeconfig = tmp.fileSync();
+                    fs.writeFileSync(tmpKubeconfig.fd, JSON.stringify(kconfig));
+                    const patch = [{
+                        op: "replace",
+                        path: "/spec/template/metadata/annotations/eks.amazonaws.com~1compute-type",
+                        value: "fargate",
+                    }];
+                    const cmd = `kubectl patch deployment coredns -n kube-system --type json -p='${JSON.stringify(patch)}'`;
+                    childProcess.execSync(cmd, {
+                        env: { ...process.env, "KUBECONFIG": tmpKubeconfig.name },
+                    });
+                }
+            }
+        });
+    }
 
     return {
         vpcId: pulumi.output(vpcId),

--- a/nodejs/eks/examples/cluster/index.ts
+++ b/nodejs/eks/examples/cluster/index.ts
@@ -27,7 +27,13 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
 });
 
 // Create an EKS cluster with the fargate configuration.
-const cluster3 = new eks.Cluster(`${projectName}-3`, { fargate: true, deployDashboard: false });
+const vpc3 = new awsx.ec2.Vpc(`${projectName}-3`);
+const cluster3 = new eks.Cluster(`${projectName}-3`, {
+    vpcId: vpc3.id,
+    privateSubnetIds: vpc3.privateSubnetIds,
+    fargate: true,
+    deployDashboard: false,
+});
 
 // Export the clusters' kubeconfig.
 export const kubeconfig1 = cluster1.kubeconfig;

--- a/nodejs/eks/examples/cluster/index.ts
+++ b/nodejs/eks/examples/cluster/index.ts
@@ -26,16 +26,6 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
     ],
 });
 
-// Create an EKS cluster with the fargate configuration.
-const vpc3 = new awsx.ec2.Vpc(`${projectName}-3`);
-const cluster3 = new eks.Cluster(`${projectName}-3`, {
-    vpcId: vpc3.id,
-    privateSubnetIds: vpc3.privateSubnetIds,
-    fargate: true,
-    deployDashboard: false,
-});
-
 // Export the clusters' kubeconfig.
 export const kubeconfig1 = cluster1.kubeconfig;
 export const kubeconfig2 = cluster2.kubeconfig;
-export const kubeconfig3 = cluster3.kubeconfig;

--- a/nodejs/eks/examples/cluster/index.ts
+++ b/nodejs/eks/examples/cluster/index.ts
@@ -26,6 +26,10 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
     ],
 });
 
+// Create an EKS cluster with the fargate configuration.
+const cluster3 = new eks.Cluster(`${projectName}-3`, { fargate: true, deployDashboard: false });
+
 // Export the clusters' kubeconfig.
 export const kubeconfig1 = cluster1.kubeconfig;
 export const kubeconfig2 = cluster2.kubeconfig;
+export const kubeconfig3 = cluster3.kubeconfig;

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -55,12 +55,14 @@ func TestAccFargate(t *testing.T) {
 				// (specifically us-west-2).
 				"aws:region": "us-east-2",
 			},
-			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-				utils.RunEKSSmokeTest(t,
-					info.Deployment.Resources,
-					info.Outputs["kubeconfig"],
-				)
-			},
+			// TODO[pulumi/pulumi-eks#286] Disabled until we address CNI daemonset issues which
+			// cause those daemonset pods not to get scheduled.
+			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+			// 	utils.RunEKSSmokeTest(t,
+			// 		info.Deployment.Resources,
+			// 		info.Outputs["kubeconfig"],
+			// 	)
+			// },
 		})
 
 	integration.ProgramTest(t, &test)

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -34,6 +34,22 @@ func TestAccCluster(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "./cluster"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig1"],
+					info.Outputs["kubeconfig2"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestAccFargate(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "./fargate"),
 			Config: map[string]string{
 				// Hard code to us-east-2 since Fargate support is not yet available in all regions
 				// (specifically us-west-2).
@@ -42,9 +58,7 @@ func TestAccCluster(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
-					info.Outputs["kubeconfig1"],
-					info.Outputs["kubeconfig2"],
-					info.Outputs["kubeconfig3"],
+					info.Outputs["kubeconfig"],
 				)
 			},
 		})

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -39,6 +39,7 @@ func TestAccCluster(t *testing.T) {
 					info.Deployment.Resources,
 					info.Outputs["kubeconfig1"],
 					info.Outputs["kubeconfig2"],
+					info.Outputs["kubeconfig3"],
 				)
 			},
 		})

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -34,6 +34,11 @@ func TestAccCluster(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "./cluster"),
+			Config: map[string]string{
+				// Hard code to us-east-2 since Fargate support is not yet available in all regions
+				// (specifically us-west-2).
+				"aws:region": "us-east-2",
+			},
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,

--- a/nodejs/eks/examples/fargate/Pulumi.yaml
+++ b/nodejs/eks/examples/fargate/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: example-cluster-fargate
+description: EKS cluster example using Fargate
+runtime: nodejs

--- a/nodejs/eks/examples/fargate/index.ts
+++ b/nodejs/eks/examples/fargate/index.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+
+const projectName = pulumi.getProject();
+
+// Create an EKS cluster with the fargate configuration.
+const vpc = new awsx.ec2.Vpc(`${projectName}`);
+const cluster = new eks.Cluster(`${projectName}`, {
+    vpcId: vpc.id,
+    privateSubnetIds: vpc.privateSubnetIds,
+    fargate: true,
+    deployDashboard: false,
+});
+
+// Export the clusters' kubeconfig.
+export const kubeconfig = cluster.kubeconfig;

--- a/nodejs/eks/examples/fargate/package.json
+++ b/nodejs/eks/examples/fargate/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "example-cluster",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/awsx": "latest",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/fargate/tsconfig.json
+++ b/nodejs/eks/examples/fargate/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -558,7 +558,7 @@ ${customUserData}
 // only the IDs of the private subnets are returned. A subnet is deemed private iff it has no route in its route table
 // that routes directly to an internet gateway. If any such route exists in a subnet's route table, it is treated as
 // public.
-async function computeWorkerSubnets(parent: pulumi.Resource, subnetIds: string[]): Promise<string[]> {
+export async function computeWorkerSubnets(parent: pulumi.Resource, subnetIds: string[]): Promise<string[]> {
     const publicSubnets: string[] = [];
 
     const privateSubnets: string[] = [];

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -11,7 +11,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
-        "@pulumi/aws": "^1.11.0",
+        "@pulumi/aws": "^1.14.0",
         "@pulumi/kubernetes": "^1.0.0-beta",
         "@pulumi/pulumi": "^1.0.0-beta",
         "axios": "^0.19.0",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -113,6 +113,11 @@ func AssertAllNodesReady(t *testing.T, clientset *kubernetes.Clientset, desiredN
 
 	PrintAndLog(fmt.Sprintf("Total Desired Worker Node Count: %d\n", desiredNodeCount), t)
 
+	// Skip this validation if no NodeGroups are attached
+	if desiredNodeCount == 0 {
+		return
+	}
+
 	// Attempt to validate that the total desired worker Node count of
 	// instances are up & running.
 	for i := 0; i < MaxRetries; i++ {


### PR DESCRIPTION
Adds support for adding Fargate support to an EKS cluster using `new eks.Cluster("cluster", { ..., fargate: true })`.

Fixes #282 
