### PR TITLE
feat(identity): add support to setup OIDC provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- feat(identity): add support to setup OIDC provider
+  [#320](https://github.com/pulumi/pulumi-eks/pull/320)
+
 ## 0.18.21 (Released February 12, 2020)
 
 ### Improvements

--- a/nodejs/eks/cert-thumprint.ts
+++ b/nodejs/eks/cert-thumprint.ts
@@ -1,0 +1,88 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as https from "https";
+import * as tls from "tls";
+
+const THUMBPRINT_MAX_RETRIES: number = 12;
+const THUMBPRINT_SLEEP_MILLISECOND_INTERVAL: number = 5000;
+
+/**
+* Get the certificate thumprint of the issuing CA for the TLS enabled URL.
+*
+* This is used for OIDC provider configuration.
+*
+* See for more details:
+* - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+* - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
+* - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
+* - https://medium.com/@marcincuber/amazon-eks-with-oidc-provider-iam-roles-for-kubernetes-services-accounts-59015d15cb0c
+* - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
+*/
+export function getIssuerCAThumbprint(issuerUrl: pulumi.Output<string>): pulumi.Output<string> {
+    return issuerUrl.apply(url => getThumbprint(url, THUMBPRINT_MAX_RETRIES, THUMBPRINT_SLEEP_MILLISECOND_INTERVAL));
+}
+
+// Thumbprint retrieval below adapted from https://git.io/JvGHB.
+
+// Find the root CA cert in a chain of certs.
+function findCACertificate(certificate: tls.DetailedPeerCertificate): tls.DetailedPeerCertificate {
+    let cert = certificate;
+    for (; cert?.issuerCertificate?.fingerprint !== cert?.fingerprint;) {
+        cert = cert.issuerCertificate;
+    }
+    return cert;
+}
+
+async function getThumbprint(issuerUrl: string, retriesLeft: number, interval: number): Promise<string> {
+    // For up to 60 seconds (12 retries @ 5000 ms), try to contact the issuer URL.
+    try {
+        return await new Promise((resolve, reject) => {
+            const options = {
+                hostname: issuerUrl,
+                port: 443,
+                rejectUnauthorized: false,
+            };
+            const req = https
+                .get(options)
+                .on("error", reject)
+                .on("socket", socket => {
+                    socket.on("secureConnect", () => {
+                        const certificate: tls.DetailedPeerCertificate = socket.getPeerCertificate(true);
+                        const fingerprint = findCACertificate(certificate).fingerprint;
+                        // Check if certificate is valid
+                        if (socket.authorized === false) {
+                            req.emit("error", new Error(socket.authorizationError));
+                            return req.abort();
+                        }
+                        resolve( // Ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+                            fingerprint
+                            .split(":")
+                            .join("")
+                            .toLowerCase(), // Ref: https://github.com/terraform-providers/terraform-provider-aws/issues/10104#issuecomment-551079323
+                        );
+                    });
+                });
+            req.end();
+        });
+    } catch (e) {
+        if (retriesLeft) {
+            pulumi.log.info(`Waiting for cert issuer URL(${THUMBPRINT_MAX_RETRIES - retriesLeft})`, undefined, undefined, true);
+            await new Promise(resolve => setTimeout(resolve, interval));
+            return getThumbprint(issuerUrl, retriesLeft - 1, interval);
+        }
+    }
+    throw new Error("Cannot retrieve the certificate fingerprint at the issuer URL: " + issuerUrl);
+}

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -25,6 +25,7 @@ import * as process from "process";
 import * as tmp from "tmp";
 import * as which from "which";
 
+import { getIssuerCAThumbprint } from "./cert-thumprint";
 import { VpcCni, VpcCniOptions } from "./cni";
 import { createDashboard } from "./dashboard";
 import { computeWorkerSubnets, createNodeGroup, NodeGroup, NodeGroupBaseOptions, NodeGroupData } from "./nodegroup";
@@ -102,6 +103,7 @@ export interface CoreData {
     tags?: InputTags;
     nodeSecurityGroupTags?: InputTags;
     fargateProfile?: aws.eks.FargateProfile;
+    oidcProvider?: aws.iam.OpenIdConnectProvider;
 }
 
 function createOrGetInstanceProfile(name: string, parent: pulumi.ComponentResource, instanceRoleName?: pulumi.Input<aws.iam.Role>, instanceProfileName?: pulumi.Input<string>): aws.iam.InstanceProfile {
@@ -562,6 +564,18 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         });
     }
 
