### PR TITLE
feat(cluster): add getKubeconfig method to generate scoped kubeconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- feat(cluster): add getKubeconfig method to generate scoped kubeconfigs
+  [#356](https://github.com/pulumi/pulumi-eks/pull/356)
+
 ## 0.18.24 (Released March 11, 2020)
 
 ### Improvements

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -84,12 +84,48 @@ export interface CreationRoleProvider {
 }
 
 /**
+ * KubeconfigOptions represents the identity and credential options to use
+ * when generating a scoped kubeconfig to use with the cluster.
+ *
+ * The options can be used independently, or additively.
+ *
+ * A scoped kubeconfig is necessary for certain auth scenarios. For example:
+ *   1. Assume a role on the default account caller,
+ *   2. Use an AWS creds profile instead of the default account caller,
+ *   3. Use an AWS creds creds profile instead of the default account caller,
+ *      and then assume a given role on the profile. This scenario is also
+ *      possible by only using a profile, iff the profile includes a role to
+ *      assume in its settings.
+ *
+ * See for more details:
+ * - https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
+ * - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html
+ * - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+ */
+export interface KubeconfigOptions {
+    /**
+     * Role ARN to assume instead of the default AWS credential provider chain.
+     *
+     * The role is passed to kubeconfig as an authentication exec argument.
+     */
+    roleArn?: pulumi.Input<aws.ARN>;
+    /**
+     * AWS credential profile name to always use instead of the
+     * default AWS credential provider chain.
+     *
+     * The profile is passed to kubeconfig as an authentication environment
+     * setting.
+     */
+    profileName?: pulumi.Input<string>;
+}
+/**
  * CoreData defines the core set of data associated with an EKS cluster, including the network in which it runs.
  */
 export interface CoreData {
     cluster: aws.eks.Cluster;
     vpcId: pulumi.Output<string>;
     subnetIds: pulumi.Output<string[]>;
+    endpoint: pulumi.Output<string>;
     clusterSecurityGroup: aws.ec2.SecurityGroup;
     provider: k8s.Provider;
     instanceRoles: pulumi.Output<aws.iam.Role[]>;
@@ -120,11 +156,22 @@ function createOrGetInstanceProfile(name: string, parent: pulumi.ComponentResour
     return instanceProfile;
 }
 
-function generateKubeconfig(clusterName: string, clusterEndpoint: string, certData: string, roleArn?: string) {
+function generateKubeconfig(
+    clusterName: pulumi.Input<string>,
+    clusterEndpoint: pulumi.Input<string>,
+    certData: pulumi.Input<string>,
+    opts?: KubeconfigOptions) {
     let args = ["token", "-i", clusterName];
+    let env: { [key: string]: pulumi.Input<string>} | undefined;
 
-    if (roleArn) {
-        args = [...args, "-r", roleArn];
+    if (opts?.roleArn) {
+        args = [...args, "-r", opts.roleArn];
+    }
+    if (opts?.profileName) {
+        env = {
+            "name": "AWS_PROFILE",
+            "value": opts.profileName,
+        };
     }
 
     return {
@@ -152,6 +199,7 @@ function generateKubeconfig(clusterName: string, clusterEndpoint: string, certDa
                     apiVersion: "client.authentication.k8s.io/v1alpha1",
                     command: "aws-iam-authenticator",
                     args: args,
+                    env: env,
                 },
             },
         }],
@@ -399,7 +447,10 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
             let config = {};
 
             if (args.creationRoleProvider) {
-                config = args.creationRoleProvider.role.arn.apply(arn => generateKubeconfig(clusterName, clusterEndpoint, clusterCertificateAuthority.data, arn));
+                config = args.creationRoleProvider.role.arn.apply(arn => {
+                    const opts: KubeconfigOptions = {roleArn: arn};
+                    return generateKubeconfig(clusterName, clusterEndpoint, clusterCertificateAuthority.data, opts);
+                });
             } else {
                 config = generateKubeconfig(clusterName, clusterEndpoint, clusterCertificateAuthority.data);
             }
@@ -584,6 +635,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         privateSubnetIds: args.privateSubnetIds ? pulumi.output(args.privateSubnetIds) : undefined,
         clusterSecurityGroup: eksClusterSecurityGroup,
         cluster: eksCluster,
+        endpoint: endpoint,
         nodeGroupOptions: nodeGroupOptions,
         kubeconfig: kubeconfig,
         provider: provider,
@@ -1106,5 +1158,28 @@ export class Cluster extends pulumi.ComponentResource {
             parent: this,
             providers: { kubernetes: this.provider },
         });
+    }
+
+    /**
+     * Generate a kubeconfig for cluster authentication that does not use the
+     * default AWS credential provider chain, and instead is scoped to
+     * the supported options in `KubeconfigOptions`.
+     *
+     * The kubeconfig generated is automatically stringified for ease of use
+     * with the pulumi/kubernetes provider.
+     *
+     * See for more details:
+     * - https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
+     * - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html
+     * - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+     */
+    getKubeconfig(args: KubeconfigOptions): pulumi.Output<string> {
+        const kc = generateKubeconfig(
+            this.eksCluster.name,
+            this.eksCluster.endpoint,
+            this.eksCluster.certificateAuthority.data,
+            args,
+        );
+        return pulumi.output(kc).apply(JSON.stringify);
     }
 }

