### PR TITLE
fix: correct spelling for encryptRootBlockDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- fix: correct spelling for encryptRootBlockDevice
+  [#450](https://github.com/pulumi/pulumi-eks/pull/450)
+
 ## 0.20.0 (Released September 3, 2020)
 
 ### Improvements

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -346,7 +346,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         nodeAssociatePublicIpAddress: args.nodeAssociatePublicIpAddress,
         instanceType: args.instanceType,
         nodePublicKey: args.nodePublicKey,
-        encryptRootBockDevice: args.encryptRootBockDevice,
+        encryptRootBlockDevice: args.encryptRootBlockDevice || args.encryptRootBockDevice,
         nodeRootVolumeSize: args.nodeRootVolumeSize,
         nodeUserData: args.nodeUserData,
         minSize: args.minSize,
@@ -1003,8 +1003,16 @@ export interface ClusterOptions {
 
     /**
      * Encrypt the root block device of the nodes in the node group.
+     *
+     * @deprecated This option has been deprecated due to a misspelling.
+     * Use the correct encryptRootBlockDevice option instead.
      */
     encryptRootBockDevice?: pulumi.Input<boolean>;
+
+    /**
+     * Encrypt the root block device of the nodes in the node group.
+     */
+    encryptRootBlockDevice?: pulumi.Input<boolean>;
 
     /**
      * The tags to apply to the default `nodeSecurityGroup` created by the cluster.

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -91,8 +91,16 @@ export interface NodeGroupBaseOptions {
 
     /**
      * Encrypt the root block device of the nodes in the node group.
+     *
+     * @deprecated This option has been deprecated due to a misspelling.
+     * Use the correct encryptRootBlockDevice option instead.
      */
     encryptRootBockDevice?: pulumi.Input<boolean>;
+
+    /**
+     * Encrypt the root block device of the nodes in the node group.
+     */
+    encryptRootBlockDevice?: pulumi.Input<boolean>;
 
     /**
      * Public key material for SSH access to worker nodes. See allowed formats at:
@@ -486,7 +494,7 @@ ${customUserData}
         securityGroups: [nodeSecurityGroupId, ...extraNodeSecurityGroupIds],
         spotPrice: args.spotPrice,
         rootBlockDevice: {
-            encrypted: args.encryptRootBockDevice,
+            encrypted: args.encryptRootBlockDevice || args.encryptRootBockDevice,
             volumeSize: args.nodeRootVolumeSize || 20, // GiB
             volumeType: "gp2", // default is "standard"
             deleteOnTermination: true,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

fix: correct spelling for encryptRootBlockDevice

### Related issues (optional)

Fixes #446 