### PR TITLE
refactor(vpcCni): set node anti-affinity to not deploy to fargate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Unreleased
 
 ### Improvements
+
+- refactor(vpcCni): set node anti-affinity to not deploy to fargate
+  [#291](https://github.com/pulumi/pulumi-eks/pull/291)
 - build: Upgrade to go1.13.4
+  [#290](https://github.com/pulumi/pulumi-eks/pull/290)
 
 ## 0.18.18 (Released December 5, 2019)
 

--- a/nodejs/eks/cni/README.md
+++ b/nodejs/eks/cni/README.md
@@ -1,0 +1,4 @@
+The CNI manfiest used has divergence between the
+[upstream CNI](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.5/aws-k8s-cni.yaml),
+Pulumi's [approach](https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/cni/aws-k8s-cni.yaml),
+and what AWS does by [default](https://github.com/aws/amazon-vpc-cni-k8s/issues/755) for Fargate clusters.

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -76,6 +76,10 @@ spec:
                     operator: In
                     values:
                       - amd64
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- refactor(vpcCni): set node anti-affinity to not deploy to fargate

This change sets a node anti-affinity for the AWS CNI DaemonSet to only deploy to nodes that are not labeled for fargate with `eks.amazonaws.com/compute-type=fargate`.

By default, the DaemonSet uses a `RollingUpdate` [strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#performing-a-rolling-update) with a `maxUnavailable` of 1 pod. This means that on a Pulumi update to this change for existing clusters, the `aws-node` pods will update one at a time, until all are updated with the new node anti-affinity. This will not cause down time of the cluster or running pods.

In summary, this change allows clusters to:

- Mix and match the type of nodes used (EC2 / self-managed, AWS managed, and/or Fargate)
- Deploy the aws-cni to the cluster for any configuration of nodes, and
- Although the DS will always be created, it will only deploy to nodes that are not fargate backed.

### Related issues (optional)

Fixes https://github.com/pulumi/pulumi-eks/issues/286
