### PR TITLE
Model storageclasses as a map in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Model storageclasses as a map in schema
+  [#596](https://github.com/pulumi/pulumi-eks/pull/596)
 
 ## 0.31.0 (Released June 8, 2021)
 

--- a/dotnet/Cluster.cs
+++ b/dotnet/Cluster.cs
@@ -491,7 +491,7 @@ namespace Pulumi.Eks
         /// Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
         /// </summary>
         [Input("storageClasses")]
-        public InputUnion<string, Inputs.StorageClassArgs>? StorageClasses { get; set; }
+        public InputUnion<string, ImmutableDictionary<string, Inputs.StorageClassArgs>>? StorageClasses { get; set; }
 
         [Input("subnetIds")]
         private InputList<string>? _subnetIds;

--- a/examples/cluster-py/__main__.py
+++ b/examples/cluster-py/__main__.py
@@ -10,19 +10,26 @@ project_name = pulumi.get_project()
 cluster1 = eks.Cluster(f"{project_name}-1")
 
 # Create an EKS cluster with a non-default configuration.
-vpc = Vpc(f"{project_name}-2") # TODO specify tags: { "Name": f"{project_name}-2" }
+# TODO specify tags: { "Name": f"{project_name}-2" }
+vpc = Vpc(f"{project_name}-2")
 
-cluster2 = eks.Cluster(f"{project_name}-2",
-                       vpc_id=vpc.vpc_id,
-                       public_subnet_ids=vpc.public_subnet_ids,
-                       desired_capacity=2,
-                       min_size=2,
-                       max_size=2,
-                       enabled_cluster_log_types=[
-                           "api",
-                           "audit",
-                           "authenticator",
-                       ])
+cluster2 = eks.Cluster('eks-cluster',
+                          vpc_id=vpc.vpc_id,
+                          public_subnet_ids=vpc.public_subnet_ids,
+                          public_access_cidrs=['0.0.0.0/0'],
+                          desired_capacity=2,
+                          min_size=2,
+                          max_size=2,
+                          instance_type='t3.micro',
+                          # set storage class.
+                          storage_classes={"gp2": eks.StorageClassArgs(
+                              type='gp2', allow_volume_expansion=True, default=True, encrypted=True,)},
+                          enabled_cluster_log_types=[
+                              "api",
+                              "audit",
+                              "authenticator",
+                          ],)
+
 
 # Export the clusters' kubeconfig.
 pulumi.export("kubeconfig1", cluster1.kubeconfig)

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -378,7 +378,7 @@ func generateSchema() schema.PackageSpec {
 					"storageClasses": {
 						TypeSpec: schema.TypeSpec{
 							OneOf: []schema.TypeSpec{
-								{Type: "string"},
+								{Type: "string"}, // TODO: EBSVolumeType enum "io1" | "gp2" | "sc1" | "st1"
 								{Type: "object", AdditionalProperties: &schema.TypeSpec{Ref: "#/types/eks:index:StorageClass"}},
 							},
 						},

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -377,10 +377,9 @@ func generateSchema() schema.PackageSpec {
 					},
 					"storageClasses": {
 						TypeSpec: schema.TypeSpec{
-							Type: "string", // TODO: EBSVolumeType enum "io1" | "gp2" | "sc1" | "st1"
 							OneOf: []schema.TypeSpec{
 								{Type: "string"},
-								{Type: "string", Ref: "#/types/eks:index:StorageClass"},
+								{Type: "object", AdditionalProperties: &schema.TypeSpec{Ref: "#/types/eks:index:StorageClass"}},
 							},
 						},
 						Description: "An optional set of StorageClasses to enable for the cluster. If this is a " +
@@ -436,10 +435,9 @@ func generateSchema() schema.PackageSpec {
 					},
 					"fargate": {
 						TypeSpec: schema.TypeSpec{
-							Type: "boolean",
 							OneOf: []schema.TypeSpec{
 								{Type: "boolean"},
-								{Type: "boolean", Ref: "#/types/eks:index:FargateProfile"},
+								{Ref: "#/types/eks:index:FargateProfile"},
 							},
 						},
 						Description: "Add support for launching pods in Fargate. Defaults to launching pods in the " +

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -636,13 +636,11 @@
                     "description": "Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default is `true`."
                 },
                 "fargate": {
-                    "type": "boolean",
                     "oneOf": [
                         {
                             "type": "boolean"
                         },
                         {
-                            "type": "boolean",
                             "$ref": "#/types/eks:index:FargateProfile"
                         }
                     ],
@@ -770,14 +768,15 @@
                     "description": "If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided."
                 },
                 "storageClasses": {
-                    "type": "string",
                     "oneOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "type": "string",
-                            "$ref": "#/types/eks:index:StorageClass"
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/types/eks:index:StorageClass"
+                            }
                         }
                     ],
                     "description": "An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.\n\nNote: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html"

--- a/python/pulumi_eks/cluster.py
+++ b/python/pulumi_eks/cluster.py
@@ -55,7 +55,7 @@ class ClusterArgs:
                  role_mappings: Optional[pulumi.Input[Sequence[pulumi.Input['RoleMappingArgs']]]] = None,
                  service_role: Optional[pulumi.Input['pulumi_aws.iam.Role']] = None,
                  skip_default_node_group: Optional[pulumi.Input[bool]] = None,
-                 storage_classes: Optional[pulumi.Input[Union[str, 'StorageClassArgs']]] = None,
+                 storage_classes: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  use_default_vpc_cni: Optional[pulumi.Input[bool]] = None,
@@ -202,7 +202,7 @@ class ClusterArgs:
         :param pulumi.Input[Sequence[pulumi.Input['RoleMappingArgs']]] role_mappings: Optional mappings from AWS IAM roles to Kubernetes users and groups.
         :param pulumi.Input['pulumi_aws.iam.Role'] service_role: IAM Service Role for EKS to use to manage the cluster.
         :param pulumi.Input[bool] skip_default_node_group: If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
-        :param pulumi.Input[Union[str, 'StorageClassArgs']] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
+        :param pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
                
                Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The set of all subnets, public and private, to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.
@@ -858,7 +858,7 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="storageClasses")
-    def storage_classes(self) -> Optional[pulumi.Input[Union[str, 'StorageClassArgs']]]:
+    def storage_classes(self) -> Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]]]:
         """
         An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
 
@@ -867,7 +867,7 @@ class ClusterArgs:
         return pulumi.get(self, "storage_classes")
 
     @storage_classes.setter
-    def storage_classes(self, value: Optional[pulumi.Input[Union[str, 'StorageClassArgs']]]):
+    def storage_classes(self, value: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]]]):
         pulumi.set(self, "storage_classes", value)
 
     @property
@@ -1005,7 +1005,7 @@ class Cluster(pulumi.ComponentResource):
                  role_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleMappingArgs']]]]] = None,
                  service_role: Optional[pulumi.Input['pulumi_aws.iam.Role']] = None,
                  skip_default_node_group: Optional[pulumi.Input[bool]] = None,
-                 storage_classes: Optional[pulumi.Input[Union[str, pulumi.InputType['StorageClassArgs']]]] = None,
+                 storage_classes: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input[pulumi.InputType['StorageClassArgs']]]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  use_default_vpc_cni: Optional[pulumi.Input[bool]] = None,
@@ -1156,7 +1156,7 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleMappingArgs']]]] role_mappings: Optional mappings from AWS IAM roles to Kubernetes users and groups.
         :param pulumi.Input['pulumi_aws.iam.Role'] service_role: IAM Service Role for EKS to use to manage the cluster.
         :param pulumi.Input[bool] skip_default_node_group: If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
-        :param pulumi.Input[Union[str, pulumi.InputType['StorageClassArgs']]] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
+        :param pulumi.Input[Union[str, Mapping[str, pulumi.Input[pulumi.InputType['StorageClassArgs']]]]] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
                
                Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The set of all subnets, public and private, to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.
@@ -1236,7 +1236,7 @@ class Cluster(pulumi.ComponentResource):
                  role_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleMappingArgs']]]]] = None,
                  service_role: Optional[pulumi.Input['pulumi_aws.iam.Role']] = None,
                  skip_default_node_group: Optional[pulumi.Input[bool]] = None,
-                 storage_classes: Optional[pulumi.Input[Union[str, pulumi.InputType['StorageClassArgs']]]] = None,
+                 storage_classes: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input[pulumi.InputType['StorageClassArgs']]]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  use_default_vpc_cni: Optional[pulumi.Input[bool]] = None,

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -2009,6 +2009,31 @@ func (i StorageClassArgs) ToStorageClassOutputWithContext(ctx context.Context) S
 	return pulumi.ToOutputWithContext(ctx, i).(StorageClassOutput)
 }
 
+// StorageClassMapInput is an input type that accepts StorageClassMap and StorageClassMapOutput values.
+// You can construct a concrete instance of `StorageClassMapInput` via:
+//
+//          StorageClassMap{ "key": StorageClassArgs{...} }
+type StorageClassMapInput interface {
+	pulumi.Input
+
+	ToStorageClassMapOutput() StorageClassMapOutput
+	ToStorageClassMapOutputWithContext(context.Context) StorageClassMapOutput
+}
+
+type StorageClassMap map[string]StorageClassInput
+
+func (StorageClassMap) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]StorageClass)(nil)).Elem()
+}
+
+func (i StorageClassMap) ToStorageClassMapOutput() StorageClassMapOutput {
+	return i.ToStorageClassMapOutputWithContext(context.Background())
+}
+
+func (i StorageClassMap) ToStorageClassMapOutputWithContext(ctx context.Context) StorageClassMapOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(StorageClassMapOutput)
+}
+
 // StorageClass describes the inputs to a single Kubernetes StorageClass provisioned by AWS. Any number of storage classes can be added to a cluster at creation time. One of these storage classes may be configured the default storage class for the cluster.
 type StorageClassOutput struct{ *pulumi.OutputState }
 
@@ -2081,6 +2106,26 @@ func (o StorageClassOutput) VolumeBindingMode() pulumi.StringPtrOutput {
 // The AWS zone or zones for the EBS volume. If zones is not specified, volumes are generally round-robin-ed across all active zones where Kubernetes cluster has a node. zone and zones parameters must not be used at the same time.
 func (o StorageClassOutput) Zones() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v StorageClass) []string { return v.Zones }).(pulumi.StringArrayOutput)
+}
+
+type StorageClassMapOutput struct{ *pulumi.OutputState }
+
+func (StorageClassMapOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]StorageClass)(nil)).Elem()
+}
+
+func (o StorageClassMapOutput) ToStorageClassMapOutput() StorageClassMapOutput {
+	return o
+}
+
+func (o StorageClassMapOutput) ToStorageClassMapOutputWithContext(ctx context.Context) StorageClassMapOutput {
+	return o
+}
+
+func (o StorageClassMapOutput) MapIndex(k pulumi.StringInput) StorageClassOutput {
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) StorageClass {
+		return vs[0].(map[string]StorageClass)[vs[1].(string)]
+	}).(StorageClassOutput)
 }
 
 // Represents a Kubernetes `taint` to apply to all Nodes in a NodeGroup. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
@@ -2840,6 +2885,7 @@ func init() {
 	pulumi.RegisterOutputType(RoleMappingOutput{})
 	pulumi.RegisterOutputType(RoleMappingArrayOutput{})
 	pulumi.RegisterOutputType(StorageClassOutput{})
+	pulumi.RegisterOutputType(StorageClassMapOutput{})
 	pulumi.RegisterOutputType(TaintOutput{})
 	pulumi.RegisterOutputType(TaintMapOutput{})
 	pulumi.RegisterOutputType(UserMappingOutput{})


### PR DESCRIPTION
Fix #523 

eks component resource seems to expect the storageclasses specification to be a map keyed by a string. Updated the schema to reflect this.
