### PR TITLE
fix(kubeconfig): treat auth & env as Output<t> in kubeconfig generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- fix(kubeconfig): treat auth & env as Output<t> in kubeconfig generation
+  [#421](https://github.com/pulumi/pulumi-eks/pull/421)
 - examples: Add VPC & subnet tag example for subnets managed with Pulumi
   [#420](https://github.com/pulumi/pulumi-eks/pull/420)
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -197,7 +197,10 @@ function generateKubeconfig(
         }];
     }
 
-    return {
+    return pulumi.all([
+        args,
+        env,
+    ]).apply(([tokenArgs, envvars]) => ({
         apiVersion: "v1",
         clusters: [{
             cluster: {
@@ -221,12 +224,12 @@ function generateKubeconfig(
                 exec: {
                     apiVersion: "client.authentication.k8s.io/v1alpha1",
                     command: "aws",
-                    args: args,
-                    env: env,
+                    args: tokenArgs,
+                    env: envvars,
                 },
             },
         }],
-    };
+    }));
 }
 
 /**

--- a/nodejs/eks/examples/README.md
+++ b/nodejs/eks/examples/README.md
@@ -11,6 +11,7 @@ clusters.
 1. [Cluster with NodeGroups and Security Groups](./extra-sg)
 1. [Cluster RBAC: Using an AWS Role](./scoped-kubeconfigs)
 1. [Cluster RBAC: Using an AWS Named Profile and Provider](./aws-profile)
+1. [Cluster RBAC: Using an AWS Named Profile and Role](./aws-profile-role)
 1. [Cluster Secrets: Using Envelope Encryption with KMS to secure Secrets in etcd](./encryption-provider)
 1. [Cluster with Custom Kubernetes Storage Classes](./storage-classes)
 1. [Import and modify the AWS-created default cluster security group](./modify-default-eks-sg)

--- a/nodejs/eks/examples/aws-profile-role/Pulumi.yaml
+++ b/nodejs/eks/examples/aws-profile-role/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: example-aws-profile-role
+description: EKS cluster example that uses an AWS named profile and role for credentials
+runtime: nodejs

--- a/nodejs/eks/examples/aws-profile-role/README.md
+++ b/nodejs/eks/examples/aws-profile-role/README.md
@@ -1,0 +1,5 @@
+# examples/aws-profile-role
+
+Creates an EKS cluster using a named profile. Additionally, creates a new
+cluster admin IAM role that gets mapped into the cluster's RBAC on creation for
+usage. Then, use the named profile and cluster role to deploy a Pod.

--- a/nodejs/eks/examples/aws-profile-role/index.ts
+++ b/nodejs/eks/examples/aws-profile-role/index.ts
@@ -1,0 +1,83 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+
+const projectName = pulumi.getProject();
+
+// Create a new VPC.
+const vpc = new awsx.ec2.Vpc(`${projectName}`, {
+    tags: { "Name": `${projectName}` },
+});
+
+// Create a new IAM role on the account caller to use as a cluster admin.
+const accountId = pulumi.output(aws.getCallerIdentity({async: true})).accountId;
+const assumeRolePolicy = accountId.apply(id => JSON.stringify(
+    {
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Sid: "",
+                Effect: "Allow",
+                Principal: {
+                    AWS: `arn:aws:iam::${id}:root`,
+                },
+                Action: "sts:AssumeRole",
+            },
+        ],
+    },
+));
+const clusterAdminRole = new aws.iam.Role("clusterAdminRole", {
+    assumeRolePolicy,
+    tags: {
+        clusterAccess: "admin-usr",
+    },
+});
+
+// Create an EKS cluster with a named profile. Map in the new IAM role into
+// RBAC for usage after the cluster is running.
+//
+// Note, the role needs to be mapped into the cluster before it can be used.
+// It is omitted from providerCredentialOpts as it will not have access
+// to the cluster yet to write the aws-auth configmap for its own permissions.
+// See example pod below to use the role once the cluster is ready.
+const cluster = new eks.Cluster(`${projectName}`, {
+    vpcId: vpc.id,
+    publicSubnetIds: vpc.publicSubnetIds,
+    providerCredentialOpts: {
+        profileName: aws.config.profile,
+    },
+    roleMappings: [
+        {
+            groups: ["system:masters"],
+            roleArn: clusterAdminRole.arn,
+            username: "pulumi:admin-usr",
+        },
+    ],
+});
+
+// Export the cluster kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Create a role-based kubeconfig with the named profile and the new
+// role mapped into the cluster's RBAC.
+const roleKubeconfigOpts: eks.KubeconfigOptions = {
+    profileName: aws.config.profile,
+    roleArn: clusterAdminRole.arn,
+};
+export const roleKubeconfig = cluster.getKubeconfig(roleKubeconfigOpts);
+const roleProvider = new k8s.Provider("provider", {
+    kubeconfig: roleKubeconfig,
+}, {dependsOn: [cluster.provider]});
+
+// Create a pod with the role-based kubeconfig.
+const pod = new k8s.core.v1.Pod("nginx", {
+    spec: {
+        containers: [{
+            name: "nginx",
+            image: "nginx",
+            ports: [{ name: "http", containerPort: 80 }],
+        }],
+    },
+}, { provider: roleProvider });

--- a/nodejs/eks/examples/aws-profile-role/package.json
+++ b/nodejs/eks/examples/aws-profile-role/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "example-aws-profile-role",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^2.0.0",
+        "@pulumi/awsx": "^0.21.0",
+        "@pulumi/kubernetes": "^2.0.0",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/nodejs/eks/examples/aws-profile-role/tsconfig.json
+++ b/nodejs/eks/examples/aws-profile-role/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -215,6 +215,21 @@ func TestAccAwsProfile(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccAwsProfileRole(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "aws-profile-role"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccEncryptionProvider(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

fix(kubeconfig): treat auth roleArn arg as Output<t>

### Related issues (optional)

Closes #418