### PR TITLE
fix: typo in error msg

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -1387,7 +1387,7 @@ export class Cluster extends pulumi.ComponentResource {
         const awsConfig = new pulumi.Config("aws");
         const awsProfile = awsConfig.get("profile");
         if (awsProfile && !args.providerCredentialOpts) {
-            throw new Error("It looks like you've set an AWS profile in your stack config. Please specify this profile providerCredentialOpts.");
+            throw new Error("It looks like you've set an AWS profile in your stack config. Please specify this profile in providerCredentialOpts.");
         }
 
         // Create the core resources required by the cluster.


### PR DESCRIPTION

### Proposed changes

Added missing word "in" in the error message

Should it be something like "Please specify the profile in providerCredentialOpts" instead of
"Please specify this profile providerCredentialOpts."?

### Related issues (optional)

 #578
