### PR TITLE
Refactor managed nodegroup API and require its role be provided to the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- Refactor managed nodegroup API and require its role be provided to the cluster
+  [#302](https://github.com/pulumi/pulumi-eks/pull/302)
 - Update pulumi/pulumi and re-enable withUpdate tests
   [#327](https://github.com/pulumi/pulumi-eks/pull/327)
 

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -112,6 +112,33 @@ func TestAccManagedNodeGroupMissingRole(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccManagedNodeGroupAwsAuth(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "tests", "managed-ng-aws-auth"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      path.Join(getCwd(t), "tests", "managed-ng-aws-auth", "step1"),
+					Additive: true,
+					ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+						utils.RunEKSSmokeTest(t,
+							info.Deployment.Resources,
+							info.Outputs["kubeconfig"],
+						)
+					},
+				},
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccTags(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -99,6 +99,19 @@ func TestAccManagedNodeGroup(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccManagedNodeGroupMissingRole(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:              path.Join(getCwd(t), "tests", "managed-ng-missing-role"),
+			ExpectFailure:    true,
+			RetryFailedSteps: false,
+			SkipRefresh:      true,
+			Quick:            true,
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccTags(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -251,6 +251,25 @@ func TestAccStorageClasses_withUpdate(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccManagedNodeGroup_withUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:           path.Join(getCwd(t), "managed-nodegroups"),
+			RunUpdateTest: true,
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccReplaceSecGroup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/Pulumi.yaml
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: managed-ng-aws-auth
+description: Tests that modifying aws-auth with roleMappings does not break managed node groups cluster access
+runtime: nodejs

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/README.md
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/README.md
@@ -1,0 +1,3 @@
+# tests/managed-ng-aws-auth
+
+Tests that modifying aws-auth with roleMappings does not break managed node groups cluster access.

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/iam.ts
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/iam.ts
@@ -1,0 +1,39 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import * as iam from "./iam";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attaches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}
+
+// Creates a collection of IAM roles.
+export function createRoles(name: string, quantity: number): aws.iam.Role[] {
+    const roles: aws.iam.Role[] = [];
+
+    for (let i = 0; i < quantity; i++) {
+        roles.push(iam.createRole(`${name}-role-${i}`));
+    }
+
+    return roles;
+}

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/index.ts
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/index.ts
@@ -1,0 +1,39 @@
+import * as aws from '@pulumi/aws';
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+import * as iam from "./iam";
+
+const projectName = pulumi.getProject();
+
+// Create IAM roles for role mappings and the managed node group.
+const roles = iam.createRoles(projectName, 3);
+
+// Create role mappings.
+const roleMapping0: eks.RoleMapping = {
+    roleArn: roles[0].arn,
+    username: "roleMapping0",
+    groups: ["system:masters"],
+};
+
+const roleMapping1: eks.RoleMapping = {
+    roleArn: roles[1].arn,
+    username: "roleMapping1",
+    groups: ["system:masters"],
+};
+
+// Create an EKS cluster.
+const cluster = new eks.Cluster(`${projectName}`, {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    roleMappings: [roleMapping0],
+    instanceRoles: [roles[2]],
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a managed node group using a cluster as input.
+eks.createManagedNodeGroup(`${projectName}-managed-ng`, {
+    cluster: cluster,
+    nodeRole: roles[2],
+});

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/package.json
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "managed-ng-aws-auth",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/step1/index.ts
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/step1/index.ts
@@ -1,0 +1,43 @@
+import * as aws from '@pulumi/aws';
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+import * as iam from "./iam";
+
+const projectName = pulumi.getProject();
+
+// Create IAM roles for role mappings and the managed node group.
+const roles = iam.createRoles(projectName, 3);
+
+// Create role mappings.
+const roleMapping0: eks.RoleMapping = {
+    roleArn: roles[0].arn,
+    username: "roleMapping0",
+    groups: ["system:masters"],
+};
+
+const roleMapping1: eks.RoleMapping = {
+    roleArn: roles[1].arn,
+    username: "roleMapping1",
+    groups: ["system:masters"],
+};
+
+// Create an EKS cluster.
+const cluster = new eks.Cluster(`${projectName}`, {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    // Modify the roleMappings to update the aws-auth configMap.
+    // This will not remove the managed node group's role from aws-auth since
+    // its role is set in instanceRoles. Not setting instanceRoles in the
+    // cluster first for the nodegroup will error eks.createManagedNodeGroup().
+    roleMappings: [roleMapping0, roleMapping1],
+    instanceRoles: [roles[2]],
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a managed node group using a cluster as input.
+eks.createManagedNodeGroup(`${projectName}-managed-ng`, {
+    cluster: cluster,
+    nodeRole: roles[2],
+});

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/tsconfig.json
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/examples/tests/managed-ng-missing-role/Pulumi.yaml
+++ b/nodejs/eks/examples/tests/managed-ng-missing-role/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: managed-ng-missing-role
+description: Tests that missing roles in cluster settings prevents managed node group creation.
+runtime: nodejs

--- a/nodejs/eks/examples/tests/managed-ng-missing-role/README.md
+++ b/nodejs/eks/examples/tests/managed-ng-missing-role/README.md
@@ -1,0 +1,3 @@
+# tests/managed-ng-missing-role
+
+Tests that missing roles in cluster settings prevents managed node group creation.

--- a/nodejs/eks/examples/tests/managed-ng-missing-role/index.ts
+++ b/nodejs/eks/examples/tests/managed-ng-missing-role/index.ts
@@ -1,0 +1,46 @@
+import * as aws from '@pulumi/aws';
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+
+const projectName = pulumi.getProject();
+
+// Creates a role and attaches the EKS worker node IAM managed policies.
+export function createRole(name: string): aws.iam.Role {
+    const managedPolicyArns: string[] = [
+        "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+        "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+        "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    ];
+
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}
+
+// Create an EKS cluster without specifying instanceRoles with the role used by
+// the managed node group below.
+const cluster = new eks.Cluster(`${projectName}`, {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a managed node group using a cluster as input.
+eks.createManagedNodeGroup(`${projectName}-managed-ng`, {
+    cluster: cluster,
+    nodeRole: createRole("role0"),
+});

--- a/nodejs/eks/examples/tests/managed-ng-missing-role/package.json
+++ b/nodejs/eks/examples/tests/managed-ng-missing-role/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "managed-ng-missing-role",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/tests/managed-ng-missing-role/tsconfig.json
+++ b/nodejs/eks/examples/tests/managed-ng-missing-role/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -653,6 +653,12 @@ export type ManagedNodeGroupOptions = Omit<aws.eks.NodeGroupArgs, "clusterName" 
     clusterName?: pulumi.Output<string>;
 
     /**
+     * Make nodeGroupName optional, since the NodeGroup resource name can be
+     * used as a default.
+     */
+    nodeGroupName?: pulumi.Input<string>;
+
+    /**
      * Make subnetIds optional, since the cluster is required and it contains it.
      *
      * Default subnetIds is chosen from the following list, in order, if
@@ -705,6 +711,7 @@ export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptio
     const nodeGroup = new aws.eks.NodeGroup(name, {
         ...nodeGroupArgs,
         clusterName: args.clusterName || core.cluster.name,
+        nodeGroupName: args.nodeGroupName || name,
         scalingConfig: pulumi.all([
             args.scalingConfig,
         ]).apply(([config]) => {

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -677,8 +677,9 @@ export type ManagedNodeGroupOptions = Omit<aws.eks.NodeGroupArgs, "clusterName" 
     scalingConfig?: pulumi.Input<awsInputs.eks.NodeGroupScalingConfig>
 };
 
-export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptions, parent: pulumi.ComponentResource): aws.eks.NodeGroup {
+export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptions, parent?: pulumi.ComponentResource): aws.eks.NodeGroup {
     const core = isCoreData(args.cluster) ? args.cluster : args.cluster.core;
+    const eksCluster = isCoreData(args.cluster) ? args.cluster.cluster : args.cluster;
 
     // Compute the node group subnets to use.
     let subnetIds: pulumi.Output<string[]> = pulumi.output([]);
@@ -717,7 +718,7 @@ export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptio
             };
         }),
         subnetIds: subnetIds,
-    }, { parent: parent, dependsOn: ngDeps });
+    }, { parent: parent ? parent : eksCluster, dependsOn: ngDeps });
 
     return nodeGroup;
 }


### PR DESCRIPTION
### Proposed changes

- Refactoring the managed node group API to simplify its use (options in role vs role.ARN, make parent arg optional, and default node group name).
- Ensuring a managed nodegroup's cluster has the respective role specified in its `instanceRoles` that the managed nodegroup role uses, and that will get set in aws-auth.
- Ensuring managed node groups do not get removed from aws-auth when role or user mappings are provided after initial update

### Related issues

Closes #285 
Fixes #293