### PR TITLE
More test fixes to unblock CI

### DIFF
--- a/nodejs/eks/Makefile
+++ b/nodejs/eks/Makefile
@@ -7,6 +7,7 @@ VERSION := $(shell ../../scripts/get-version)
 export PATH := $(shell yarn bin 2>/dev/null):$(PATH)
 
 TESTPARALLELISM ?= 7
+NODE_OPTIONS ?= --max_old_space_size=6144
 
 build::
 	yarn install

--- a/nodejs/eks/Makefile
+++ b/nodejs/eks/Makefile
@@ -6,7 +6,7 @@ VERSION := $(shell ../../scripts/get-version)
 
 export PATH := $(shell yarn bin 2>/dev/null):$(PATH)
 
-TESTPARALLELISM := 20
+TESTPARALLELISM ?= 7
 
 build::
 	yarn install

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -404,6 +404,7 @@ func getCwd(t *testing.T) string {
 func getBaseOptions() integration.ProgramTestOptions {
 	return integration.ProgramTestOptions{
 		ExpectRefreshChanges: true,
+		RetryFailedSteps:     true,
 		ReportStats:          integration.NewS3Reporter("us-west-2", "eng.pulumi.com", "testreports"),
 		Tracing:              "https://tracing.pulumi-engineering.com/collector/api/v1/spans",
 	}
@@ -419,7 +420,6 @@ func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 		Dependencies: []string{
 			"@pulumi/eks",
 		},
-		RetryFailedSteps: true,
 	})
 
 	return baseJS

--- a/nodejs/eks/examples/tests/replace-secgroup/index.ts
+++ b/nodejs/eks/examples/tests/replace-secgroup/index.ts
@@ -28,7 +28,7 @@ const nodeSecurityGroup = secgroup.createNodeGroupSecurityGroup(secgroupName, {
     vpcId: vpc.id,
     clusterSecurityGroup: testCluster.clusterSecurityGroup,
     eksCluster: testCluster.core.cluster,
-}, testCluster);
+}, vpc);
 const eksClusterIngressRule = new aws.ec2.SecurityGroupRule(`${secgroupName}-eksClusterIngressRule`, {
     description: "Allow pods to communicate with the cluster API Server",
     type: "ingress",


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- test(replace-sg): fix cluster parent not ready by using vpc instead
- tests: set RetryFailedSteps in getBaseOptions since .with doesnt pass it
- tests: allow TESTPARALLELISM to be set through envvar, if not default to 7
- tests: allow NODE_OPTIONS to be set and default RAM use to 6GB

### Related issues (optional)

- https://github.com/pulumi/pulumi-eks/issues/300
- https://github.com/pulumi/pulumi-eks/issues/312
