### PR TITLE
tests(import): Add ex. to import & edit rules of default EKS secgroup

### DIFF
--- a/nodejs/eks/examples/README.md
+++ b/nodejs/eks/examples/README.md
@@ -10,6 +10,7 @@ clusters.
 1. [Cluster RBAC: Using an AWS Role](./scoped-kubeconfigs)
 1. [Cluster RBAC: Using an AWS Named Profile and Provider](./aws-profile)
 1. [Cluster with Custom Kubernetes Storage Classes](./storage-classes)
+1. [Import and modify the AWS-created default cluster security group](./modify-default-eks-sg)
 1. [Cluster with AWS Resource Tags](./tags)
 1. [Cluster with Fargate Managed Nodes](./fargate)
 1. [Cluster with an OIDC provider and Service Accounts for Pod IAM](./oidc-iam-sa)

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -431,6 +431,36 @@ func TestAccNodegroupOptions(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccImportDefaultEksSecgroup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "modify-default-eks-sg"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      path.Join(getCwd(t), "modify-default-eks-sg", "step1"),
+					Additive: true,
+					ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+						utils.RunEKSSmokeTest(t,
+							info.Deployment.Resources,
+							info.Outputs["kubeconfig"],
+						)
+					},
+				},
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccMigrateNodeGroups(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/nodejs/eks/examples/modify-default-eks-sg/Pulumi.yaml
+++ b/nodejs/eks/examples/modify-default-eks-sg/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: modify-default-eks-sg
+description: EKS cluster example that imports and modifies the default EKS cluster security group
+runtime: nodejs

--- a/nodejs/eks/examples/modify-default-eks-sg/README.md
+++ b/nodejs/eks/examples/modify-default-eks-sg/README.md
@@ -1,0 +1,107 @@
+# examples/modify-default-eks-sg
+
+EKS cluster example that [imports][pulumi-import] and modifies the default EKS cluster security group.
+
+[pulumi-import]: https://www.pulumi.com/docs/guides/adopting/import/#adopting-existing-resources
+
+## Initialize the Pulumi Project
+
+1.  Clone the repo:
+
+    ```bash
+    git clone https://github.com/metral/modify-default-eks-sg
+    cd modify-default-eks-sg
+    ```
+
+1.  Install the dependencies.
+
+    ```bash
+    npm install
+    ```
+
+1.  Create a new Pulumi stack e.g. `dev`.
+
+    ```bash
+    pulumi stack init dev
+    ```
+
+1. Set the Pulumi configuration variables for the project.
+
+    > **Note:** Select any valid Kubernetes regions for the providers.
+
+    ```bash
+    pulumi config set aws:region us-west-2
+    ```
+
+## Run the initial update
+
+Create the cluster and import the default cluster security group created
+automatically by EKS.
+
+```bash
+pulumi up
+```
+
+## Run a follow-up update
+
+With the cluster created and the default security group imported in the initial
+update, modify the security group properties and run another update.
+
+An example to remove the ingress and egress rules from the default security
+group is in `step1.ts`.
+
+Use the example to remove the rules.
+
+```bash
+mv index.ts index.ts.bak
+cp step1.ts index.ts
+pulumi up
+```
+
+Both sets of rules should now be removed from the default security group.
+
+> Note: Not all security group properties are patchable, some require a replace.
+>
+> Since EKS [creates][eks-default-sec-group] this security group
+> and attaches ENIs to it for the control plane, an attempt to replace or delete the security group 
+> will be held up by the ENIs  to be deleted first. For easier cluster management and
+> teardown, it's best to only update patchable properties of this security group,
+> instead of deleting the security group resource.
+
+[eks-default-sec-group]: https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+
+## Using the cluster
+
+Once the update is complete, you can use the cluster.
+
+```bash
+pulumi stack output kubeconfig > kubeconfig.json
+export KUBECONFIG=`pwd`/kubeconfig.json
+```
+
+Example: query the cluster's nodes and pods.
+
+```bash
+kubectl get nodes -o wide --show-labels
+kubectl get pods --all-namespaces -o wide --show-labels
+```
+
+## Clean Up
+
+Run the following command to tear down the resources that are part of our
+stack.
+
+1. Run `pulumi destroy` to tear down all resources.  You'll be prompted to make
+   sure you really want to delete these resources.
+
+   ```bash
+   pulumi destroy
+   ```
+
+1. To delete the stack, run the following command.
+
+   ```bash
+   pulumi stack rm
+   ```
+   > **Note:** This command deletes all deployment history from the Pulumi
+   > Console and cannot be undone.

--- a/nodejs/eks/examples/modify-default-eks-sg/index.ts
+++ b/nodejs/eks/examples/modify-default-eks-sg/index.ts
@@ -1,0 +1,41 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create an EKS cluster.
+const projectName = pulumi.getProject();
+const cluster = new eks.Cluster(projectName);
+export const kubeconfig = cluster.kubeconfig;
+
+// Get the results of the default security group created by AWS EKS.
+const defaultSecgroupId = cluster.core.cluster.vpcConfig.clusterSecurityGroupId;
+const defaultSecgroupResult = defaultSecgroupId.apply(id => {
+    if (!id) { return undefined; }
+    return pulumi.output(aws.ec2.getSecurityGroup({
+        filters: [{
+            name: "group-id",
+            values: [id],
+        }],
+        tags: cluster.core.cluster.name.apply(clusterName => ({
+            [`kubernetes.io/cluster/${clusterName}`]: "owned",
+        })),
+    }, {async: true}));
+});
+
+// Import the default security group into Pulumi.
+// https://www.pulumi.com/docs/guides/adopting/import/#adopting-existing-resources
+const defaultSecgroup = pulumi.all([
+    cluster.core.cluster.name,
+    cluster.core.vpcId,
+    defaultSecgroupResult,
+]).apply(([clusterName, vpcId, sgResult]) => {
+    if (!sgResult) { return undefined; }
+    return new aws.ec2.SecurityGroup("default-eks-sg", {
+        name: sgResult.name,
+        description: sgResult.description,
+        ingress: [{ protocol: "-1", fromPort: 0, toPort: 0, self: true}],
+        egress: [{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"]}],
+        tags: sgResult.tags,
+        vpcId,
+    }, {import: sgResult.id});
+});

--- a/nodejs/eks/examples/modify-default-eks-sg/package.json
+++ b/nodejs/eks/examples/modify-default-eks-sg/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "modify-default-eks-sg",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/modify-default-eks-sg/step1/index.ts
+++ b/nodejs/eks/examples/modify-default-eks-sg/step1/index.ts
@@ -1,0 +1,43 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create an EKS cluster.
+const projectName = pulumi.getProject();
+const cluster = new eks.Cluster(projectName);
+export const kubeconfig = cluster.kubeconfig;
+
+// Get the results of the default security group created by AWS EKS.
+const defaultSecgroupId = cluster.core.cluster.vpcConfig.clusterSecurityGroupId;
+const defaultSecgroupResult = defaultSecgroupId.apply(id => {
+    if (!id) { return undefined; }
+    return pulumi.output(aws.ec2.getSecurityGroup({
+        filters: [{
+            name: "group-id",
+            values: [id],
+        }],
+        tags: cluster.core.cluster.name.apply(clusterName => ({
+            [`kubernetes.io/cluster/${clusterName}`]: "owned",
+        })),
+    }, {async: true}));
+});
+
+// Import the default security group into Pulumi.
+// https://www.pulumi.com/docs/guides/adopting/import/#adopting-existing-resources
+const defaultSecgroup = pulumi.all([
+    cluster.core.cluster.name,
+    cluster.core.vpcId,
+    defaultSecgroupResult,
+]).apply(([clusterName, vpcId, sgResult]) => {
+    if (!sgResult) { return undefined; }
+    return new aws.ec2.SecurityGroup("default-eks-sg", {
+        name: sgResult.name,
+        description: sgResult.description,
+        // Set empty lists to update the inputs for the rules.
+        ingress: [/*{ protocol: "-1", fromPort: 0, toPort: 0, self: true}*/],
+        egress: [/*{ protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"]}*/],
+        tags: sgResult.tags,
+        vpcId,
+        // optional (but suggested): remove the import property after initial import is completed.
+    }, {import: sgResult.id});
+});

--- a/nodejs/eks/examples/modify-default-eks-sg/tsconfig.json
+++ b/nodejs/eks/examples/modify-default-eks-sg/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Add new example that showcases how to import the default security group [automatically created](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html)
by AWS into Pulumi, and then modify its rules in a subsequent update.