### PR TITLE
feat(cluster): support HTTP(S) proxy for cluster readiness & OIDC config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- feat(cluster): support HTTP(S) proxy for cluster readiness & OIDC config
+  [#364](https://github.com/pulumi/pulumi-eks/pull/364)
 - deps(pulumi): bump node and go pulumi/pulumi to v1.13.1
   [#361](https://github.com/pulumi/pulumi-eks/pull/361)
 - feat(cluster): add getKubeconfig method to generate scoped kubeconfigs

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -18,7 +18,8 @@
         "netmask": "^1.0.6",
         "@types/js-yaml": "^3.12.0",
         "js-yaml": "^3.13.0",
-        "which": "^1.3.1"
+        "which": "^1.3.1",
+        "https-proxy-agent": "^5.0.0"
     },
     "devDependencies": {
         "@types/netmask": "^1.0.30",

--- a/nodejs/eks/tsconfig.json
+++ b/nodejs/eks/tsconfig.json
@@ -12,7 +12,8 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true,
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "allowSyntheticDefaultImports": true
     },
     "files": [
         "cluster.ts",


### PR DESCRIPTION
### Proposed changes

Users in a proxied environment are unable to create and configure clusters,
as HTTP requests made by Node during install and setup are not being properly
routed to the proxy first.

Using a proxy is now supported by either setting the conventional proxy environment
variables (`HTTP(S)_PROXY` and/or `http(s)_proxy`), or alternatively by
specifying the `proxy: string` property in the cluster definition with the
settings to use.

Format:      `<protocol>://<host>:<port>`
Auth Format: `<protocol>://<username>:<password>@<host>:<port>`

Ex:
  - `"http://proxy.example.com:3128"`
  - `"https://proxy.example.com"`
  - `"http://username:password@proxy.example.com:3128"`

Support for both cluster and OIDC examples was tested using a local Squid v3.5
proxy server [running in Docker.](https://hub.docker.com/r/metral/squid)

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/350
