### PR TITLE
feat(nodegroup): Support encryption of the root block device for nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- feat(nodegroup): Support encryption of the root block device for nodes
+  [#407](https://github.com/pulumi/pulumi-eks/pull/407)
 - fix(ex/default-sg): rm Output tag values per string type reqs
   [#404](https://github.com/pulumi/pulumi-eks/pull/404)
 - nodegroup(asgName): fix asgName definition

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -343,6 +343,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         nodeAssociatePublicIpAddress: args.nodeAssociatePublicIpAddress,
         instanceType: args.instanceType,
         nodePublicKey: args.nodePublicKey,
+        encryptRootBockDevice: args.encryptRootBockDevice,
         nodeRootVolumeSize: args.nodeRootVolumeSize,
         nodeUserData: args.nodeUserData,
         minSize: args.minSize,
@@ -977,6 +978,11 @@ export interface ClusterOptions {
      * The tags to apply to the cluster security group.
      */
     clusterSecurityGroupTags?: InputTags;
+
+    /**
+     * Encrypt the root block device of the nodes in the node group.
+     */
+    encryptRootBockDevice?: pulumi.Input<boolean>;
 
     /**
      * The tags to apply to the default `nodeSecurityGroup` created by the cluster.

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -90,6 +90,11 @@ export interface NodeGroupBaseOptions {
     extraNodeSecurityGroups?: aws.ec2.SecurityGroup[];
 
     /**
+     * Encrypt the root block device of the nodes in the node group.
+     */
+    encryptRootBockDevice?: pulumi.Input<boolean>;
+
+    /**
      * Public key material for SSH access to worker nodes. See allowed formats at:
      * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
      * If not provided, no SSH access is enabled on VMs.
@@ -467,6 +472,7 @@ ${customUserData}
         securityGroups: [nodeSecurityGroupId, ...extraNodeSecurityGroupIds],
         spotPrice: args.spotPrice,
         rootBlockDevice: {
+            encrypted: args.encryptRootBockDevice,
             volumeSize: args.nodeRootVolumeSize || 20, // GiB
             volumeType: "gp2", // default is "standard"
             deleteOnTermination: true,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

feat(nodegroup): Support encryption of the root block device for nodes

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/388
