### PR TITLE
tests(migrate-ng): unpin to specific cluster version and matching AMIs

### DIFF
--- a/nodejs/eks/examples/tests/migrate-nodegroups/echoserver.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/echoserver.ts
@@ -122,10 +122,8 @@ interface EchoserverIngressArgs {
 export function createIngress(
     name: string,
     args: EchoserverIngressArgs,
-): k8s.extensions.v1beta1.Ingress {
-    // TODO(metral): change to k8s.networking.v1beta.Ingress
-    // when EKS supports >= 1.14.
-    return new k8s.extensions.v1beta1.Ingress(
+): k8s.networking.v1beta1.Ingress {
+    return new k8s.networking.v1beta1.Ingress(
         name,
         {
             metadata: {

--- a/nodejs/eks/examples/tests/migrate-nodegroups/index.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/index.ts
@@ -26,7 +26,6 @@ const instanceProfiles = iam.createInstanceProfiles(projectName, roles);
 
 // Create an EKS cluster.
 const myCluster = new eks.Cluster(`${projectName}`, {
-    version: "1.13",
     vpcId: vpcId,
     publicSubnetIds: vpc.publicSubnetIds,
     privateSubnetIds: vpc.privateSubnetIds,
@@ -42,7 +41,6 @@ export const clusterName = myCluster.core.cluster.name;
 
 // Create a Standard node group of t2.medium workers.
 const ngStandard = utils.createNodeGroup(`${projectName}-ng-standard`, {
-    ami: "ami-03a55127c613349a7", // k8s v1.13.7 in us-west-2
     instanceType: "t2.medium",
     desiredCapacity: 3,
     cluster: myCluster,
@@ -53,7 +51,6 @@ const ngStandard = utils.createNodeGroup(`${projectName}-ng-standard`, {
 // dedicated for the NGINX Ingress Controller.
 if (config.createNodeGroup2xlarge) {
     const ng2xlarge = utils.createNodeGroup(`${projectName}-ng-2xlarge`, {
-        ami: "ami-0355c210cb3f58aa2", // k8s v1.12.7 in us-west-2
         instanceType: "t3.2xlarge",
         desiredCapacity: config.desiredCapacity2xlarge,
         cluster: myCluster,
@@ -66,7 +63,6 @@ if (config.createNodeGroup2xlarge) {
 // be used to migrate NGINX away from the 2xlarge node group.
 if (config.createNodeGroup4xlarge) {
     const ng4xlarge = utils.createNodeGroup(`${projectName}-ng-4xlarge`, {
-        ami: "ami-03a55127c613349a7", // k8s v1.13.7 in us-west-2
         instanceType: "c5.4xlarge",
         desiredCapacity: config.desiredCapacity4xlarge,
         cluster: myCluster,

--- a/nodejs/eks/examples/tests/migrate-nodegroups/nginx-ing-cntlr-rbac.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/nginx-ing-cntlr-rbac.ts
@@ -51,9 +51,7 @@ export function makeNginxClusterRole(
                     verbs: ["get", "list", "watch"],
                 },
                 {
-                    // TODO(metral): change to k8s.networking.v1beta.Ingress
-                    // when EKS supports >= 1.14.
-                    apiGroups: ["extensions"],
+                    apiGroups: ["networking.k8s.io"],
                     resources: ["ingresses"],
                     verbs: ["get", "list", "watch"],
                 },
@@ -63,9 +61,7 @@ export function makeNginxClusterRole(
                     verbs: ["create", "patch"],
                 },
                 {
-                    // TODO(metral): change to k8s.networking.v1beta.Ingress
-                    // when EKS supports >= 1.14.
-                    apiGroups: ["extensions"],
+                    apiGroups: ["networking.k8s.io"],
                     resources: ["ingresses/status"],
                     verbs: ["update"],
                 },

--- a/nodejs/eks/examples/tests/migrate-nodegroups/utils.ts
+++ b/nodejs/eks/examples/tests/migrate-nodegroups/utils.ts
@@ -4,7 +4,6 @@ import * as pulumi from "@pulumi/pulumi";
 
 // Creates an EKS NodeGroup.
 interface NodeGroupArgs {
-    ami: string;
     instanceType: pulumi.Input<aws.ec2.InstanceType>;
     desiredCapacity: pulumi.Input<number>;
     cluster: eks.Cluster;
@@ -20,13 +19,11 @@ export function createNodeGroup(
         nodeSecurityGroup: args.cluster.nodeSecurityGroup,
         clusterIngressRule: args.cluster.eksClusterIngressRule,
         instanceType: args.instanceType,
-        amiId: args.ami,
         nodeAssociatePublicIpAddress: false,
         desiredCapacity: args.desiredCapacity,
         minSize: args.desiredCapacity,
         maxSize: 10,
         instanceProfile: args.instanceProfile,
-        labels: {"amiId": args.ami},
         taints: args.taints,
     }, {
         providers: { kubernetes: args.cluster.provider},


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

tests(migrate-ng): unpin to specific cluster version and matching AMIs
### Related issues (optional)

Fixes #413 