### PR TITLE
Enable the ability for EKS to run on ap-east-1 / me-south-1

### DIFF
--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -415,9 +415,15 @@ ${customUserData}
                 },
             ];
 
+            // `602401143452` is the ID assigned to `Amazon` and is required for AMIs that are hosted in AWS default regions
+            // `800184023465` is the owner ID of the creator of the EKS Optimized AMI in ap-east-1
+            // `558608220178` is the owner ID of the creator of the EKS Optimized AMI in me-south-1
+            // It is important to note that neither `800184023465` nor `558608220178` are assigned any IDs in default regions
+            // and `602401143452` is not assigned any AMIs in `ap-east-1` or `me-south-1` regions so this lookup is safe to make
+            // AWS Guide for EKS Optimized AMIs https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
             const eksWorkerAmiIds = aws.getAmiIds({
                 filters,
-                owners: ["602401143452"], // Amazon
+                owners: ["602401143452", "800184023465", "558608220178"],
                 sortAscending: true,
             }, { parent, async: true });
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/examples/issues/517

The owner of the AMI that Amazon uses to run on EKS in ap-east-1
isn't actually owned by amazon - or rather, it's not the same owner id
that we have hard coded in our Eks setup

I have followed the EKS ami list here - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
to find the owner of the AMIs

I also added the Owner for me-south-1. The reason we needed to do
this is that these are regions that need to be opted-in to


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->