### PR TITLE
Extend Cluster Timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 **/Pulumi.*.yaml
 **/yarn-error.log
 yarn.lock
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- update cluster creation and deletion default timeouts to be `1hr`
+  [#341](https://github.com/pulumi/pulumi-eks/pull/341)
 
 ### Improvements
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -365,6 +365,10 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     }, {
         parent: parent,
         provider: args.creationRoleProvider ? args.creationRoleProvider.provider : undefined,
+        customTimeouts: {
+            create: "1h",
+            delete: "1h",
+        },
     });
 
     // Instead of using the kubeconfig directly, we also add a wait of up to 5 minutes or until we


### PR DESCRIPTION
Fixes: #340

Sometimes clusters can time out whne creating, to allow this not
to be the case, we are going to specify a create timeout of 1hour
by default. This means the user *should not* need to worry about
custom timeouts.

For good measure, I added a delete timeout extension as well since
that can sometimes that a long time as well


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->