### PR TITLE
Add AWS CLI prerequisite to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This includes:
 
 1. [Install Pulumi](https://www.pulumi.com/docs/reference/install).
 1. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
+1. [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 ## Installing
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Update the README to list installation of the AWS CLI as a prerequisite and link to installation documentation.


### Related issues (optional)

Someone in [slack](https://pulumi-community.slack.com/archives/C019YSXN04B/p1647380911363889) received the following error message:
`Unhandled exception: Error: Could not find aws CLI for EKS. See https://github.com/pulumi/pulumi-eks for installation instructions`

Upon checking the repo, there were no instructions for installing the AWS CLI.

The source code that generated the error message is here:
https://github.com/pulumi/pulumi-eks/blob/d599a1b1f3650dba4c3dc4f560080e95ce6fb5b1/nodejs/eks/cluster.ts#L347-L351

As the user correctly noted, there are no instructions in the README for installing the AWS CLI.