### PR TITLE
Update node & go pulumi deps to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- Update node & go pulumi deps to 2.0
+  [#375](https://github.com/pulumi/pulumi-eks/pull/375)
 - fix(aws): rm sync invokes for AWS data source calls
   [#373](https://github.com/pulumi/pulumi-eks/pull/373)
 - refactor(aws-auth): replace aws-iam-authenticator with aws eks get-token

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,19 @@ require (
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/pulumi/pulumi/pkg v1.13.1
-	github.com/pulumi/pulumi/sdk v1.13.1
+	github.com/onsi/ginkgo v1.12.0 // indirect
+	github.com/onsi/gomega v1.9.0 // indirect
+	github.com/pulumi/pulumi/pkg/v2 v2.0.0
+	github.com/pulumi/pulumi/sdk/v2 v2.0.0
 	github.com/stretchr/testify v1.5.1
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1
 	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -421,11 +421,10 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/glog v0.0.0-20180820174630-7eaa6ffb71e4 h1:/qvWZpmGSkjImeceqLKi6LpGuKi++sGUh++wm1yTP+4=
 github.com/pulumi/glog v0.0.0-20180820174630-7eaa6ffb71e4/go.mod h1:6V/nMJd07pUX6IDP/oTGEQ0RwnBuBGM+kp8leKyKo50=
-github.com/pulumi/pulumi/pkg v1.13.1 h1:jtUfc+BLefpoF56pCNITXHRJNfKhrD+p8Z+QXjDzcVE=
-github.com/pulumi/pulumi/pkg v1.13.1/go.mod h1:iX8/aPGtI3VhJnIUqHoT2iy3/0wQJySIRMs9y2TBILw=
-github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e/go.mod h1:ZCVEM4V8vr5IogqUhSu28+FEEn3bIjGYpEOSHRureO0=
-github.com/pulumi/pulumi/sdk v1.13.1 h1:BX0ttL/g5ofKxkK2VY/gp8SdBxJi4eIyIG34JRn9ENU=
-github.com/pulumi/pulumi/sdk v1.13.1/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=
+github.com/pulumi/pulumi/pkg/v2 v2.0.0 h1:5rBPG2Wnoqgbt4Fz1MbahtE4gLxaPdwI9sr1zaV6lUs=
+github.com/pulumi/pulumi/pkg/v2 v2.0.0/go.mod h1:kNG9MBTdKP9AzMgkETumR3fmX9gUYB+HpQL767K6jXc=
+github.com/pulumi/pulumi/sdk/v2 v2.0.0 h1:3VMXbEo3bqeaU+YDt8ufVBLD0WhLYE3tG3t/nIZ3Iac=
+github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -640,7 +640,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     let oidcProvider: aws.iam.OpenIdConnectProvider | undefined;
     if (args.createOidcProvider) {
         // Retrieve the OIDC provider URL's intermediate root CA fingerprint.
-        const awsRegionName = pulumi.output(aws.getRegion({}, {parent, async: true })).apply(r => r.name);
+        const awsRegionName = pulumi.output(aws.getRegion({}, {parent, async: true })).name;
         const eksOidcProviderUrl = pulumi.interpolate `https://oidc.eks.${awsRegionName}.amazonaws.com`;
         const agent = createHttpAgent(args.proxy);
         const fingerprint = getIssuerCAThumbprint(eksOidcProviderUrl, agent);

--- a/nodejs/eks/examples/cluster/package.json
+++ b/nodejs/eks/examples/cluster/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/awsx": "^0.19.2",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi-eks/utils"
-	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
 )
 
 func TestAccCluster(t *testing.T) {

--- a/nodejs/eks/examples/fargate/package.json
+++ b/nodejs/eks/examples/fargate/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/awsx": "^0.19.2",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/managed-nodegroups/package.json
+++ b/nodejs/eks/examples/managed-nodegroups/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/nodegroup/package.json
+++ b/nodejs/eks/examples/nodegroup/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/oidc-iam-sa/index.ts
+++ b/nodejs/eks/examples/oidc-iam-sa/index.ts
@@ -107,7 +107,7 @@ const bucket = new aws.s3.Bucket("pod-irsa-job-bucket", {
     forceDestroy: true,
 });
 const bucketName = bucket.id;
-const regionName = aws.getRegion().name;
+const regionName = pulumi.output(aws.getRegion({}, {async: true})).name;
 const podName = `${saName}-pod-test`;
 const s3Pod = pulumi.all([bucketName, regionName]).apply(([bName, region]) => {
     return new k8s.core.v1.Pod(podName,

--- a/nodejs/eks/examples/oidc-iam-sa/package.json
+++ b/nodejs/eks/examples/oidc-iam-sa/package.json
@@ -5,9 +5,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
-        "@pulumi/eks": "latest",
-        "@pulumi/kubernetes": "latest"
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/kubernetes": "^2.0.0",
+        "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/scoped-kubeconfigs/package.json
+++ b/nodejs/eks/examples/scoped-kubeconfigs/package.json
@@ -4,9 +4,9 @@
         "typescript": "^3.0.0"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
-        "@pulumi/kubernetes": "latest",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/kubernetes": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/storage-classes/package.json
+++ b/nodejs/eks/examples/storage-classes/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/kubernetes": "latest",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/kubernetes": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tags/package.json
+++ b/nodejs/eks/examples/tags/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/managed-ng-aws-auth/package.json
+++ b/nodejs/eks/examples/tests/managed-ng-aws-auth/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/managed-ng-missing-role/package.json
+++ b/nodejs/eks/examples/tests/managed-ng-missing-role/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/migrate-nodegroups/package.json
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/package.json
@@ -5,10 +5,10 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
-        "@pulumi/awsx": "^0.19.2",
-        "@pulumi/kubernetes": "latest",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/awsx": "^0.19.3",
+        "@pulumi/kubernetes": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/nodegroup-options/package.json
+++ b/nodejs/eks/examples/tests/nodegroup-options/package.json
@@ -4,7 +4,7 @@
         "typescript": "^3.0.0"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/pulumi": "^2.0.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/replace-cluster-add-subnets/package.json
+++ b/nodejs/eks/examples/tests/replace-cluster-add-subnets/package.json
@@ -5,8 +5,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/awsx": "^0.19.2",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/replace-secgroup/index.ts
+++ b/nodejs/eks/examples/tests/replace-secgroup/index.ts
@@ -28,7 +28,7 @@ const nodeSecurityGroup = secgroup.createNodeGroupSecurityGroup(secgroupName, {
     vpcId: vpc.id,
     clusterSecurityGroup: testCluster.clusterSecurityGroup,
     eksCluster: testCluster.core.cluster,
-}, vpc);
+}, testCluster);
 const eksClusterIngressRule = new aws.ec2.SecurityGroupRule(`${secgroupName}-eksClusterIngressRule`, {
     description: "Allow pods to communicate with the cluster API Server",
     type: "ingress",

--- a/nodejs/eks/examples/tests/replace-secgroup/package.json
+++ b/nodejs/eks/examples/tests/replace-secgroup/package.json
@@ -5,9 +5,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
-        "@pulumi/awsx": "^0.19.2",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/examples/tests/tag-input-types/package.json
+++ b/nodejs/eks/examples/tests/tag-input-types/package.json
@@ -5,9 +5,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.29.0",
-        "@pulumi/awsx": "^0.19.2",
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -422,7 +422,7 @@ ${customUserData}
         const amiType = args.gpu ? "amazon-linux-2-gpu" : "amazon-linux-2";
         amiId = version.apply(v => {
             const parameterName = `/aws/service/eks/optimized-ami/${v}/${amiType}/recommended/image_id`;
-            return pulumi.output(aws.ssm.getParameter({name: parameterName}, {parent, async: true})).apply(pv => pv.value);
+            return pulumi.output(aws.ssm.getParameter({name: parameterName}, {parent, async: true})).value;
         });
     }
 

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -11,9 +11,9 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-eks",
     "dependencies": {
-        "@pulumi/aws": "^1.18.0",
-        "@pulumi/kubernetes": "^1.5.3",
-        "@pulumi/pulumi": "^1.13.1",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/kubernetes": "^2.0.0",
+        "@pulumi/pulumi": "^2.0.0",
         "axios": "^0.19.0",
         "netmask": "^1.0.6",
         "@types/js-yaml": "^3.12.0",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- Update node packages used in tests to `pulumi/{pulumi,aws,kubernetes}` 2.0
- Update go tests to use new `pulumi/pkg/v2` and `pulumi/sdk/v2` import paths
- Update test utils and tests to work with 2.0

`2.0.0` was tested with:
- 1.14.1 CLI in Travis,
- Locally using 2.0.0 CLI

### Related issues (optional)

https://github.com/pulumi/pulumi-eks/issues/374