--- a/nodejs/eks/examples/README.md
+++ b/nodejs/eks/examples/README.md
@@ -6,6 +6,7 @@ clusters.
 1. [Default Cluster and a Custom Cluster](./cluster)
 1. [Cluster with AWS Managed NodeGroups](./managed-nodegroups)
 1. [Cluster with NodeGroups (using CloudFormation)](./nodegroup)
+1. [Cluster RBAC: Using AWS Roles and Named Profiles](./scoped-kubeconfigs)
 1. [Cluster with Custom Kubernetes Storage Classes](./storage-classes)
 1. [Cluster with AWS Resource Tags](./tags)
 1. [Cluster with Fargate Managed Nodes](./fargate)

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -186,6 +186,21 @@ func TestAccOidcIam(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccRoleKubeconfig(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "scoped-kubeconfigs"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccCluster_withUpdate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/nodejs/eks/examples/scoped-kubeconfigs/Pulumi.yaml
+++ b/nodejs/eks/examples/scoped-kubeconfigs/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: scoped-kubeconfigs
+description: Example of using the getKubeconfig method to generate role and profile based kubeconfigs
+runtime: nodejs

--- a/nodejs/eks/examples/scoped-kubeconfigs/README.md
+++ b/nodejs/eks/examples/scoped-kubeconfigs/README.md
@@ -1,0 +1,4 @@
+# examples/scoped-kubeconfigs
+
+Example of using the `cluster.getKubeconfig()` method to generate role and
+profile based kubeconfigs.

--- a/nodejs/eks/examples/scoped-kubeconfigs/index.ts
+++ b/nodejs/eks/examples/scoped-kubeconfigs/index.ts
@@ -1,0 +1,106 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import assert = require("assert");
+
+const projectName = pulumi.getProject();
+const current = aws.getCallerIdentity();
+const accountId = current.accountId;
+
+// Create a new IAM role for devs on the account caller.
+const devsGroupName = "pulumi:devs"; // Can be any value.
+const devsAlice = "pulumi:alice"; // Can be any value.
+const devsRole = new aws.iam.Role(`${projectName}`, {
+    assumeRolePolicy: {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {"AWS": `${accountId}`},
+                "Action": "sts:AssumeRole",
+            },
+        ],
+    },
+});
+
+// Create an EKS cluster with a role mapping from the devs IAM role to the
+// dev group and user in k8s.
+const cluster = new eks.Cluster(`${projectName}`, {
+    deployDashboard: false,
+    roleMappings      : [
+        {
+            roleArn   : devsRole.arn,
+            groups    : [devsGroupName],
+            username  : devsAlice,
+        },
+    ],
+});
+
+// Export the cluster kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create the devs namespace and limited RBAC role to only work with Pods.
+const appsNamespace = new k8s.core.v1.Namespace("apps", undefined, {provider: cluster.provider});
+const devsGroupRole = new k8s.rbac.v1.Role("pulumi-devs",
+    {
+        metadata: { namespace: appsNamespace.metadata.name },
+        rules: [
+            {
+                apiGroups: [""],
+                resources: ["pods"],
+                verbs: ["get", "list", "watch", "create", "update", "delete"],
+            },
+        ],
+    }, { provider: cluster.provider },
+);
+
+// Bind the devs RBAC group to the new, limited role.
+const devsGroupRoleBinding = new k8s.rbac.v1.RoleBinding("pulumi-devs",
+    {
+        metadata: { namespace: appsNamespace.metadata.name },
+        subjects: [{
+            kind: "Group",
+            name: devsGroupName,
+        }],
+        roleRef: {
+            apiGroup: "rbac.authorization.k8s.io",
+            kind: "Role",
+            name: devsGroupRole.metadata.name,
+        },
+    }, { provider: cluster.provider },
+);
+
+// Create and use a role-based kubeconfig.
+const roleKubeconfigOpts: eks.KubeconfigOptions = { roleArn: devsRole.arn };
+const roleKubeconfig = cluster.getKubeconfig(roleKubeconfigOpts);
+const roleProvider = new k8s.Provider("provider", {kubeconfig: roleKubeconfig});
+const pod = new k8s.core.v1.Pod("nginx", {
+    metadata: { namespace: appsNamespace.metadata.name },
+    spec: {
+        containers: [{
+            name: "nginx",
+            image: "nginx",
+            ports: [{ name: "http", containerPort: 80 }],
+        }],
+    },
+}, { provider: roleProvider, dependsOn: devsGroupRoleBinding  });
+
+// Create a profile-based kubeconfig.
+const profileName = "my-profile";
+const profileKubeconfigOpts: eks.KubeconfigOptions = { profileName};
+export const profileKubeconfig = cluster.getKubeconfig(profileKubeconfigOpts);
+
+// For testing purposes only: assert that the AWS_PROFILE is set in the
+// kubeconfig's exec args.
+profileKubeconfig.apply(kc => {
+    // Manually parse since the kubeconfig Config api resource [1] is not
+    // a known type.
+    // 1. https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration
+    for (const user of JSON.parse(kc).users) {
+        const u = user["user"];
+        assert(u?.exec?.env?.name === "AWS_PROFILE");
+        assert(u?.exec?.env?.value === profileName);
+    }
+});

