### PR TITLE
test(oidc): make pod sleep after run, to avoid termination crashloop

### DIFF
--- a/nodejs/eks/examples/oidc-iam-sa/index.ts
+++ b/nodejs/eks/examples/oidc-iam-sa/index.ts
@@ -120,7 +120,7 @@ const s3Pod = pulumi.all([bucketName, regionName]).apply(([bName, region]) => {
                         name: podName,
                         image: "amazonlinux:2018.03",
                         command: ["sh", "-c",
-                            `curl -sL -o /s3-echoer https://github.com/mhausenblas/s3-echoer/releases/latest/download/s3-echoer-linux && chmod +x /s3-echoer && echo This is an in-cluster test | /s3-echoer ${bName}`],
+                            `curl -sL -o /s3-echoer https://github.com/mhausenblas/s3-echoer/releases/latest/download/s3-echoer-linux && chmod +x /s3-echoer && echo This is an in-cluster test | /s3-echoer ${bName} && sleep 3600`],
                         env: [
                             {name: "AWS_DEFAULT_REGION", value: `${region}`},
                             {name: "ENABLE_IRP", value: "true"},


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

test(oidc): make pod sleep after run to avoid termination crashloop

#351 moved from a Job for the S3 assertion test to a Pod because Job's create new pods until one succeeds, where as a regular Pod by default always restarts the same pod on failure until success is reached. For the CI smoketest, using a Job created issues when the Job's failed pods stick around even though the Job may have eventually succeeded.

The caveat though in moving to using a Pod instead, is that it should remain running for the sake of the smoke test, otherwise after it successfully runs, the Pod will terminate, come up again, succeed, and terminate as the [example](https://github.com/mhausenblas/s3-echoer) referenced in the [AWS blog](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) is not long-running by default.

This change adds a sleep command to the end of the S3 pod test to keep the pod up for the sake of the smoketest.

### Related issues (optional)

Fixes https://github.com/pulumi/pulumi-eks/issues/349