### PR TITLE
feat(cluster): add encryptionConfigKeyArn opt to encrypt k8s Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- feat(cluster): add encryptionConfigKeyArn opt to encrypt k8s Secrets
+  [#389](https://github.com/pulumi/pulumi-eks/pull/389)
+
 ## 0.19.0 (Released April 20, 2020)
 
 **For a more detailed list of the changes introduced in this release, please

--- a/nodejs/eks/examples/encryption-provider/Pulumi.yaml
+++ b/nodejs/eks/examples/encryption-provider/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: encryption-provider
+description: Example of using KMS for envelope encryption of Kubernetes secrets in EKS
+runtime: nodejs

--- a/nodejs/eks/examples/encryption-provider/README.md
+++ b/nodejs/eks/examples/encryption-provider/README.md
@@ -1,0 +1,3 @@
+# examples/encryption-provider
+
+Example of using KMS for envelope encryption of Kubernetes secrets in EKS

--- a/nodejs/eks/examples/encryption-provider/index.ts
+++ b/nodejs/eks/examples/encryption-provider/index.ts
@@ -1,0 +1,71 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as kx from "@pulumi/kubernetesx";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import * as fs from "fs";
+import * as os from "os";
+
+const projectName = pulumi.getProject();
+
+// Create a new KMS key.
+const key = new aws.kms.Key("secrets-encryption-key", {
+    deletionWindowInDays: 7,
+    description: "KMS key for encrypting Kubernetes Secrets using envelope encryption",
+});
+
+// Create a new alias to the key.
+const alias = new aws.kms.Alias("alias/k8s-secrets-encryption-key", {
+    targetKeyId: key.keyId,
+});
+
+// Export the arns
+export const keyArn = key.arn;
+export const aliasArn = alias.arn;
+
+// Create an EKS cluster with a KMS encryption provider.
+const cluster = new eks.Cluster(`${projectName}`, {
+    encryptionConfigKeyArn: alias.targetKeyArn,
+});
+
+// Export the cluster kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a random password for an example DB, and store it in a secret.
+const dbPassword = new random.RandomPassword("db-password",
+    {length: 32},
+    {additionalSecretOutputs: ["result"]},
+).result;
+const dbPasswordSecret = new kx.Secret("db-password", {
+    stringData: {"dbPassword": dbPassword},
+}, {provider: cluster.provider});
+
+/*
+// Create an Kubernetes image pull secret to use local client Docker creds (if
+// it exists).
+const homedir = os.homedir();
+const imagePullSecretData = fs.readFileSync(`${homedir}/.docker/config.json`);
+const imagePullSecretStr = imagePullSecretData.toString();
+const imagePullSecretB64Str = Buffer.from(imagePullSecretStr).toString("base64");
+const imagePullSecret = new kx.Secret("image-pull-secret", {
+    type: "kubernetes.io/dockerconfigjson",
+    data: {".dockerconfigjson": imagePullSecretB64Str },
+}, {provider: cluster.provider});
+*/
+
+// Create a pod builder that uses the DB password and local Docker creds.
+const podBuilder = new kx.PodBuilder({
+    // imagePullSecrets: [{ name: imagePullSecret.metadata.name }],
+    containers: [{
+        image: "nginx",
+        ports: { "http": 8080 },
+        env: {
+            "PASSWORD": dbPasswordSecret.asEnvValue("dbPassword"),
+        },
+    }],
+});
+
+// Create a deployment from the pod builder.
+const deployment = new kx.Deployment("nginx", {
+    spec: podBuilder.asDeploymentSpec({replicas: 1}),
+}, {provider: cluster.provider});

--- a/nodejs/eks/examples/encryption-provider/package.json
+++ b/nodejs/eks/examples/encryption-provider/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "encryption-provider",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/kubernetesx": "^0.1.0",
+        "@pulumi/random": "^2.1.0",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/encryption-provider/tsconfig.json
+++ b/nodejs/eks/examples/encryption-provider/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -215,6 +215,24 @@ func TestAccAwsProfile(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccEncryptionProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "encryption-provider"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccCluster_withUpdate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

EKS supports envelope encryption for Kubernetes Secrets that use an AWS
KMS key to sign the Secrets in etcd.

A new cluster option `encryptionConfigKeyArn` is being added that allows
the configuration of a KMS key ARN to be provided for establishing the
cluster's encryption configuration.

Note: the encryption configuration becomes a core part of the cluster's
configuration. Any changes to its settings will require rebuilding a new cluster
and nodes.

See for more details from [AWS](https://aws.amazon.com/blogs/containers/using-eks-encryption-provider-support-for-defense-in-depth/).

### Related issues (optional)

Closes #384