### PR TITLE
nodejs: support all EBS EC2 LaunchConfiguration params for EKS cluster node root volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Add support for all EC2 LaunchConfiguration EBS parameters related to cluster root node volumes
+  [#597](https://github.com/pulumi/pulumi-eks/issues/597)
 - Add support for setting `WARM_PREFIX_TARGET` and `ENABLE_PREFIX_DELEGATION`
   [#618](https://github.com/pulumi/pulumi-eks/pull/618)
 - NodeGroups accept strings as InstanceTypes

--- a/dotnet/Cluster.cs
+++ b/dotnet/Cluster.cs
@@ -337,10 +337,40 @@ namespace Pulumi.Eks
         public Input<string>? NodePublicKey { get; set; }
 
         /// <summary>
+        /// Whether to delete a cluster node's root volume on termination. Defaults to true.
+        /// </summary>
+        [Input("nodeRootVolumeDeleteOnTermination")]
+        public Input<bool>? NodeRootVolumeDeleteOnTermination { get; set; }
+
+        /// <summary>
+        /// Whether to encrypt a cluster node's root volume. Defaults to false.
+        /// </summary>
+        [Input("nodeRootVolumeEncrypted")]
+        public Input<bool>? NodeRootVolumeEncrypted { get; set; }
+
+        /// <summary>
+        /// Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.
+        /// </summary>
+        [Input("nodeRootVolumeIops")]
+        public Input<int>? NodeRootVolumeIops { get; set; }
+
+        /// <summary>
         /// The size in GiB of a cluster node's root volume. Defaults to 20.
         /// </summary>
         [Input("nodeRootVolumeSize")]
         public Input<int>? NodeRootVolumeSize { get; set; }
+
+        /// <summary>
+        /// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.
+        /// </summary>
+        [Input("nodeRootVolumeThroughput")]
+        public Input<int>? NodeRootVolumeThroughput { get; set; }
+
+        /// <summary>
+        /// Configured EBS type for a cluster node's root volume. Default is gp2.
+        /// </summary>
+        [Input("nodeRootVolumeType")]
+        public Input<string>? NodeRootVolumeType { get; set; }
 
         [Input("nodeSecurityGroupTags")]
         private InputMap<string>? _nodeSecurityGroupTags;
@@ -576,6 +606,10 @@ namespace Pulumi.Eks
 
         public ClusterArgs()
         {
+            NodeRootVolumeDeleteOnTermination = true;
+            NodeRootVolumeEncrypted = false;
+            NodeRootVolumeSize = 20;
+            NodeRootVolumeType = "gp2";
         }
     }
 

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -99,6 +99,8 @@ export interface NodeGroupBaseOptions {
 
     /**
      * Encrypt the root block device of the nodes in the node group.
+     * @deprecated This option has been deprecated for parameter naming coherence.
+     * Use the nodeRootVolumeEncrypted option instead.
      */
     encryptRootBlockDevice?: pulumi.Input<boolean>;
 
@@ -118,6 +120,33 @@ export interface NodeGroupBaseOptions {
      * The size in GiB of a cluster node's root volume. Defaults to 20.
      */
     nodeRootVolumeSize?: pulumi.Input<number>;
+
+    /**
+     * Whether to delete a cluster node's root volume on termination. Defaults to true.
+     */
+    nodeRootVolumeDeleteOnTermination?: pulumi.Input<boolean>;
+
+    /**
+     * Whether to encrypt a cluster node's root volume. Defaults to false.
+     */
+    nodeRootVolumeEncrypted?: pulumi.Input<boolean>;
+
+    /**
+     * Provisioned IOPS for a cluster node's root volume.
+     * Only valid for io1 volumes.
+     */
+    nodeRootVolumeIops?: pulumi.Input<number> | undefined;
+
+    /**
+     * Provisioned throughput performance in integer MiB/s for a cluster node's root volume.
+     * Only valid for gp3 volumes.
+     */
+    nodeRootVolumeThroughput?: pulumi.Input<number> | undefined;
+
+    /**
+     * Configured EBS type for a cluster node's root volume. Default is gp2.
+     */
+    nodeRootVolumeType?: "standard" | "gp2" | "gp3" | "st1" | "sc1" | "io1";
 
     /**
      * Extra code to run on node startup. This code will run after the AWS EKS bootstrapping code and before the node
@@ -485,6 +514,28 @@ ${customUserData}
         nodeAssociatePublicIpAddress = args.nodeAssociatePublicIpAddress;
     }
 
+    const numeric = new RegExp("^\d+$");
+
+    if (args.nodeRootVolumeIops && args.nodeRootVolumeType !== "io1") {
+        throw new Error("Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).");
+    }
+
+    if (args.nodeRootVolumeType === "io1" && args.nodeRootVolumeIops) {
+        if (!numeric.test(args.nodeRootVolumeIops?.toString())) {
+            throw new Error("Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.");
+        }
+    }
+
+    if (args.nodeRootVolumeThroughput && args.nodeRootVolumeType !== "gp3") {
+        throw new Error("Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).");
+    }
+
+    if (args.nodeRootVolumeType === "gp3" && args.nodeRootVolumeThroughput) {
+        if (!numeric.test(args.nodeRootVolumeThroughput?.toString())) {
+            throw new Error("Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.");
+        }
+    }
+
     const nodeLaunchConfiguration = new aws.ec2.LaunchConfiguration(`${name}-nodeLaunchConfiguration`, {
         associatePublicIpAddress: nodeAssociatePublicIpAddress,
         imageId: amiId,
@@ -494,10 +545,12 @@ ${customUserData}
         securityGroups: [nodeSecurityGroupId, ...extraNodeSecurityGroupIds],
         spotPrice: args.spotPrice,
         rootBlockDevice: {
-            encrypted: args.encryptRootBlockDevice || args.encryptRootBockDevice,
-            volumeSize: args.nodeRootVolumeSize || 20, // GiB
-            volumeType: "gp2", // default is "standard"
-            deleteOnTermination: true,
+            encrypted: ((args.encryptRootBlockDevice ?? args.encryptRootBockDevice) ?? args.nodeRootVolumeEncrypted) ?? false,
+            volumeSize: args.nodeRootVolumeSize ?? 20, // GiB
+            volumeType: args.nodeRootVolumeType ?? "gp2",
+            iops: args.nodeRootVolumeIops,
+            throughput: args.nodeRootVolumeThroughput,
+            deleteOnTermination: args.nodeRootVolumeDeleteOnTermination ?? true,
         },
         userData: args.nodeUserDataOverride || userdata,
     }, { parent, provider });

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -396,6 +396,30 @@ func generateSchema() schema.PackageSpec {
 					"nodeRootVolumeSize": {
 						TypeSpec:    schema.TypeSpec{Type: "integer"},
 						Description: "The size in GiB of a cluster node's root volume. Defaults to 20.",
+						Default:     20,
+					},
+					"nodeRootVolumeDeleteOnTermination": {
+						TypeSpec:    schema.TypeSpec{Type: "boolean"},
+						Description: "Whether to delete a cluster node's root volume on termination. Defaults to true.",
+						Default:     true,
+					},
+					"nodeRootVolumeEncrypted": {
+						TypeSpec:    schema.TypeSpec{Type: "boolean"},
+						Description: "Whether to encrypt a cluster node's root volume. Defaults to false.",
+						Default:     false,
+					},
+					"nodeRootVolumeIops": {
+						TypeSpec:    schema.TypeSpec{Type: "integer"},
+						Description: "Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.",
+					},
+					"nodeRootVolumeThroughput": {
+						TypeSpec:    schema.TypeSpec{Type: "integer"},
+						Description: "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.",
+					},
+					"nodeRootVolumeType": {
+						TypeSpec:    schema.TypeSpec{Type: "string"},
+						Description: "Configured EBS type for a cluster node's root volume. Default is gp2.",
+						Default:     "gp2",
 					},
 					"nodeUserData": {
 						TypeSpec: schema.TypeSpec{Type: "string"},
@@ -1498,7 +1522,7 @@ func vpcCniProperties(kubeconfig bool) map[string]schema.PropertySpec {
 				"Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md",
 		},
 		"enablePrefixDelegation": {
-			TypeSpec: schema.TypeSpec{Type: "boolean"},
+			TypeSpec:    schema.TypeSpec{Type: "boolean"},
 			Description: "IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.",
 		},
 		"logLevel": {

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -717,9 +717,33 @@
                     "type": "string",
                     "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
                 },
+                "nodeRootVolumeDeleteOnTermination": {
+                    "type": "boolean",
+                    "description": "Whether to delete a cluster node's root volume on termination. Defaults to true.",
+                    "default": true
+                },
+                "nodeRootVolumeEncrypted": {
+                    "type": "boolean",
+                    "description": "Whether to encrypt a cluster node's root volume. Defaults to false.",
+                    "default": false
+                },
+                "nodeRootVolumeIops": {
+                    "type": "integer",
+                    "description": "Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes."
+                },
                 "nodeRootVolumeSize": {
                     "type": "integer",
-                    "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
+                    "description": "The size in GiB of a cluster node's root volume. Defaults to 20.",
+                    "default": 20
+                },
+                "nodeRootVolumeThroughput": {
+                    "type": "integer",
+                    "description": "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes."
+                },
+                "nodeRootVolumeType": {
+                    "type": "string",
+                    "description": "Configured EBS type for a cluster node's root volume. Default is gp2.",
+                    "default": "gp2"
                 },
                 "nodeSecurityGroupTags": {
                     "type": "object",

--- a/python/pulumi_eks/cluster.py
+++ b/python/pulumi_eks/cluster.py
@@ -43,7 +43,12 @@ class ClusterArgs:
                  node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
                  node_group_options: Optional[pulumi.Input['ClusterNodeGroupOptionsArgs']] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -136,7 +141,12 @@ class ClusterArgs:
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether to delete a cluster node's root volume on termination. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is gp2.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] node_security_group_tags: The tags to apply to the default `nodeSecurityGroup` created by the cluster.
                
                Note: The `nodeSecurityGroupTags` option and the node group option `nodeSecurityGroup` are mutually exclusive.
@@ -271,8 +281,26 @@ class ClusterArgs:
             pulumi.set(__self__, "node_group_options", node_group_options)
         if node_public_key is not None:
             pulumi.set(__self__, "node_public_key", node_public_key)
+        if node_root_volume_delete_on_termination is None:
+            node_root_volume_delete_on_termination = True
+        if node_root_volume_delete_on_termination is not None:
+            pulumi.set(__self__, "node_root_volume_delete_on_termination", node_root_volume_delete_on_termination)
+        if node_root_volume_encrypted is None:
+            node_root_volume_encrypted = False
+        if node_root_volume_encrypted is not None:
+            pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
+        if node_root_volume_iops is not None:
+            pulumi.set(__self__, "node_root_volume_iops", node_root_volume_iops)
+        if node_root_volume_size is None:
+            node_root_volume_size = 20
         if node_root_volume_size is not None:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
+        if node_root_volume_throughput is not None:
+            pulumi.set(__self__, "node_root_volume_throughput", node_root_volume_throughput)
+        if node_root_volume_type is None:
+            node_root_volume_type = 'gp2'
+        if node_root_volume_type is not None:
+            pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group_tags is not None:
             pulumi.set(__self__, "node_security_group_tags", node_security_group_tags)
         if node_subnet_ids is not None:
@@ -659,6 +687,42 @@ class ClusterArgs:
         pulumi.set(self, "node_public_key", value)
 
     @property
+    @pulumi.getter(name="nodeRootVolumeDeleteOnTermination")
+    def node_root_volume_delete_on_termination(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether to delete a cluster node's root volume on termination. Defaults to true.
+        """
+        return pulumi.get(self, "node_root_volume_delete_on_termination")
+
+    @node_root_volume_delete_on_termination.setter
+    def node_root_volume_delete_on_termination(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_delete_on_termination", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeEncrypted")
+    def node_root_volume_encrypted(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether to encrypt a cluster node's root volume. Defaults to false.
+        """
+        return pulumi.get(self, "node_root_volume_encrypted")
+
+    @node_root_volume_encrypted.setter
+    def node_root_volume_encrypted(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_encrypted", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeIops")
+    def node_root_volume_iops(self) -> Optional[pulumi.Input[int]]:
+        """
+        Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.
+        """
+        return pulumi.get(self, "node_root_volume_iops")
+
+    @node_root_volume_iops.setter
+    def node_root_volume_iops(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_iops", value)
+
+    @property
     @pulumi.getter(name="nodeRootVolumeSize")
     def node_root_volume_size(self) -> Optional[pulumi.Input[int]]:
         """
@@ -669,6 +733,30 @@ class ClusterArgs:
     @node_root_volume_size.setter
     def node_root_volume_size(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "node_root_volume_size", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeThroughput")
+    def node_root_volume_throughput(self) -> Optional[pulumi.Input[int]]:
+        """
+        Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.
+        """
+        return pulumi.get(self, "node_root_volume_throughput")
+
+    @node_root_volume_throughput.setter
+    def node_root_volume_throughput(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_throughput", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeType")
+    def node_root_volume_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        Configured EBS type for a cluster node's root volume. Default is gp2.
+        """
+        return pulumi.get(self, "node_root_volume_type")
+
+    @node_root_volume_type.setter
+    def node_root_volume_type(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_root_volume_type", value)
 
     @property
     @pulumi.getter(name="nodeSecurityGroupTags")
@@ -993,7 +1081,12 @@ class Cluster(pulumi.ComponentResource):
                  node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
                  node_group_options: Optional[pulumi.Input[pulumi.InputType['ClusterNodeGroupOptionsArgs']]] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -1090,7 +1183,12 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether to delete a cluster node's root volume on termination. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is gp2.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] node_security_group_tags: The tags to apply to the default `nodeSecurityGroup` created by the cluster.
                
                Note: The `nodeSecurityGroupTags` option and the node group option `nodeSecurityGroup` are mutually exclusive.
@@ -1224,7 +1322,12 @@ class Cluster(pulumi.ComponentResource):
                  node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
                  node_group_options: Optional[pulumi.Input[pulumi.InputType['ClusterNodeGroupOptionsArgs']]] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -1283,7 +1386,20 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["node_associate_public_ip_address"] = node_associate_public_ip_address
             __props__.__dict__["node_group_options"] = node_group_options
             __props__.__dict__["node_public_key"] = node_public_key
+            if node_root_volume_delete_on_termination is None:
+                node_root_volume_delete_on_termination = True
+            __props__.__dict__["node_root_volume_delete_on_termination"] = node_root_volume_delete_on_termination
+            if node_root_volume_encrypted is None:
+                node_root_volume_encrypted = False
+            __props__.__dict__["node_root_volume_encrypted"] = node_root_volume_encrypted
+            __props__.__dict__["node_root_volume_iops"] = node_root_volume_iops
+            if node_root_volume_size is None:
+                node_root_volume_size = 20
             __props__.__dict__["node_root_volume_size"] = node_root_volume_size
+            __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
+            if node_root_volume_type is None:
+                node_root_volume_type = 'gp2'
+            __props__.__dict__["node_root_volume_type"] = node_root_volume_type
             __props__.__dict__["node_security_group_tags"] = node_security_group_tags
             __props__.__dict__["node_subnet_ids"] = node_subnet_ids
             __props__.__dict__["node_user_data"] = node_user_data

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -48,6 +48,19 @@ func NewCluster(ctx *pulumi.Context,
 		args = &ClusterArgs{}
 	}
 
+	if args.NodeRootVolumeDeleteOnTermination == nil {
+		args.NodeRootVolumeDeleteOnTermination = pulumi.BoolPtr(true)
+	}
+	if args.NodeRootVolumeEncrypted == nil {
+		args.NodeRootVolumeEncrypted = pulumi.BoolPtr(false)
+	}
+	if args.NodeRootVolumeSize == nil {
+		args.NodeRootVolumeSize = pulumi.IntPtr(20)
+	}
+	if args.NodeRootVolumeType == nil {
+		args.NodeRootVolumeType = pulumi.StringPtr("gp2")
+	}
+
 	var resource Cluster
 	err := ctx.RegisterRemoteComponentResource("eks:index:Cluster", name, args, &resource, opts...)
 	if err != nil {
@@ -153,8 +166,18 @@ type clusterArgs struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey *string `pulumi:"nodePublicKey"`
+	// Whether to delete a cluster node's root volume on termination. Defaults to true.
+	NodeRootVolumeDeleteOnTermination *bool `pulumi:"nodeRootVolumeDeleteOnTermination"`
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted *bool `pulumi:"nodeRootVolumeEncrypted"`
+	// Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.
+	NodeRootVolumeIops *int `pulumi:"nodeRootVolumeIops"`
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize *int `pulumi:"nodeRootVolumeSize"`
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.
+	NodeRootVolumeThroughput *int `pulumi:"nodeRootVolumeThroughput"`
+	// Configured EBS type for a cluster node's root volume. Default is gp2.
+	NodeRootVolumeType *string `pulumi:"nodeRootVolumeType"`
 	// The tags to apply to the default `nodeSecurityGroup` created by the cluster.
 	//
 	// Note: The `nodeSecurityGroupTags` option and the node group option `nodeSecurityGroup` are mutually exclusive.
@@ -357,8 +380,18 @@ type ClusterArgs struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey pulumi.StringPtrInput
+	// Whether to delete a cluster node's root volume on termination. Defaults to true.
+	NodeRootVolumeDeleteOnTermination pulumi.BoolPtrInput
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted pulumi.BoolPtrInput
+	// Provisioned IOPS for a cluster node's root volume. Only valid for io1 volumes.
+	NodeRootVolumeIops pulumi.IntPtrInput
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize pulumi.IntPtrInput
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. Only valid for gp3 volumes.
+	NodeRootVolumeThroughput pulumi.IntPtrInput
+	// Configured EBS type for a cluster node's root volume. Default is gp2.
+	NodeRootVolumeType pulumi.StringPtrInput
 	// The tags to apply to the default `nodeSecurityGroup` created by the cluster.
 	//
 	// Note: The `nodeSecurityGroupTags` option and the node group option `nodeSecurityGroup` are mutually exclusive.

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -60,7 +60,6 @@ func NewCluster(ctx *pulumi.Context,
 	if args.NodeRootVolumeType == nil {
 		args.NodeRootVolumeType = pulumi.StringPtr("gp2")
 	}
-
 	var resource Cluster
 	err := ctx.RegisterRemoteComponentResource("eks:index:Cluster", name, args, &resource, opts...)
 	if err != nil {


### PR DESCRIPTION
### Proposed changes

Modify the NodeJS SDK to support all EC2 LaunchConfiguration parameters for EKS cluster node root volumes. This will enable users to configure any currently supported EBS volume type to power their EKS cluster nodes.

### Related issues (optional)

https://github.com/pulumi/pulumi-eks/issues/597