### PR TITLE
Fix deprecated tag in JSDoc comments

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -742,11 +742,11 @@ export interface ClusterOptions {
     instanceRoles?: pulumi.Input<pulumi.Input<aws.iam.Role>[]>;
 
     /**
+     * Attach a custom role policy to worker node instance role
+     *
      * @deprecated This option has been replaced with the use of
      * `instanceRole` or `instanceRoles`. The role provided to either option
      * should already include all required policies.
-     *
-     * Attach a custom role policy to worker node instance role
      */
     customInstanceRolePolicy?: pulumi.Input<string>;
 
@@ -832,11 +832,6 @@ export interface ClusterOptions {
     skipDefaultNodeGroup?: boolean;
 
     /**
-     * @deprecated This option has been deprecated due to a lack of
-     * support for it on EKS, and the general community recommendation to avoid
-     * using it for security concerns. If you'd like alternatives to deploy the
-     * dashboard, consider writing it in Pulumi, or using the Helm chart.
-     *
      * Whether or not to deploy the Kubernetes dashboard to the cluster. If the dashboard is deployed, it can be
      * accessed as follows:
      *
@@ -855,6 +850,11 @@ export interface ClusterOptions {
      * 4. Choose `Token` authentication, paste the token retrieved earlier into the `Token` field, and sign in.
      *
      * Defaults to `true`.
+     *
+     * @deprecated This option has been deprecated due to a lack of
+     * support for it on EKS, and the general community recommendation to avoid
+     * using it for security concerns. If you'd like alternatives to deploy the
+     * dashboard, consider writing it in Pulumi, or using the Helm chart.
      */
     deployDashboard?: boolean;
 


### PR DESCRIPTION
The description in the doc comment should come before the `@deprecated` tag, otherwise the description will be included as part of the deprecation message.

Part of https://github.com/pulumi/docs/issues/2229