### PR TITLE
feat(identity): add support to setup OIDC provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Improvements
 
+- feat(identity): add support to setup OIDC provider
+  [#319](https://github.com/pulumi/pulumi-eks/pull/319)
+
+## 0.18.19 (Released December 27, 2019)
+
+### Improvements
+
 - Unblock CI by disabling debug logging, rm unnecessary tests, and fixing broken tests
   [#309](https://github.com/pulumi/pulumi-eks/pull/309)
 - feat(cluster): Support public access controls


### PR DESCRIPTION
### Proposed changes

Add support to setup [OIDC provider for Pod Service Accounts](https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-adds-support-to-assign-iam-permissions-to-kubernetes-service-accounts/).

Refs:

  - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
  - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
  - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
  - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts

Related implementations:

  - This PR is adapted from [aws-cdk](https://github.com/aws/aws-cdk/pull/6062/files#diff-0c88b2ccea9d77dbb7ac2285fd5f63afR113-R148)
  - [eksctl](https://github.com/weaveworks/eksctl/blob/master/pkg/iam/oidc/api.go#L116-L141)
  - https://github.com/pulumi/pulumi-eks/pull/281

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes https://github.com/pulumi/pulumi-eks/issues/318