### PR TITLE
[prototype] Tweaks to support multilang

### DIFF
--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -445,11 +445,13 @@ ${customUserData}
         nodeAssociatePublicIpAddress = args.nodeAssociatePublicIpAddress;
     }
 
+    const instanceProfile = args.instanceProfile || core.nodeGroupOptions.instanceProfile;
+
     const nodeLaunchConfiguration = new aws.ec2.LaunchConfiguration(`${name}-nodeLaunchConfiguration`, {
         associatePublicIpAddress: nodeAssociatePublicIpAddress,
         imageId: amiId,
         instanceType: args.instanceType || "t2.medium",
-        iamInstanceProfile: args.instanceProfile || core.nodeGroupOptions.instanceProfile,
+        iamInstanceProfile: instanceProfile && instanceProfile.id,
         keyName: keyName,
         securityGroups: [nodeSecurityGroupId],
         spotPrice: args.spotPrice,

--- a/nodejs/eks/servicerole.ts
+++ b/nodejs/eks/servicerole.ts
@@ -80,7 +80,7 @@ export class ServiceRole extends pulumi.ComponentResource {
         for (const policy of (args.managedPolicyArns || [])) {
             rolePolicyAttachments.push(new aws.iam.RolePolicyAttachment(`${name}-${sha1hash(policy)}`, {
                 policyArn: policy,
-                role: role,
+                role: role.id,
             }, { parent: this }));
         }
         this.role = pulumi.all([role.arn, ...rolePolicyAttachments.map(r => r.id)]).apply(() => role);


### PR DESCRIPTION
These changes don't change any behaviour, but allow the component to be used with the current multilang prototype in pulumi/pulumi#3711.

There are two changes:
1. Pass `id` explcitly instead of strongly typed references.  This change shouldn't be needed, but the current multilang prototype makes a breaking change to pass custom resource references as URNs instead of `id`s.  This breaks cases where strongly typed CustomResoures are passed as inputs.  We work around that sugar here for now by manually passing the `id` property.  (We should be able to undo this breaking change in the prototype).
2. Return more resource outputs as `registerOutput`s.  The only output proeprties that get serialized to guest langauges are those returned as part of `registerOutput`s (vs. just stored on `this.`), so we must return all output proeprties in the `registerOutput`s as well.
