### PR TITLE
CI: re-enable withUpdate tests, and tune CI settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check_clean_worktree:
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
-travis_cron: all
+travis_cron: default
 travis_push: only_build check_clean_worktree only_test publish_packages
 travis_pull_request: all
 travis_api: all

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -131,13 +131,11 @@ func TestAccStorageClasses(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-/*
 func TestAccCluster_withUpdate(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:                  path.Join(getCwd(t), "./cluster"),
-			ExpectRefreshChanges: true,
-			RunUpdateTest:        true,
+			Dir:           path.Join(getCwd(t), "./cluster"),
+			RunUpdateTest: true,
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
@@ -153,9 +151,8 @@ func TestAccCluster_withUpdate(t *testing.T) {
 func TestAccNodeGroup_withUpdate(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:                  path.Join(getCwd(t), "nodegroup"),
-			ExpectRefreshChanges: true,
-			RunUpdateTest:        true,
+			Dir:           path.Join(getCwd(t), "nodegroup"),
+			RunUpdateTest: true,
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
@@ -171,9 +168,8 @@ func TestAccNodeGroup_withUpdate(t *testing.T) {
 func TestAccTags_withUpdate(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:                  path.Join(getCwd(t), "tags"),
-			ExpectRefreshChanges: true,
-			RunUpdateTest:        true,
+			Dir:           path.Join(getCwd(t), "tags"),
+			RunUpdateTest: true,
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
@@ -189,9 +185,8 @@ func TestAccTags_withUpdate(t *testing.T) {
 func TestAccStorageClasses_withUpdate(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:                  path.Join(getCwd(t), "storage-classes"),
-			ExpectRefreshChanges: true,
-			RunUpdateTest:        true,
+			Dir:           path.Join(getCwd(t), "storage-classes"),
+			RunUpdateTest: true,
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
@@ -203,7 +198,6 @@ func TestAccStorageClasses_withUpdate(t *testing.T) {
 
 	integration.ProgramTest(t, &test)
 }
-*/
 
 func TestAccReplaceSecGroup(t *testing.T) {
 	test := getJSBaseOptions(t).

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -132,6 +132,9 @@ func TestAccStorageClasses(t *testing.T) {
 }
 
 func TestAccCluster_withUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "./cluster"),
@@ -149,6 +152,9 @@ func TestAccCluster_withUpdate(t *testing.T) {
 }
 
 func TestAccNodeGroup_withUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "nodegroup"),
@@ -166,6 +172,9 @@ func TestAccNodeGroup_withUpdate(t *testing.T) {
 }
 
 func TestAccTags_withUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "tags"),
@@ -183,6 +192,9 @@ func TestAccTags_withUpdate(t *testing.T) {
 }
 
 func TestAccStorageClasses_withUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "storage-classes"),
@@ -200,6 +212,9 @@ func TestAccStorageClasses_withUpdate(t *testing.T) {
 }
 
 func TestAccReplaceSecGroup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "tests", "replace-secgroup"),
@@ -221,6 +236,9 @@ func TestAccReplaceSecGroup(t *testing.T) {
 }
 
 func TestAccReplaceClusterAddSubnets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "tests", "replace-cluster-add-subnets"),
@@ -242,6 +260,9 @@ func TestAccReplaceClusterAddSubnets(t *testing.T) {
 }
 
 func TestAccTagInputTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "tests", "tag-input-types"),
@@ -257,6 +278,9 @@ func TestAccTagInputTypes(t *testing.T) {
 }
 
 func TestAccMigrateNodeGroups(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "tests", "migrate-nodegroups"),


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The following changes are for tests and CI:

- Re-enable withUpdate tests that were disabled in https://github.com/pulumi/pulumi-eks/pull/309
- Configure CI cron to use fast tests
- Mark tests that can be skipped if testing fast 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes https://github.com/pulumi/pulumi-eks/issues/313