### PR TITLE
Fix issue in OIDC getThumbprint helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- fix(oidc): Fix issue in OIDC getThumbprint helper function
+  [#346](https://github.com/pulumi/pulumi-eks/pull/346)
+
 ## 0.18.23 (Released March 5, 2020)
 
 ### Improvements

--- a/nodejs/eks/cert-thumprint.ts
+++ b/nodejs/eks/cert-thumprint.ts
@@ -67,6 +67,9 @@ async function getThumbprint(issuerUrl: string, retriesLeft: number, interval: n
                 hostname: issuerUrl,
                 port: 443,
                 rejectUnauthorized: false,
+                // Cached sessions can result in the certificate not being available since its already been "accepted",
+                // don't allow any for this purpose.
+                agent: new https.Agent({ maxCachedSessions: 0 }),
             };
             const req = https
                 .get(options)


### PR DESCRIPTION
### Proposed changes

Fixes an issue in the OIDC provisioning `getThumbprint` helper function.  It is possible for HTTPS sessions to be cached between calls to this.  When this happens, the SSL cert is not available.  Allow no caching so we can always get the cert.

This probably only caused issues when multiple clusters were in the stack.

### Related issues

Fixes #345 