### PR TITLE
[nodejs] Add resource registration for VpcCni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Upgrade Pulumi dependencies
   [#589](https://github.com/pulumi/pulumi-eks/pull/589)
 
+- Add resource registration for VpcCni
+  [#590](https://github.com/pulumi/pulumi-eks/pull/590)
+
 ## 0.30.0 (Released April 19, 2021)
 
 - Upgrade Pulumi dependencies to 3.0 releases

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ provider::
 
 build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs::
-	rm -rf nodejs/eks/bin
+	rm -rf nodejs/eks/bin/*
 	cd nodejs/eks && \
 		yarn install && \
 		yarn run tsc && \

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -184,25 +184,24 @@ export class VpcCni extends pulumi.CustomResource {
         // This was previously implemented as a dynamic provider, so alias the old type.
         const aliasOpts = { aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }] };
         opts = pulumi.mergeOptions(opts, aliasOpts);
-        args = args || {};
         super("eks:index:VpcCni", name, {
-            kubeconfig: pulumi.output(kubeconfig).apply(JSON.stringify),
-            nodePortSupport: args.nodePortSupport,
-            customNetworkConfig: args.customNetworkConfig,
-            externalSnat: args.externalSnat,
-            warmEniTarget: args.warmEniTarget,
-            warmIpTarget: args.warmIpTarget,
-            logLevel: args.logLevel,
-            logFile: args.logFile,
-            image: args.image,
-            eniConfigLabelDef: args.eniConfigLabelDef,
-            pluginLogLevel: args.pluginLogLevel,
-            pluginLogFile: args.pluginLogFile,
-            enablePodEni: args.enablePodEni,
-            cniConfigureRpfilter: args.cniConfigureRpfilter,
-            cniCustomNetworkCfg: args.cniCustomNetworkCfg,
-            cniExternalSnat: args.cniCustomNetworkCfg,
-            securityContextPrivileged: args.securityContextPrivileged,
+            kubeconfig: kubeconfig ? pulumi.output(kubeconfig).apply(JSON.stringify) : undefined,
+            nodePortSupport: args?.nodePortSupport,
+            customNetworkConfig: args?.customNetworkConfig,
+            externalSnat: args?.externalSnat,
+            warmEniTarget: args?.warmEniTarget,
+            warmIpTarget: args?.warmIpTarget,
+            logLevel: args?.logLevel,
+            logFile: args?.logFile,
+            image: args?.image,
+            eniConfigLabelDef: args?.eniConfigLabelDef,
+            pluginLogLevel: args?.pluginLogLevel,
+            pluginLogFile: args?.pluginLogFile,
+            enablePodEni: args?.enablePodEni,
+            cniConfigureRpfilter: args?.cniConfigureRpfilter,
+            cniCustomNetworkCfg: args?.cniCustomNetworkCfg,
+            cniExternalSnat: args?.cniCustomNetworkCfg,
+            securityContextPrivileged: args?.securityContextPrivileged,
         }, opts);
     }
 }


### PR DESCRIPTION
The `VpcCni` resource can be passed back to the TypeScript implementation from other languages as a resource reference, and needs to be instantiated as an instance of `VpcCni` when deserialized so it can be used in a `dependsOn`.

Part of #566