### PR TITLE
Remove tracing - discontinued

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -51,7 +51,6 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 		ExpectRefreshChanges: true,
 		RetryFailedSteps:     true,
 		ReportStats:          integration.NewS3Reporter("us-west-2", "eng.pulumi.com", "testreports"),
-		Tracing:              "https://tracing.pulumi-engineering.com/collector/api/v1/spans",
 	}
 }
 


### PR DESCRIPTION
According to @stack72 this service has been discontinued. Leaving it in makes some examples hang (at least for me when running locally). Shall we just remove?