--- a/nodejs/eks/examples/scoped-kubeconfigs/package.json
+++ b/nodejs/eks/examples/scoped-kubeconfigs/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "scoped-kubeconfigs",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest",
+        "@pulumi/kubernetes": "latest",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/scoped-kubeconfigs/tsconfig.json
+++ b/nodejs/eks/examples/scoped-kubeconfigs/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/index.ts
+++ b/nodejs/eks/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { Cluster, ClusterOptions, ClusterNodeGroupOptions, CoreData, RoleMapping, UserMapping, CreationRoleProvider, getRoleProvider } from "./cluster";
+export { Cluster, ClusterOptions, ClusterNodeGroupOptions, CoreData, RoleMapping, UserMapping, CreationRoleProvider, getRoleProvider, KubeconfigOptions } from "./cluster";
 export { ManagedNodeGroupOptions, NodeGroup, NodeGroupOptions, NodeGroupData, createManagedNodeGroup } from "./nodegroup";
 export { VpcCni, VpcCniOptions } from "./cni";
 export { createNodeGroupSecurityGroup } from "./securitygroup";


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- feat(cluster): add getKubeconfig method to generate scoped kubeconfigs

A scoped kubeconfig is necessary for certain auth scenarios. For example:
  1. Assume a role on the default account caller,
  2. Use an AWS creds profile instead of the default account caller,
  3. Use an AWS creds creds profile instead of the default account caller,
     and then assume a given role on the profile. This scenario is also
     possible by only using a profile, iff the profile includes a role to
     assume in its settings.

---

Scope options added are based on [AWS kubeconfig docs](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html), and include:
  - `roleArn`: Role ARN to assume instead of the default AWS credential
  provider chain
  - `profileName`: AWS credential profile name to always use instead of the
  default AWS credential provider chain

**Note**: The options can be used independently, or additively as they configure different settings of the kubeconfig authentication steps.

PR includes example of:
  - Using role-based kubeconfig: create a Pod as a dev with limited permissions.
  - Asserting profile-based kubeconfig is properly configured, since testing profiles is out of scope.

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/348
