### PR TITLE
Ensure the provider's cwd is set to the program dir

### DIFF
--- a/provider/cmd/pulumi-resource-eks/main.go
+++ b/provider/cmd/pulumi-resource-eks/main.go
@@ -35,7 +35,6 @@ func main() {
 	args = append(args, os.Args[1:]...)
 
 	cmd := exec.Command(nodePath, args...)
-	cmd.Dir = binaryDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
We're shelling out to node from the Go binary to run the actual provider implementation (written in TypeScript), and need to ensure the node process gets the same working directory as the Go process (the Pulumi program dir).

Part of https://github.com/pulumi/pulumi/issues/6368