### PR TITLE
NodeGroups accept strings as InstanceTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 - Add support for setting `WARM_PREFIX_TARGET` and `ENABLE_PREFIX_DELEGATION`
   [#618](https://github.com/pulumi/pulumi-eks/pull/618)
+- NodeGroups accept strings as InstanceTypes
+  [#639](https://github.com/pulumi/pulumi-eks/pull/639)
 ## 0.35.0 (Released November 10, 2021)
 - Add support for setting the init container image
   [#631](https://github.com/pulumi/pulumi-eks/pull/631)

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -56,7 +56,7 @@ export interface NodeGroupBaseOptions {
     /**
      * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
      */
-    instanceType?: pulumi.Input<aws.ec2.InstanceType>;
+    instanceType?: pulumi.Input<string | aws.ec2.InstanceType>;
 
     /**
      * Bidding price for spot instance. If set, only spot instances will be added as worker node


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
The instance type parameter to NodeGroups should accept strings, in addition to the InstanceType enum, because the enum could be out of date. This is similar to what the [EC2 object itself accepts in Pulumi](https://github.com/pulumi/pulumi-aws/blob/8cdca73c8c37d91ad9bcdc2e6b616926df730ea2/sdk/nodejs/ec2/instance.ts#L709).