### PR TITLE
fix nodegroup minsize and desiredsize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 - Fix `ENABLE_PREFIX_DELEGATION` not working
   [#646](https://github.com/pulumi/pulumi-eks/pull/646)
+- Fix node group's `minSize` and `desiredSize` cannot be 0
+  [#645](https://github.com/pulumi/pulumi-eks/issues/645)
 
 ## 0.36.0 (Released December 3, 2021)
 - Add support for all EC2 LaunchConfiguration EBS parameters related to cluster root node volumes

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -904,8 +904,8 @@ export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptio
         scalingConfig: pulumi.all([
             args.scalingConfig,
         ]).apply(([config]) => {
-            const desiredSize = config && config.desiredSize !== undefined ? config.desiredSize : 2;
-            const minSize = config && config.minSize !== undefined ? config.minSzie : 1;
+            const desiredSize = config?.desiredSize ?? 2;
+            const minSize = config?.minSize ?? 1;
             const maxSize = config && config.maxSize || 2;
             return {
                 desiredSize: desiredSize,

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -904,8 +904,8 @@ export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptio
         scalingConfig: pulumi.all([
             args.scalingConfig,
         ]).apply(([config]) => {
-            const desiredSize = config && config.desiredSize || 2;
-            const minSize = config && config.minSize || 1;
+            const desiredSize = config && config.desiredSize !== undefined ? config.desiredSize : 2;
+            const minSize = config && config.minSize !== undefined ? config.minSzie : 1;
             const maxSize = config && config.maxSize || 2;
             return {
                 desiredSize: desiredSize,

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -906,7 +906,7 @@ export function createManagedNodeGroup(name: string, args: ManagedNodeGroupOptio
         ]).apply(([config]) => {
             const desiredSize = config?.desiredSize ?? 2;
             const minSize = config?.minSize ?? 1;
-            const maxSize = config && config.maxSize || 2;
+            const maxSize = config?.maxSize ?? 2;
             return {
                 desiredSize: desiredSize,
                 minSize: minSize,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

fixes bug #645. `minSize` and `desiredSize` of 0 not correctly supported.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
