### PR TITLE
Support for the ENI_CONFIG_LABEL_DEF environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Support for the ENI_CONFIG_LABEL_DEF environment variable 
+  [#411](https://github.com/pulumi/pulumi-eks/pull/411)
+
 ### Improvements
 
 ## 0.19.3 (Released July 7, 2020)


### PR DESCRIPTION
### Proposed changes

When an EKS cluster worker node group is spread across multiple availability zones,
and we want to use custom CNI networking, EKS allows you to specify the
ENI_CONFIG_LABEL_DEF environment variable value for worker nodes
This is used to tell Kubernetes to automatically apply the ENIConfig for each Availability Zone
Ref: https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html (step 6(c)).

This PR exposes the env variable in the CNI module in pulumi-eks.

### Related issues (optional)

Addresses issue #410 