+    // Setup OIDC provider to leverage IAM roles for k8s service accounts.
+    let oidcProvider: aws.iam.OpenIdConnectProvider | undefined;
+    if (args.createOidcProvider) {
+        const eksOidcProviderUrl = pulumi.interpolate `oidc.eks.${aws.getRegion().name}.amazonaws.com`;
+        const fingerprint = getIssuerCAThumbprint(eksOidcProviderUrl); // Amazon root CA thumbprint
+        oidcProvider = new aws.iam.OpenIdConnectProvider(`${name}-oidcProvider`, {
+            clientIdLists: ["sts.amazonaws.com"],
+            url: eksCluster.identities[0].oidcs[0].issuer,
+            thumbprintLists: [fingerprint],
+        }, { parent: parent });
+    }
+
     return {
         vpcId: pulumi.output(vpcId),
         subnetIds: args.subnetIds ? pulumi.output(args.subnetIds) : pulumi.output(clusterSubnetIds),
@@ -579,6 +593,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         nodeSecurityGroupTags: args.nodeSecurityGroupTags,
         storageClasses: userStorageClasses,
         fargateProfile: fargateProfile,
+        oidcProvider: oidcProvider,
     };
 }
 
@@ -902,6 +917,20 @@ export interface ClusterOptions {
      * The tags to apply to the EKS cluster.
      */
     clusterTags?: InputTags;
+
+    /**
+     * Indicates whether an IAM OIDC Provider is created for the EKS cluster.
+     *
+     * The OIDC provider is used in the cluster in combination with k8s
+     * Service Account annotations to provide IAM roles at the k8s Pod level.
+     *
+     * See for more details:
+     * - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+     * - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
+     * - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
+     * - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
+     */
+    createOidcProvider?: pulumi.Input<boolean>;
 }
 
 /**

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -171,6 +171,21 @@ func TestAccStorageClasses(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccOidcIam(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "oidc-iam-sa"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccCluster_withUpdate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/nodejs/eks/examples/oidc-iam-sa/Pulumi.yaml
+++ b/nodejs/eks/examples/oidc-iam-sa/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: example-oidc-iam-sa
+description: OIDC Provider and IAM roles for Service Accounts
+runtime: nodejs

--- a/nodejs/eks/examples/oidc-iam-sa/README.md
+++ b/nodejs/eks/examples/oidc-iam-sa/README.md
@@ -1,0 +1,5 @@
+# examples/oidc-iam-sa
+
+Demonstrates how to use an OIDC Provider, and IAM roles for Service Accounts.
+
+See the [AWS blog](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) for more details.

--- a/nodejs/eks/examples/oidc-iam-sa/index.ts
+++ b/nodejs/eks/examples/oidc-iam-sa/index.ts
@@ -1,0 +1,142 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import assert = require("assert");
+
+const projectName = pulumi.getProject();
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attaches the EKS worker node IAM managed policies.
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}
+
+// IAM role for the node group.
+const role1 = createRole("example-role1");
+
+// Create an EKS cluster.
+const cluster = new eks.Cluster(`${projectName}`, {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    instanceRoles: [role1],
+    createOidcProvider: true,
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a simple AWS managed node group using a cluster as input.
+const managedNodeGroup1 = eks.createManagedNodeGroup("example-managed-ng1", {
+    cluster: cluster,
+    nodeRole: role1,
+    version: "1.14",
+});
+
+// Export the cluster OIDC provider URL.
+if (!cluster?.core?.oidcProvider) {
+    throw new Error("Invalid cluster OIDC provider URL");
+}
+const clusterOidcProvider = cluster.core.oidcProvider;
+export const clusterOidcProviderUrl = clusterOidcProvider.url;
+
+// Setup Pulumi Kubernetes provider.
+const provider = new k8s.Provider("eks-k8s", {
+    kubeconfig: kubeconfig.apply(JSON.stringify),
+});
+
+// Create a namespace.
+const appsNamespace = new k8s.core.v1.Namespace("apps", undefined, {provider: provider});
+export const appsNamespaceName = appsNamespace.metadata.name;
+
+// Create the IAM target policy and role for the Service Account.
+const saName = "s3-readonly";
+const saAssumeRolePolicy = pulumi.all([clusterOidcProviderUrl, clusterOidcProvider.arn]).apply(([url, arn]) => aws.iam.getPolicyDocument({
+    statements: [{
+        actions: ["sts:AssumeRoleWithWebIdentity"],
+        conditions: [{
+            test: "StringEquals",
+            values: [`system:serviceaccount:${appsNamespaceName}:${saName}`],
+            variable: `${url.replace("https://", "")}:sub`,
+        }],
+        effect: "Allow",
+        principals: [{
+            identifiers: [arn],
+            type: "Federated",
+        }],
+    }],
+}));
+
+const saRole = new aws.iam.Role(saName, {
+    assumeRolePolicy: saAssumeRolePolicy.json,
+});
+
+// Attach the S3 read only access policy.
+const saS3Rpa = new aws.iam.RolePolicyAttachment(saName, {
+    policyArn: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+    role: saRole,
+});
+
+// Create the Service Account with the IAM role annotated.
+const sa = new k8s.core.v1.ServiceAccount(saName, {
+    metadata: {
+        namespace: appsNamespaceName,
+        name: saName,
+        annotations: {
+            "eks.amazonaws.com/role-arn": saRole.arn,
+        },
+    },
+}, { provider: provider});
+
+// Use the Service Account in a Pod.
+const labels = {"app": saName};
+const pod = new k8s.core.v1.Pod(saName,
+    {
+        metadata: {labels: labels, namespace: appsNamespaceName},
+        spec: {
+            serviceAccountName: sa.metadata.name,
+            containers: [
+                {
+                    name: saName,
+                    image: "nginx",
+                    ports: [{ name: "http", containerPort: 80 }],
+                },
+            ],
+        },
+    },
+    {
+        provider: provider,
+    },
+);
+
+// (For testing only): Assert that the Service Account's IAM role and token are projected into the Pod.
+if (!pulumi.runtime.isDryRun()) {
+    const envvars = pod.spec.containers[0].env;
+    envvars.apply(evs => {
+        if (evs) {
+            assert(evs.find(e => e.name === "AWS_ROLE_ARN") !== undefined);
+            assert(evs.find(e => e.name === "AWS_WEB_IDENTITY_TOKEN_FILE") !== undefined);
+        } else {
+            throw new Error("No AWS IAM envvars exist in the pod.");
+        }
+    });
+}

--- a/nodejs/eks/examples/oidc-iam-sa/package.json
+++ b/nodejs/eks/examples/oidc-iam-sa/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "example-oidc-iam-sa",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
+        "@pulumi/eks": "latest",
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/nodejs/eks/examples/oidc-iam-sa/tsconfig.json
+++ b/nodejs/eks/examples/oidc-iam-sa/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
### Proposed changes

Add support to setup [OIDC provider for Pod Service Accounts](https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-adds-support-to-assign-iam-permissions-to-kubernetes-service-accounts/).

Refs:

  - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
  - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
  - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
  - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts

Related implementations:

  - This PR is adapted from [aws-cdk](https://github.com/aws/aws-cdk/pull/6062/files#diff-0c88b2ccea9d77dbb7ac2285fd5f63afR113-R148)
  - [eksctl](https://github.com/weaveworks/eksctl/blob/master/pkg/iam/oidc/api.go#L116-L141)
  - https://github.com/pulumi/pulumi-eks/pull/281

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes https://github.com/pulumi/pulumi-eks/issues/318