### PR TITLE
fix(nodejs): Do not fallback on cluster name when creating node group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- fix(nodejs): Do not fallback on cluster name when creating node group
+  This is a breaking change as it will recreate the node group on the first deploy
+  [#492](https://github.com/pulumi/pulumi-eks/pull/492)
 - fix: correct spelling for encryptRootBlockDevice
   [#450](https://github.com/pulumi/pulumi-eks/pull/450)
 - Initial support for Python and .NET

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -847,7 +847,6 @@ export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptio
     const nodeGroup = new aws.eks.NodeGroup(name, {
         ...nodeGroupArgs,
         clusterName: args.clusterName || core.cluster.name,
-        nodeGroupName: args.nodeGroupName || name,
         nodeRoleArn: roleArn,
         scalingConfig: pulumi.all([
             args.scalingConfig,


### PR DESCRIPTION
### Proposed changes

`createManagedNodeGroup` had a fallback on the cluster name for `nodeGroupName` which disabled the auto naming feature which led `deleteBeforeReplace` to be true.

The fix is probably a breaking change as it will update the NodeGroup after an update.

### Related issues

Fixes #491
