### PR TITLE
Widen type for `instanceType` to allow `string`

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -960,7 +960,7 @@ export interface ClusterOptions {
     /**
      * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
      */
-    instanceType?: pulumi.Input<aws.ec2.InstanceType>;
+    instanceType?: pulumi.Input<aws.ec2.InstanceType | string>;
 
     /**
      * This enables the simple case of only registering a *single* IAM


### PR DESCRIPTION
Allow `string` in addition to the `InstanceType` enum for `instanceType`

Related: https://pulumi-community.slack.com/archives/CRH5ENVDX/p1643301919171600