### PR TITLE
Fix recent CI errors with storageClasses, and managedNodeGroup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- fix(storageClasses): fix userStorageClass initialization
+  [#336](https://github.com/pulumi/pulumi-eks/pull/336)
 - feat(cluster): allow optional configuration of cluster name
   [#322](https://github.com/pulumi/pulumi-eks/pull/322)
 - feat(identity): add support to setup OIDC provider

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -413,7 +413,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
 
     // Add any requested StorageClasses.
     const storageClasses = args.storageClasses || {};
-    const userStorageClasses: UserStorageClasses = pulumi.output({});
+    const userStorageClasses = {} as UserStorageClasses;
     if (typeof storageClasses === "string") {
         const storageClass = { type: storageClasses, default: true };
         userStorageClasses[storageClasses] = pulumi.output(

--- a/nodejs/eks/examples/managed-nodegroups/index.ts
+++ b/nodejs/eks/examples/managed-nodegroups/index.ts
@@ -46,7 +46,5 @@ const managedNodeGroup2 = eks.createManagedNodeGroup("example-managed-ng2", {
     diskSize: 20,
     instanceTypes: "t2.medium",
     labels: {"ondemand": "true"},
-    releaseVersion: "1.14.7-20190927",
     tags: {"org": "pulumi"},
-    version: "1.14",
 }, cluster);


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- fix(storageClasses): fix userStorageClass initialization
- test(mgdNodegroup): rm version pin to avoid invalid/deprecated versions


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Fixes https://github.com/pulumi/pulumi-eks/issues/335
Fixes https://github.com/pulumi/pulumi-eks/issues/333