### PR TITLE
Port dynamic provider resources to custom resources

### DIFF
--- a/examples/cluster-cs/MyStack.cs
+++ b/examples/cluster-cs/MyStack.cs
@@ -12,13 +12,6 @@ class MyStack : Stack
 
     public MyStack()
     {
-        // TODO[pulumi/pulumi#5455]: To temporarily workaround an issue with dynamic providers
-        // we need to install the @pulumi/eks Node.js package in our example's directory.
-        // Once the issue has been addressed, we can remove these lines.
-        System.IO.File.WriteAllText("package.json", "{ \"dependencies\": { \"@pulumi/eks\": \"latest\" } }");
-        System.Diagnostics.Process.Start("yarn", "install").WaitForExit();
-        System.Diagnostics.Process.Start("yarn", "link @pulumi/eks").WaitForExit();
-
         string projectName = Deployment.Instance.ProjectName;
 
         var cluster1 = new Cluster($"{projectName}-1");

--- a/examples/cluster-py/__main__.py
+++ b/examples/cluster-py/__main__.py
@@ -1,14 +1,6 @@
-import os
 import pulumi
 import pulumi_aws as aws
 import pulumi_eks as eks
-
-# TODO[pulumi/pulumi#5455]: To temporarily workaround an issue with dynamic providers
-# we need to install the @pulumi/eks Node.js package in our example's directory.
-# Once the issue has been addressed, we can remove this.
-with open("package.json", "w") as writer:
-    writer.write('{ "dependencies": { "@pulumi/eks": "latest" } }')
-os.system("yarn install && yarn link @pulumi/eks")
 
 project_name = pulumi.get_project()
 

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -24,13 +24,8 @@ import (
 )
 
 func TestAccClusterCs(t *testing.T) {
-	pathEnv, err := providerPluginPathEnv()
-	if err != nil {
-		t.Fatalf("failed to build provider plugin PATH: %v", err)
-	}
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Env: []string{pathEnv},
 			Dir: filepath.Join(getCwd(t), "cluster-cs"),
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
@@ -47,7 +42,7 @@ func TestAccClusterCs(t *testing.T) {
 
 func getCSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	region := getEnvRegion(t)
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	csharpBase := base.With(integration.ProgramTestOptions{
 		Config: map[string]string{
 			"aws:region": region,

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -529,7 +529,7 @@ func TestAccMigrateNodeGroups(t *testing.T) {
 
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	region := getEnvRegion(t)
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		Config: map[string]string{
 			"aws:region": region,

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -24,13 +24,8 @@ import (
 )
 
 func TestAccClusterPy(t *testing.T) {
-	pathEnv, err := providerPluginPathEnv()
-	if err != nil {
-		t.Fatalf("failed to build provider plugin PATH: %v", err)
-	}
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Env: []string{pathEnv},
 			Dir: filepath.Join(getCwd(t), "cluster-py"),
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
@@ -47,7 +42,7 @@ func TestAccClusterPy(t *testing.T) {
 
 func getPythonBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	region := getEnvRegion(t)
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	pythonBase := base.With(integration.ProgramTestOptions{
 		Config: map[string]string{
 			"aws:region": region,

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -41,8 +41,13 @@ func getCwd(t *testing.T) string {
 	return cwd
 }
 
-func getBaseOptions() integration.ProgramTestOptions {
+func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
+	pathEnv, err := providerPluginPathEnv()
+	if err != nil {
+		t.Fatalf("failed to build provider plugin PATH: %v", err)
+	}
 	return integration.ProgramTestOptions{
+		Env:                  []string{pathEnv},
 		ExpectRefreshChanges: true,
 		RetryFailedSteps:     true,
 		ReportStats:          integration.NewS3Reporter("us-west-2", "eng.pulumi.com", "testreports"),
@@ -50,7 +55,6 @@ func getBaseOptions() integration.ProgramTestOptions {
 	}
 }
 
-//nolint:golint,deadcode
 func providerPluginPathEnv() (string, error) {
 	pluginDir := filepath.Join("..", "provider", "cmd", "pulumi-resource-eks", "bin")
 	absPluginDir, err := filepath.Abs(pluginDir)

--- a/nodejs/eks/cmd/provider/cluster.ts
+++ b/nodejs/eks/cmd/provider/cluster.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import { Cluster } from "../../cluster";
+
+const clusterProvider: pulumi.provider.Provider = {
+    construct: (name: string, type: string, inputs: pulumi.Inputs, options: pulumi.ComponentResourceOptions) => {
+        const cluster = new Cluster(name, inputs, options);
+        return Promise.resolve({
+            urn: cluster.urn,
+            state: {
+                kubeconfig: cluster.kubeconfig,
+            },
+        });
+    },
+    version: "", // ignored
+};
+
+/** @internal */
+export function clusterProviderFactory(): pulumi.provider.Provider {
+    return clusterProvider;
+}

--- a/nodejs/eks/cmd/provider/cni.ts
+++ b/nodejs/eks/cmd/provider/cni.ts
@@ -1,0 +1,150 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as childProcess from "child_process";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as jsyaml from "js-yaml";
+import * as path from "path";
+import * as process from "process";
+import * as tmp from "tmp";
+import which = require("which");
+
+interface VpcCniInputs {
+    kubeconfig: string;
+    nodePortSupport?: boolean;
+    customNetworkConfig?: boolean;
+    externalSnat?: boolean;
+    warmEniTarget?: number;
+    warmIpTarget?: number;
+    logLevel?: string;
+    logFile?: string;
+    image?: string;
+    vethPrefix?: string;
+    eniMtu?: number;
+    eniConfigLabelDef?: string;
+}
+
+function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
+    const cniYaml = jsyaml.safeLoadAll(cniYamlText);
+
+    // Rewrite the envvars for the CNI daemon set as per the inputs.
+    const daemonSet = cniYaml.filter(o => o.kind === "DaemonSet")[0];
+    const env = daemonSet.spec.template.spec.containers[0].env;
+    if (args.nodePortSupport) {
+        env.push({name: "AWS_VPC_CNI_NODE_PORT_SUPPORT", value: args.nodePortSupport ? "true" : "false"});
+    }
+    if (args.customNetworkConfig) {
+        env.push({name: "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG", value: args.customNetworkConfig ? "true" : "false"});
+    }
+    if (args.externalSnat) {
+        env.push({name: "AWS_VPC_K8S_CNI_EXTERNALSNAT", value: args.externalSnat ? "true" : "false"});
+    }
+    if (args.warmEniTarget) {
+        env.push({name: "WARM_ENI_TARGET", value: args.warmEniTarget.toString()});
+    }
+    if (args.warmIpTarget) {
+        env.push({name: "WARM_IP_TARGET", value: args.warmIpTarget.toString()});
+    }
+    if (args.logLevel) {
+        env.push({name: "AWS_VPC_K8S_CNI_LOGLEVEL", value: args.logLevel.toString()});
+    } else {
+        env.push({name: "AWS_VPC_K8S_CNI_LOGLEVEL", value: "DEBUG"});
+    }
+    if (args.logFile) {
+        env.push({name: "AWS_VPC_K8S_CNI_LOG_FILE", value: args.logFile.toString()});
+    } else {
+        env.push({name: "AWS_VPC_K8S_CNI_LOG_FILE", value: "stdout"});
+    }
+    if (args.vethPrefix) {
+        env.push({name: "AWS_VPC_K8S_CNI_VETHPREFIX", value: args.vethPrefix.toString()});
+    } else {
+        env.push({name: "AWS_VPC_K8S_CNI_VETHPREFIX", value: "eni"});
+    }
+    if (args.eniMtu) {
+        env.push({name: "AWS_VPC_ENI_MTU", value: args.eniMtu.toString()});
+    } else {
+        env.push({name: "AWS_VPC_ENI_MTU", value: "9001"});
+    }
+    if (args.image) {
+        daemonSet.spec.template.spec.containers[0].image = args.image.toString();
+    }
+    if (args.eniConfigLabelDef) {
+        env.push({name: "ENI_CONFIG_LABEL_DEF", value: args.eniConfigLabelDef.toString()});
+    }
+    // Return the computed YAML.
+    return cniYaml.map(o => `---\n${jsyaml.safeDump(o)}`).join("");
+}
+
+function applyVpcCniYaml(args: VpcCniInputs) {
+    // Check to ensure that kubectl is installed, as we'll need it in order to deploy k8s resources below.
+    try {
+        which.sync("kubectl");
+    } catch (err) {
+        throw new Error("Could not set VPC CNI options: kubectl is missing. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for installation instructions.");
+    }
+
+    const yamlPath = path.join(__dirname, "..", "..", "cni", "aws-k8s-cni.yaml");
+    const cniYamlText = fs.readFileSync(yamlPath).toString();
+
+    // Dump the kubeconfig to a file.
+    const tmpKubeconfig = tmp.fileSync();
+    fs.writeFileSync(tmpKubeconfig.fd, args.kubeconfig);
+
+    // Compute the required CNI YAML and dump it to a file.
+    const tmpYaml = tmp.fileSync();
+    fs.writeFileSync(tmpYaml.fd, computeVpcCniYaml(cniYamlText, args));
+
+    // Call kubectl to apply the YAML.
+    childProcess.execSync(`kubectl apply -f ${tmpYaml.name}`, {
+        env: { ...process.env, "KUBECONFIG": tmpKubeconfig.name },
+    });
+}
+
+/** @internal */
+export function vpcCniProviderFactory(): pulumi.provider.Provider {
+    return {
+        check: (urn: pulumi.URN, olds: any, news: any) => {
+            let inputs = news;
+            // Since this used to be implemented as a dynamic provider, if we have an old `__provider`
+            // input, propagate it to the new inputs so the engine doesn't see a diff, to avoid any
+            // unnecessary calls to `update`.
+            if (olds.__provider && !news.__provider) {
+                inputs = {
+                    ...news,
+                    __provider: olds.__provider,
+                };
+            }
+            return Promise.resolve({ inputs });
+        },
+        create: (urn: pulumi.URN, inputs: any) => {
+            try {
+                applyVpcCniYaml(<VpcCniInputs>inputs);
+            } catch (e) {
+                return Promise.reject(e);
+            }
+            return Promise.resolve({id: crypto.randomBytes(8).toString("hex"), outs: {}});
+        },
+        update: (id: pulumi.ID, urn: pulumi.URN, olds: any, news: any) => {
+            try {
+                applyVpcCniYaml(<VpcCniInputs>news);
+            } catch (e) {
+                return Promise.reject(e);
+            }
+            return Promise.resolve({outs: {}});
+        },
+        version: "", // ignored
+    };
+}

--- a/nodejs/eks/cmd/provider/index.ts
+++ b/nodejs/eks/cmd/provider/index.ts
@@ -13,25 +13,102 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
-import { Cluster } from "../../cluster";
+import { clusterProviderFactory } from "./cluster";
+import { vpcCniProviderFactory } from "./cni";
+import { randomSuffixProviderFactory } from "./randomSuffix";
 
 class Provider implements pulumi.provider.Provider {
     readonly version = getVersion();
 
+    // A map of types to provider factories. Calling a factory may return a new instance each
+    // time or return the same provider instance.
+    private readonly typeToProviderFactoryMap: Record<string, () => pulumi.provider.Provider> = {
+        "eks:index:Cluster": clusterProviderFactory,
+        "eks:index:RandomSuffix": randomSuffixProviderFactory,
+        "eks:index:VpcCni": vpcCniProviderFactory,
+    };
+
+    check(urn: pulumi.URN, olds: any, news: any): Promise<pulumi.provider.CheckResult> {
+        const provider = this.getProviderForURN(urn);
+        if (!provider) { return unknownResourceRejectedPromise(urn); }
+        return provider.check
+            ? provider.check(urn, olds, news)
+            : Promise.resolve({ inputs: news, failures: [] });
+    }
+
+    diff(id: pulumi.ID, urn: pulumi.URN, olds: any, news: any): Promise<pulumi.provider.DiffResult> {
+        const provider = this.getProviderForURN(urn);
+        if (!provider) { return unknownResourceRejectedPromise(urn); }
+        return provider.diff
+            ? provider.diff(id, urn, olds, news)
+            : Promise.resolve({});
+    }
+
+    create(urn: pulumi.URN, inputs: any): Promise<pulumi.provider.CreateResult> {
+        const provider = this.getProviderForURN(urn);
+        return provider?.create
+            ? provider.create(urn, inputs)
+            : unknownResourceRejectedPromise(urn);
+    }
+
+    read(id: pulumi.ID, urn: pulumi.URN, props?: any): Promise<pulumi.provider.ReadResult> {
+        const provider = this.getProviderForURN(urn);
+        if (!provider) { return unknownResourceRejectedPromise(urn); }
+        return provider.read
+            ? provider.read(id, urn, props)
+            : Promise.resolve({ id, props });
+    }
+
+    update(id: pulumi.ID, urn: pulumi.URN, olds: any, news: any): Promise<pulumi.provider.UpdateResult> {
+        const provider = this.getProviderForURN(urn);
+        if (!provider) { return unknownResourceRejectedPromise(urn); }
+        return provider.update
+            ? provider.update(id, urn, olds, news)
+            : Promise.resolve({ outs: news });
+    }
+
+    delete(id: pulumi.ID, urn: pulumi.URN, props: any): Promise<void> {
+        const provider = this.getProviderForURN(urn);
+        if (!provider) { return unknownResourceRejectedPromise(urn); }
+        return provider.delete
+            ? provider.delete(id, urn, props)
+            : Promise.resolve();
+    }
+
     construct(name: string, type: string, inputs: pulumi.Inputs,
               options: pulumi.ComponentResourceOptions): Promise<pulumi.provider.ConstructResult> {
-        if (type !== "eks:index:Cluster") {
-            return Promise.reject(new Error(`unknown resource type ${type}`));
-        }
-
-        const cluster = new Cluster(name, inputs, options);
-        return Promise.resolve({
-            urn: cluster.urn,
-            state: {
-                kubeconfig: cluster.kubeconfig,
-            },
-        });
+        const provider = this.getProviderForType(type);
+        return provider?.construct
+            ? provider.construct(name, type, inputs, options)
+            : unknownResourceRejectedPromise(type);
     }
+
+    /**
+     * Returns a provider for the URN or undefined if not found.
+     */
+    private getProviderForURN(urn: pulumi.URN): pulumi.provider.Provider | undefined {
+        const type = getType(urn);
+        return this.getProviderForType(type);
+    }
+
+    /**
+     * Returns a provider for the type or undefined if not found.
+     */
+    private getProviderForType(type: string): pulumi.provider.Provider | undefined {
+        const factory = this.typeToProviderFactoryMap[type];
+        return factory ? factory() : undefined;
+    }
+}
+
+function unknownResourceRejectedPromise<T>(type: string): Promise<T> {
+    return Promise.reject(new Error(`unknown resource type ${type}`));
+}
+
+function getType(urn: pulumi.URN): string {
+    const qualifiedType = urn.split("::")[2];
+    const types = qualifiedType.split("$");
+    const lastType = types[types.length - 1];
+    return lastType;
 }
 
 function getVersion(): string {

--- a/nodejs/eks/cmd/provider/randomSuffix.ts
+++ b/nodejs/eks/cmd/provider/randomSuffix.ts
@@ -1,0 +1,53 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as crypto from "crypto";
+
+/** @internal */
+export function randomSuffixProviderFactory(): pulumi.provider.Provider {
+    return {
+        check: (urn: pulumi.URN, olds: any, news: any) => {
+            let inputs = news;
+            // Since this used to be implemented as a dynamic provider, if we have an old `__provider`
+            // input, propagate it to the new inputs so the engine doesn't see a diff, to avoid any
+            // unnecessary calls to `update`.
+            if (olds.__provider && !news.__provider) {
+                inputs = {
+                    ...news,
+                    __provider: olds.__provider,
+                };
+            }
+            return Promise.resolve({ inputs });
+        },
+        create: (urn: pulumi.URN, inputs: any) => {
+            return Promise.resolve({
+                id: getName(urn),
+                outs: { output: appendRandom(inputs.input) },
+            });
+        },
+        update: (id: pulumi.ID, urn: pulumi.URN, olds: any, news: any) => {
+            return Promise.resolve({ outs: { output: appendRandom(news.input) } });
+        },
+        version: "", // ignored
+    };
+}
+
+function appendRandom(v: string): string {
+    return `${v}-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+function getName(urn: pulumi.URN): string {
+    return urn.split("::")[3];
+}

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -20,8 +20,8 @@ import * as crypto from "crypto";
 import * as netmask from "netmask";
 
 import { Cluster, CoreData } from "./cluster";
+import randomSuffix from "./randomSuffix";
 import { createNodeGroupSecurityGroup } from "./securitygroup";
-import transform from "./transform";
 import { InputTags } from "./utils";
 
 /**
@@ -413,7 +413,7 @@ export function createNodeGroup(name: string, args: NodeGroupOptions, parent: pu
         keyName = key.keyName;
     }
 
-    const cfnStackName = transform(`${name}-cfnStackName`, name, n => `${n}-${crypto.randomBytes(4).toString("hex")}`, { parent });
+    const cfnStackName = randomSuffix(`${name}-cfnStackName`, name, { parent });
 
     const awsRegion = pulumi.output(aws.getRegion({}, { parent, async: true }));
     const userDataArg = args.nodeUserData || pulumi.output("");

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -28,5 +28,8 @@
         "@types/which": "^1.3.1",
         "tslint": "^5.7.0",
         "typescript": "^3.7.0"
+    },
+    "pulumi": {
+        "resource": true
     }
 }

--- a/nodejs/eks/randomSuffix.ts
+++ b/nodejs/eks/randomSuffix.ts
@@ -1,0 +1,49 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+
+// Dynamic providers don't currently work well with multi-language components [1]. To workaround this, the
+// dynamic providers in this library have been ported to be custom resources implemented by the new provider
+// plugin. Previously, this functionality was implemented using a generic Transform<T, U> dynamic provider, which
+// accepted a function that would be called when its `input` property changed and the result would be exported
+// as an output. There was only one place in EKS where this was used to append a random suffix to a given input.
+// Instead of reimplementing the general Transform resource as a custom resource in this provider, which would
+// need to (de)serialize the function, this is a reimplementation of just the random suffix functionality needed
+// for EKS. An alias is used and care has been taken in the implementation inside the provider to avoid any diffs
+// for any existing stacks that were created using the old dynamic provider-based Transform for this.
+// [1] https://github.com/pulumi/pulumi/issues/5455
+
+class RandomSuffix extends pulumi.CustomResource {
+    public readonly output!: pulumi.Output<string>;
+
+    constructor(name: string, input: string, opts?: pulumi.CustomResourceOptions) {
+        // This was previously implemented as a dynamic provider, so alias the old type.
+        const aliasOpts = { aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }] };
+        opts = pulumi.mergeOptions(opts, aliasOpts);
+        super("eks:index:RandomSuffix", name, {
+            input: input,
+            output: undefined,
+        }, opts);
+    }
+}
+
+/**
+ * Appends a random string to the given input iff the input's value has changed and returns the result
+ * as an output.
+ * @internal
+ */
+export default function randomSuffix(name: string, input: string, opts?: pulumi.CustomResourceOptions): pulumi.Output<string> {
+    return (new RandomSuffix(name, input, opts)).output;
+}

--- a/nodejs/eks/transform.ts
+++ b/nodejs/eks/transform.ts
@@ -43,6 +43,8 @@ class Transform<T, U> extends dynamic.Resource {
 /**
  * transform evaluates the given function on the given input iff the input's value has changed and returns the result
  * as an output.
+ *
+ * @deprecated This is no longer used and will be removed in the future.
  */
 export default function transform<T, U>(name: string, input: T, func: (v: T) => U, opts?: pulumi.CustomResourceOptions): pulumi.Output<U> {
     return (new Transform(name, input, func, opts)).output;

--- a/nodejs/eks/tsconfig.json
+++ b/nodejs/eks/tsconfig.json
@@ -20,12 +20,15 @@
         "cni.ts",
         "nodegroup.ts",
         "dashboard.ts",
+        "randomSuffix.ts",
         "securitygroup.ts",
         "index.ts",
         "servicerole.ts",
         "storageclass.ts",
 
-        "cmd/provider/index.ts"
+        "cmd/provider/cluster.ts",
+        "cmd/provider/cni.ts",
+        "cmd/provider/index.ts",
+        "cmd/provider/randomSuffix.ts"
     ]
 }
-


### PR DESCRIPTION
Dynamic providers don't currently work well with multi-language components. To workaround in the short term, the dynamic provider resources in this library have been ported to regular custom resources implemented in the new provider plugin. Aliases are used and care has been taken in the implementations inside the provider to avoid any diffs for any existing stacks that were created using the old dynamic provider -based resources.

This does mean that the `@pulumi/eks` node package will require the new `eks` plugin to be installed.

Fixes https://github.com/pulumi/pulumi-eks/issues/451
