### PR TITLE
Temporarily skipping ReplaceSecurityGroup acceptance test

### DIFF
--- a/nodejs/eks/examples/examples_test.go
+++ b/nodejs/eks/examples/examples_test.go
@@ -272,9 +272,10 @@ func TestAccExtraSecurityGroups(t *testing.T) {
 }
 
 func TestAccReplaceSecGroup(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
+	t.Skip("Temporarily skipping test - needs addressed as https://github.com/pulumi/pulumi-eks/issues/463")
+	//if testing.Short() {
+	//	t.Skip("skipping test in short mode.")
+	//}
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "tests", "replace-secgroup"),


### PR DESCRIPTION
This is a continually failing test that we need to skip to get
some balance into the build

We will follow up as https://github.com/pulumi/pulumi-eks/issues/463