### PR TITLE
refactor(aws-auth): replace aws-iam-authenticator with aws eks get-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Improvements
 
+- refactor(aws-auth): replace aws-iam-authenticator with aws eks get-token
+  [#362](https://github.com/pulumi/pulumi-eks/pull/362)
+  **Note:** for existing clusters, this change will recompute the kubeconfig used,
+  as its auth arguments and settings get updated to work with `aws eks get-token`.
+  It should not affect cluster access or cause replacements of existing k8s
+  resources.
 - feat(nodegroup): use the latest recommended AMIs from the SSM store
   [#366](https://github.com/pulumi/pulumi-eks/pull/366)
 - feat(cluster): support HTTP(S) proxy for cluster readiness & OIDC config

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ This includes:
 1. [Install Pulumi](https://www.pulumi.com/docs/reference/install).
 1. Install [Node.js](https://nodejs.org/en/download).
 1. Install a package manager for Node.js, such as [NPM](https://www.npmjs.com/get-npm) or [Yarn](https://yarnpkg.com/lang/en/docs/install).
-1. [Configure AWS Credentials](https://www.pulumi.com/docs/reference/clouds/aws/setup/).
-1. [Install AWS IAM Authenticator for Kubernetes](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html).
+1. [Install and Configure the AWS CLI](https://www.pulumi.com/docs/reference/clouds/aws/setup/).
+    * Use AWS CLI version >= `1.18.17`.
+    * See the [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/managing-auth.html) for more details.
 1. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
 
 ## Installing

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -163,11 +163,11 @@ function generateKubeconfig(
     clusterEndpoint: pulumi.Input<string>,
     certData: pulumi.Input<string>,
     opts?: KubeconfigOptions) {
-    let args = ["token", "-i", clusterName];
+    let args = ["eks", "get-token", "--cluster-name", clusterName];
     let env: { [key: string]: pulumi.Input<string>} | undefined;
 
     if (opts?.roleArn) {
-        args = [...args, "-r", opts.roleArn];
+        args = [...args, "--role", opts.roleArn];
     }
     if (opts?.profileName) {
         env = {
@@ -199,7 +199,7 @@ function generateKubeconfig(
             user: {
                 exec: {
                     apiVersion: "client.authentication.k8s.io/v1alpha1",
-                    command: "aws-iam-authenticator",
+                    command: "aws",
                     args: args,
                     env: env,
                 },
@@ -278,12 +278,12 @@ export function getRoleProvider(name: string, region?: aws.Region, profile?: str
  * Create the core components and settings required for the EKS cluster.
  */
 export function createCore(name: string, args: ClusterOptions, parent: pulumi.ComponentResource): CoreData {
-    // Check to ensure that aws-iam-authenticator is installed, as we'll need it in order to deploy k8s resources
+    // Check to ensure that aws CLI is installed, as we'll need it in order to deploy k8s resources
     // to the EKS cluster.
     try {
-        which.sync("aws-iam-authenticator");
+        which.sync("aws");
     } catch (err) {
-        throw new Error("Could not find aws-iam-authenticator for EKS. See https://github.com/pulumi/eks#installing for installation instructions.");
+        throw new Error("Could not find aws CLI for EKS. See https://github.com/pulumi/pulumi-eks for installation instructions.");
     }
 
     if (args.instanceRole && args.instanceRoles) {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

refactor(aws-auth): replace `aws-iam-authenticator` with `aws eks get-token`.

Note: for existing clusters, this change will recompute the kubeconfig used,
as its arguments and settings get updated to work with `aws eks get-token`.
It should not affect cluster access.

Examples of kubeconfig changes:

![image](https://user-images.githubusercontent.com/1112768/77951844-88d07f80-727f-11ea-9a61-bac2e9a68ee6.png)
![image](https://user-images.githubusercontent.com/1112768/77951873-971e9b80-727f-11ea-9542-c2c2236ff8c0.png)

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/304
