### PR TITLE
feat(nodegroup): use the latest recommended AMIs from the SSM store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- feat(nodegroup): use the latest recommended AMIs from the SSM store
+  [#366](https://github.com/pulumi/pulumi-eks/pull/366)
 - feat(cluster): support HTTP(S) proxy for cluster readiness & OIDC config
   [#364](https://github.com/pulumi/pulumi-eks/pull/364)
 - deps(pulumi): bump node and go pulumi/pulumi to v1.13.1

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -305,7 +305,8 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         args.minSize ||
         args.maxSize ||
         args.desiredCapacity ||
-        args.nodeAmiId)) {
+        args.nodeAmiId ||
+        args.gpu)) {
         throw new Error("Setting nodeGroupOptions, and any set of singular node group option(s) on the cluster, is mutually exclusive. Choose a single approach.");
     }
 
@@ -321,6 +322,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         maxSize: args.maxSize,
         desiredCapacity: args.desiredCapacity,
         amiId: args.nodeAmiId,
+        gpu: args.gpu,
         version: args.version,
     };
 
@@ -880,11 +882,31 @@ export interface ClusterOptions {
     customInstanceRolePolicy?: pulumi.Input<string>;
 
     /**
-     * The AMI to use for worker nodes. Defaults to the value of Amazon EKS - Optimized AMI if no value is provided.
-	 * More information about the AWS eks optimized ami is available at https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html.
-	 * Use the information provided by AWS if you want to build your own AMI.
+     * The AMI ID to use for the worker nodes.
+     *
+     * Defaults to the latest recommended EKS Optimized Linux AMI from the
+     * AWS Systems Manager Parameter Store.
+     *
+     * Note: `nodeAmiId` and `gpu` are mutually exclusive.
+     *
+     * See for more details:
+     * - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html.
      */
     nodeAmiId?: pulumi.Input<string>;
+
+    /**
+     * Use the latest recommended EKS Optimized Linux AMI with GPU support for
+     * the worker nodes from the AWS Systems Manager Parameter Store.
+     *
+     * Defaults to false.
+     *
+     * Note: `gpu` and `nodeAmiId` are mutually exclusive.
+     *
+     * See for more details:
+     * - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html.
+     * - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
+     */
+    gpu?: pulumi.Input<boolean>;
 
     /**
      * Public key material for SSH access to worker nodes. See allowed formats at:

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -366,6 +366,21 @@ func TestAccTagInputTypes(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccNodegroupOptions(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "tests", "nodegroup-options"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccMigrateNodeGroups(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/nodejs/eks/examples/tests/nodegroup-options/Pulumi.yaml
+++ b/nodejs/eks/examples/tests/nodegroup-options/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-nodegroup-options
+description: Tests nodegroup options
+runtime: nodejs

--- a/nodejs/eks/examples/tests/nodegroup-options/README.md
+++ b/nodejs/eks/examples/tests/nodegroup-options/README.md
@@ -1,0 +1,3 @@
+# tests/nodegroup-options
+
+Tests nodegroup options: gpu.

--- a/nodejs/eks/examples/tests/nodegroup-options/index.ts
+++ b/nodejs/eks/examples/tests/nodegroup-options/index.ts
@@ -1,0 +1,12 @@
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+
+const projectName = pulumi.getProject();
+
+const cluster = new eks.Cluster(`${projectName}`, {
+    deployDashboard: false,
+    gpu: true,
+});
+
+// Export the cluster kubeconfig.
+export const kubeconfig = cluster.kubeconfig;

--- a/nodejs/eks/examples/tests/nodegroup-options/package.json
+++ b/nodejs/eks/examples/tests/nodegroup-options/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "example-nodegroup-options",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/tests/nodegroup-options/tsconfig.json
+++ b/nodejs/eks/examples/tests/nodegroup-options/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
### Proposed changes

feat(nodegroup): use the latest recommended AMIs from the SSM store

- Default to the latest recommended AMI IDs from the AWS SSM Parameter Store.
- Add new `NodeGroupOption`: `gpu` to use the latest recommended EKS
  Optimized Linux AMI with GPU support.

See for more details:
  - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
  - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
  - https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/258
Closes https://github.com/pulumi/pulumi-eks/issues/354