### PR TITLE
fix(oidc): use thumbprint of the intermediate root CA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- fix(oidc): use thumbprint of the intermediate root CA
+  [#342](https://github.com/pulumi/pulumi-eks/pull/342)
+
 ## 0.18.22 (Released February 24, 2020)
 
 ### Improvements

--- a/nodejs/eks/examples/oidc-iam-sa/index.ts
+++ b/nodejs/eks/examples/oidc-iam-sa/index.ts
@@ -8,20 +8,12 @@ const projectName = pulumi.getProject();
 
 // Create an EKS cluster.
 const cluster = new eks.Cluster(`${projectName}`, {
-    skipDefaultNodeGroup: true,
     deployDashboard: false,
     createOidcProvider: true,
 });
 
 // Export the cluster's kubeconfig.
 export const kubeconfig = cluster.kubeconfig;
-
-// Create a simple AWS managed node group using a cluster as input.
-const managedNodeGroup1 = eks.createManagedNodeGroup("example-managed-ng1", {
-    cluster: cluster,
-    nodeRole: role1,
-    version: "1.14",
-});
 
 // Export the cluster OIDC provider URL.
 if (!cluster?.core?.oidcProvider) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,7 +28,7 @@ import (
 
 // MaxRetries is the maximum number of retries that a resource will be
 // attempted to be fetched from the Kubernetes API Server.
-const MaxRetries = 20
+const MaxRetries = 40
 
 // RetryInterval is the number of seconds to sleep in between requests
 // to the Kubernetes API Server.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -334,7 +334,10 @@ func IsPodReady(t *testing.T, clientset *kubernetes.Clientset, pod *corev1.Pod) 
 	if o.Status.Phase == corev1.PodRunning || o.Status.Phase == corev1.PodSucceeded {
 		for _, condition := range o.Status.Conditions {
 			if condition.Type == corev1.PodReady {
-				t.Logf("Checking if Pod %q is Ready | Condition.Status: %q | Condition: %v\n", pod.Name, condition.Status, condition)
+				t.Logf("Checking if Pod %q is Ready | Condition.Status: %q | Condition.Reason: %q | Condition: %v\n", pod.Name, condition.Status, condition.Reason, condition)
+				if o.Status.Phase == corev1.PodSucceeded {
+					return true
+				}
 				return condition.Status == corev1.ConditionTrue
 			}
 		}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- fix(oidc): use thumbprint of the intermediate root CA
- test(oidc): add s3 example to test service account IAM token works
- test(utils): update smoketest to mark succeeded pods like jobs, as ready
- test(utils): bump req wait time from 5m -> 10m to avoid early timeouts
- test(oidc): use default ng as pods fail smoketest if mgdng is not up yet

### Related issues (optional)

Fixes #342
