### PR TITLE
Add enableIpv6 option to clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+- Add enableIpv6 option to clusters
+  [#695](https://github.com/pulumi/pulumi-eks/pull/695)
+  This change upgrades amazon-vpc-cni-k8s to v1.11.
 
 ## 0.39.0 (Released May 9, 2022)
 - Add support for Pulumi AWS 5.x

--- a/dotnet/Inputs/VpcCniOptionsArgs.cs
+++ b/dotnet/Inputs/VpcCniOptionsArgs.cs
@@ -48,6 +48,12 @@ namespace Pulumi.Eks.Inputs
         public Input<bool>? DisableTcpEarlyDemux { get; set; }
 
         /// <summary>
+        /// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+        /// </summary>
+        [Input("enableIpv6")]
+        public Input<bool>? EnableIpv6 { get; set; }
+
+        /// <summary>
         /// Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
         /// </summary>
         [Input("enablePodEni")]

--- a/dotnet/VpcCni.cs
+++ b/dotnet/VpcCni.cs
@@ -92,6 +92,12 @@ namespace Pulumi.Eks
         public Input<bool>? DisableTcpEarlyDemux { get; set; }
 
         /// <summary>
+        /// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+        /// </summary>
+        [Input("enableIpv6")]
+        public Input<bool>? EnableIpv6 { get; set; }
+
+        /// <summary>
         /// Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
         /// </summary>
         [Input("enablePodEni")]

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -25,8 +25,6 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
         "authenticator",
     ],
     vpcCniOptions: {
-        image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0",
-        initImage: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0",
         disableTcpEarlyDemux: true,
     },
 });

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -45,12 +45,9 @@ func TestAccCluster(t *testing.T) {
 				)
 
 				assert.NoError(t, utils.ValidateDaemonSet(t, info.Outputs["kubeconfig2"], "kube-system", "aws-node", func(ds *appsv1.DaemonSet) {
-					for _, c := range ds.Spec.Template.Spec.Containers {
-						assert.Equal(t, "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0", c.Image)
-					}
-
 					for _, ic := range ds.Spec.Template.Spec.InitContainers {
-						assert.Equal(t, "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0", ic.Image)
+						assert.Equal(t, "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.0",
+							ic.Image)
 						var tcpEarly bool
 						for _, env := range ic.Env {
 							if env.Name == "DISABLE_TCP_EARLY_DEMUX" {
@@ -59,6 +56,9 @@ func TestAccCluster(t *testing.T) {
 							}
 						}
 						assert.True(t, tcpEarly)
+					}
+					for _, c := range ds.Spec.Template.Spec.Containers {
+						assert.Equal(t, "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.0", c.Image)
 					}
 				}))
 			},

--- a/nodejs/eks/cmd/provider/cni.ts
+++ b/nodejs/eks/cmd/provider/cni.ts
@@ -78,8 +78,8 @@ function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
         env.push({name: "WARM_PREFIX_TARGET", value: args.warmPrefixTarget.toString()});
     }
     if (args.enableIpv6) {
-        env.push({name: "ENABLE_IPv6", value: "true"});
-        initEnv.push({name: "ENABLE_IPv6", value: "true"});
+        env.push({name: "ENABLE_IPv6", value: args.enableIpv6 ? "true" : "false"});
+        initEnv.push({name: "ENABLE_IPv6", value: args.enableIpv6 ? "true" : "false"});
     } else {
         env.push({name: "ENABLE_IPv6", value: "false"});
         initEnv.push({name: "ENABLE_IPv6", value: "false"});

--- a/nodejs/eks/cmd/provider/cni.ts
+++ b/nodejs/eks/cmd/provider/cni.ts
@@ -31,6 +31,7 @@ interface VpcCniInputs {
     warmIpTarget?: number;
     warmPrefixTarget?: number;
     enablePrefixDelegation?: boolean;
+    enableIpv6?: boolean;
     logLevel?: string;
     logFile?: string;
     image?: string;
@@ -75,6 +76,13 @@ function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
     }
     if (args.warmPrefixTarget) {
         env.push({name: "WARM_PREFIX_TARGET", value: args.warmPrefixTarget.toString()});
+    }
+    if (args.enableIpv6) {
+        env.push({name: "ENABLE_IPv6", value: "true"});
+        initEnv.push({name: "ENABLE_IPv6", value: "true"});
+    } else {
+        env.push({name: "ENABLE_IPv6", value: "false"});
+        initEnv.push({name: "ENABLE_IPv6", value: "false"});
     }
     if (args.enablePrefixDelegation) {
         env.push({name: "ENABLE_PREFIX_DELEGATION", value: args.enablePrefixDelegation ? "true" : "false"});

--- a/nodejs/eks/cmd/provider/cni.ts
+++ b/nodejs/eks/cmd/provider/cni.ts
@@ -83,6 +83,8 @@ function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
     } else {
         env.push({name: "ENABLE_IPv6", value: "false"});
         initEnv.push({name: "ENABLE_IPv6", value: "false"});
+        env.push({name: "ENABLE_IPv4", value: "true"});
+        initEnv.push({name: "ENABLE_IPv4", value: "true"});
     }
     if (args.enablePrefixDelegation) {
         env.push({name: "ENABLE_PREFIX_DELEGATION", value: args.enablePrefixDelegation ? "true" : "false"});

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -70,6 +70,14 @@ export interface VpcCniOptions {
      enablePrefixDelegation?: pulumi.Input<boolean>;
 
     /**
+     * VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode.
+     * Note that IPv6 is only supported in Prefix Delegation mode so enablePrefixDelegation must also be set.
+     *
+     * Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md#enable_ipv6-v1100
+     */
+    enableIpv6?: pulumi.Input<boolean>;
+
+    /**
      * Specifies the log level used for logs.
      *
      * Defaults to "DEBUG".
@@ -221,6 +229,7 @@ export class VpcCni extends pulumi.CustomResource {
             warmEniTarget: args?.warmEniTarget,
             warmIpTarget: args?.warmIpTarget,
             enablePrefixDelegation: args?.enablePrefixDelegation,
+            enableIpv6: args?.enableIpv6,
             warmPrefixTarget: args?.warmPrefixTarget,
             logLevel: args?.logLevel,
             logFile: args?.logFile,

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.10.3"
+    app.kubernetes.io/version: "v1.11.0"
 spec:
   updateStrategy:
     rollingUpdate:

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -60,72 +60,85 @@ metadata:
   name: aws-node
   namespace: kube-system
   labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
+    app.kubernetes.io/version: "v1.10.3"
 spec:
   updateStrategy:
-    type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: "10%"
+      maxUnavailable: 10%
+    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: aws-node
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: aws-node
+        app.kubernetes.io/instance: aws-vpc-cni
         k8s-app: aws-node
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: beta.kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                  - key: eks.amazonaws.com/compute-type
-                    operator: NotIn
-                    values:
-                      - fargate
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                  - key: eks.amazonaws.com/compute-type
-                    operator: NotIn
-                    values:
-                      - fargate
+      priorityClassName: "system-node-critical"
+      serviceAccountName: aws-node
+      hostNetwork: true
+      initContainers:
+        - name: aws-vpc-cni-init
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.3"
+          env: []
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      securityContext:
+        {}
       containers:
-        - env:
+        - name: aws-node
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.3"
+          ports:
+            - containerPort: 61678
+              name: metrics
+          livenessProbe:
+            exec:
+              command:
+                - /app/grpc-health-probe
+                - -addr=:50051
+                - -connect-timeout=5s
+                - -rpc-timeout=5s
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /app/grpc-health-probe
+                - -addr=:50051
+                - -connect-timeout=5s
+                - -rpc-timeout=5s
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+          env:
+            - name: ADDITIONAL_ENI_TAGS
+              value: "{}"
+            - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+              value: "false"
+            - name: AWS_VPC_K8S_CNI_RANDOMIZESNAT
+              value: "prng"
+            - name: DISABLE_INTROSPECTION
+              value: "false"
+            - name: DISABLE_METRICS
+              value: "false"
+            - name: DISABLE_NETWORK_RESOURCE_PROVISIONING
+              value: "false"
+            - name: WARM_PREFIX_TARGET
+              value: "1"
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.7.5
-          imagePullPolicy: Always
-          livenessProbe:
-            exec:
-              command: ["/app/grpc-health-probe", "-addr=:50051"]
-            initialDelaySeconds: 60
-          name: aws-node
-          ports:
-            - containerPort: 61678
-              name: metrics
-          readinessProbe:
-            exec:
-              command: ["/app/grpc-health-probe", "-addr=:50051"]
-            initialDelaySeconds: 1
           resources:
             requests:
               cpu: 10m
@@ -140,50 +153,51 @@ spec:
               name: cni-net-dir
             - mountPath: /host/var/log/aws-routed-eni
               name: log-dir
-            - mountPath: /var/run/aws-node
-              name: run-dir
             - mountPath: /var/run/dockershim.sock
               name: dockershim
+            - mountPath: /var/run/aws-node
+              name: run-dir
             - mountPath: /run/xtables.lock
               name: xtables-lock
-      hostNetwork: true
-      initContainers:
-        - env: []
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.5
-          imagePullPolicy: Always
-          name: aws-vpc-cni-init
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-      priorityClassName: system-node-critical
-      serviceAccountName: aws-node
-      terminationGracePeriodSeconds: 10
-      tolerations:
-        - operator: Exists
       volumes:
-        - hostPath:
+        - name: cni-bin-dir
+          hostPath:
             path: /opt/cni/bin
-          name: cni-bin-dir
-        - hostPath:
+        - name: cni-net-dir
+          hostPath:
             path: /etc/cni/net.d
-          name: cni-net-dir
-        - hostPath:
+        - name: dockershim
+          hostPath:
             path: /var/run/dockershim.sock
-          name: dockershim
-        - hostPath:
-            path: /run/xtables.lock
-          name: xtables-lock
-        - hostPath:
+        - name: log-dir
+          hostPath:
             path: /var/log/aws-routed-eni
             type: DirectoryOrCreate
-          name: log-dir
-        - hostPath:
+        - name: run-dir
+          hostPath:
             path: /var/run/aws-node
             type: DirectoryOrCreate
-          name: run-dir
-
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/nodejs/eks/cni/aws-k8s-cni.yaml
+++ b/nodejs/eks/cni/aws-k8s-cni.yaml
@@ -84,7 +84,7 @@ spec:
       hostNetwork: true
       initContainers:
         - name: aws-vpc-cni-init
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.3"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.0"
           env: []
           securityContext:
             privileged: true
@@ -98,7 +98,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.3"
+          image: "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.0"
           ports:
             - containerPort: 61678
               name: metrics

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1525,6 +1525,10 @@ func vpcCniProperties(kubeconfig bool) map[string]schema.PropertySpec {
 			TypeSpec:    schema.TypeSpec{Type: "boolean"},
 			Description: "IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.",
 		},
+		"enableIpv6": {
+			TypeSpec:    schema.TypeSpec{Type: "boolean"},
+			Description: "VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.",
+		},
 		"logLevel": {
 			TypeSpec: schema.TypeSpec{Type: "string"}, // TODO consider typing this as an enum
 			Description: "Specifies the log level used for logs.\n\nDefaults to \"DEBUG\"\nValid " +

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -473,6 +473,10 @@
                     "type": "boolean",
                     "description": "Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency."
                 },
+                "enableIpv6": {
+                    "type": "boolean",
+                    "description": "VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances."
+                },
                 "enablePodEni": {
                     "type": "boolean",
                     "description": "Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux."
@@ -1228,6 +1232,10 @@
                 "disableTcpEarlyDemux": {
                     "type": "boolean",
                     "description": "Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency."
+                },
+                "enableIpv6": {
+                    "type": "boolean",
+                    "description": "VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances."
                 },
                 "enablePodEni": {
                     "type": "boolean",

--- a/python/pulumi_eks/_inputs.py
+++ b/python/pulumi_eks/_inputs.py
@@ -1252,6 +1252,7 @@ class VpcCniOptionsArgs:
                  cni_external_snat: Optional[pulumi.Input[bool]] = None,
                  custom_network_config: Optional[pulumi.Input[bool]] = None,
                  disable_tcp_early_demux: Optional[pulumi.Input[bool]] = None,
+                 enable_ipv6: Optional[pulumi.Input[bool]] = None,
                  enable_pod_eni: Optional[pulumi.Input[bool]] = None,
                  enable_prefix_delegation: Optional[pulumi.Input[bool]] = None,
                  eni_config_label_def: Optional[pulumi.Input[str]] = None,
@@ -1276,6 +1277,7 @@ class VpcCniOptionsArgs:
                
                Defaults to false.
         :param pulumi.Input[bool] disable_tcp_early_demux: Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
+        :param pulumi.Input[bool] enable_ipv6: VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
         :param pulumi.Input[bool] enable_pod_eni: Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
         :param pulumi.Input[bool] enable_prefix_delegation: IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.
         :param pulumi.Input[str] eni_config_label_def: Specifies the ENI_CONFIG_LABEL_DEF environment variable value for worker nodes. This is used to tell Kubernetes to automatically apply the ENIConfig for each Availability Zone
@@ -1326,6 +1328,8 @@ class VpcCniOptionsArgs:
             pulumi.set(__self__, "custom_network_config", custom_network_config)
         if disable_tcp_early_demux is not None:
             pulumi.set(__self__, "disable_tcp_early_demux", disable_tcp_early_demux)
+        if enable_ipv6 is not None:
+            pulumi.set(__self__, "enable_ipv6", enable_ipv6)
         if enable_pod_eni is not None:
             pulumi.set(__self__, "enable_pod_eni", enable_pod_eni)
         if enable_prefix_delegation is not None:
@@ -1418,6 +1422,18 @@ class VpcCniOptionsArgs:
     @disable_tcp_early_demux.setter
     def disable_tcp_early_demux(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "disable_tcp_early_demux", value)
+
+    @property
+    @pulumi.getter(name="enableIpv6")
+    def enable_ipv6(self) -> Optional[pulumi.Input[bool]]:
+        """
+        VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+        """
+        return pulumi.get(self, "enable_ipv6")
+
+    @enable_ipv6.setter
+    def enable_ipv6(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_ipv6", value)
 
     @property
     @pulumi.getter(name="enablePodEni")

--- a/python/pulumi_eks/vpc_cni.py
+++ b/python/pulumi_eks/vpc_cni.py
@@ -19,6 +19,7 @@ class VpcCniArgs:
                  cni_external_snat: Optional[pulumi.Input[bool]] = None,
                  custom_network_config: Optional[pulumi.Input[bool]] = None,
                  disable_tcp_early_demux: Optional[pulumi.Input[bool]] = None,
+                 enable_ipv6: Optional[pulumi.Input[bool]] = None,
                  enable_pod_eni: Optional[pulumi.Input[bool]] = None,
                  enable_prefix_delegation: Optional[pulumi.Input[bool]] = None,
                  eni_config_label_def: Optional[pulumi.Input[str]] = None,
@@ -44,6 +45,7 @@ class VpcCniArgs:
                
                Defaults to false.
         :param pulumi.Input[bool] disable_tcp_early_demux: Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
+        :param pulumi.Input[bool] enable_ipv6: VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
         :param pulumi.Input[bool] enable_pod_eni: Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
         :param pulumi.Input[bool] enable_prefix_delegation: IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.
         :param pulumi.Input[str] eni_config_label_def: Specifies the ENI_CONFIG_LABEL_DEF environment variable value for worker nodes. This is used to tell Kubernetes to automatically apply the ENIConfig for each Availability Zone
@@ -95,6 +97,8 @@ class VpcCniArgs:
             pulumi.set(__self__, "custom_network_config", custom_network_config)
         if disable_tcp_early_demux is not None:
             pulumi.set(__self__, "disable_tcp_early_demux", disable_tcp_early_demux)
+        if enable_ipv6 is not None:
+            pulumi.set(__self__, "enable_ipv6", enable_ipv6)
         if enable_pod_eni is not None:
             pulumi.set(__self__, "enable_pod_eni", enable_pod_eni)
         if enable_prefix_delegation is not None:
@@ -199,6 +203,18 @@ class VpcCniArgs:
     @disable_tcp_early_demux.setter
     def disable_tcp_early_demux(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "disable_tcp_early_demux", value)
+
+    @property
+    @pulumi.getter(name="enableIpv6")
+    def enable_ipv6(self) -> Optional[pulumi.Input[bool]]:
+        """
+        VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+        """
+        return pulumi.get(self, "enable_ipv6")
+
+    @enable_ipv6.setter
+    def enable_ipv6(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_ipv6", value)
 
     @property
     @pulumi.getter(name="enablePodEni")
@@ -415,6 +431,7 @@ class VpcCni(pulumi.CustomResource):
                  cni_external_snat: Optional[pulumi.Input[bool]] = None,
                  custom_network_config: Optional[pulumi.Input[bool]] = None,
                  disable_tcp_early_demux: Optional[pulumi.Input[bool]] = None,
+                 enable_ipv6: Optional[pulumi.Input[bool]] = None,
                  enable_pod_eni: Optional[pulumi.Input[bool]] = None,
                  enable_prefix_delegation: Optional[pulumi.Input[bool]] = None,
                  eni_config_label_def: Optional[pulumi.Input[str]] = None,
@@ -444,6 +461,7 @@ class VpcCni(pulumi.CustomResource):
                
                Defaults to false.
         :param pulumi.Input[bool] disable_tcp_early_demux: Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
+        :param pulumi.Input[bool] enable_ipv6: VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
         :param pulumi.Input[bool] enable_pod_eni: Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
         :param pulumi.Input[bool] enable_prefix_delegation: IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.
         :param pulumi.Input[str] eni_config_label_def: Specifies the ENI_CONFIG_LABEL_DEF environment variable value for worker nodes. This is used to tell Kubernetes to automatically apply the ENIConfig for each Availability Zone
@@ -514,6 +532,7 @@ class VpcCni(pulumi.CustomResource):
                  cni_external_snat: Optional[pulumi.Input[bool]] = None,
                  custom_network_config: Optional[pulumi.Input[bool]] = None,
                  disable_tcp_early_demux: Optional[pulumi.Input[bool]] = None,
+                 enable_ipv6: Optional[pulumi.Input[bool]] = None,
                  enable_pod_eni: Optional[pulumi.Input[bool]] = None,
                  enable_prefix_delegation: Optional[pulumi.Input[bool]] = None,
                  eni_config_label_def: Optional[pulumi.Input[str]] = None,
@@ -547,6 +566,7 @@ class VpcCni(pulumi.CustomResource):
             __props__.__dict__["cni_external_snat"] = cni_external_snat
             __props__.__dict__["custom_network_config"] = custom_network_config
             __props__.__dict__["disable_tcp_early_demux"] = disable_tcp_early_demux
+            __props__.__dict__["enable_ipv6"] = enable_ipv6
             __props__.__dict__["enable_pod_eni"] = enable_pod_eni
             __props__.__dict__["enable_prefix_delegation"] = enable_prefix_delegation
             __props__.__dict__["eni_config_label_def"] = eni_config_label_def

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -1825,6 +1825,8 @@ type VpcCniOptions struct {
 	CustomNetworkConfig *bool `pulumi:"customNetworkConfig"`
 	// Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
 	DisableTcpEarlyDemux *bool `pulumi:"disableTcpEarlyDemux"`
+	// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+	EnableIpv6 *bool `pulumi:"enableIpv6"`
 	// Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
 	EnablePodEni *bool `pulumi:"enablePodEni"`
 	// IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.
@@ -1906,6 +1908,8 @@ type VpcCniOptionsArgs struct {
 	CustomNetworkConfig pulumi.BoolPtrInput `pulumi:"customNetworkConfig"`
 	// Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
 	DisableTcpEarlyDemux pulumi.BoolPtrInput `pulumi:"disableTcpEarlyDemux"`
+	// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+	EnableIpv6 pulumi.BoolPtrInput `pulumi:"enableIpv6"`
 	// Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
 	EnablePodEni pulumi.BoolPtrInput `pulumi:"enablePodEni"`
 	// IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.
@@ -2065,6 +2069,11 @@ func (o VpcCniOptionsOutput) CustomNetworkConfig() pulumi.BoolPtrOutput {
 // Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
 func (o VpcCniOptionsOutput) DisableTcpEarlyDemux() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v VpcCniOptions) *bool { return v.DisableTcpEarlyDemux }).(pulumi.BoolPtrOutput)
+}
+
+// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+func (o VpcCniOptionsOutput) EnableIpv6() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v VpcCniOptions) *bool { return v.EnableIpv6 }).(pulumi.BoolPtrOutput)
 }
 
 // Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
@@ -2239,6 +2248,16 @@ func (o VpcCniOptionsPtrOutput) DisableTcpEarlyDemux() pulumi.BoolPtrOutput {
 			return nil
 		}
 		return v.DisableTcpEarlyDemux
+	}).(pulumi.BoolPtrOutput)
+}
+
+// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+func (o VpcCniOptionsPtrOutput) EnableIpv6() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *VpcCniOptions) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.EnableIpv6
 	}).(pulumi.BoolPtrOutput)
 }
 

--- a/sdk/go/eks/vpcCni.go
+++ b/sdk/go/eks/vpcCni.go
@@ -70,6 +70,8 @@ type vpcCniArgs struct {
 	CustomNetworkConfig *bool `pulumi:"customNetworkConfig"`
 	// Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
 	DisableTcpEarlyDemux *bool `pulumi:"disableTcpEarlyDemux"`
+	// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+	EnableIpv6 *bool `pulumi:"enableIpv6"`
 	// Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
 	EnablePodEni *bool `pulumi:"enablePodEni"`
 	// IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.
@@ -142,6 +144,8 @@ type VpcCniArgs struct {
 	CustomNetworkConfig pulumi.BoolPtrInput
 	// Allows the kubelet's liveness and readiness probes to connect via TCP when pod ENI is enabled. This will slightly increase local TCP connection latency.
 	DisableTcpEarlyDemux pulumi.BoolPtrInput
+	// VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode. IPv6 is only supported in Prefix Delegation mode, so ENABLE_PREFIX_DELEGATION needs to set to true if VPC CNI is configured to operate in IPv6 mode. Prefix delegation is only supported on nitro instances.
+	EnableIpv6 pulumi.BoolPtrInput
 	// Specifies whether to allow IPAMD to add the `vpc.amazonaws.com/has-trunk-attached` label to the node if the instance has capacity to attach an additional ENI. Default is `false`. If using liveness and readiness probes, you will also need to disable TCP early demux.
 	EnablePodEni pulumi.BoolPtrInput
 	// IPAMD will start allocating (/28) prefixes to the ENIs with ENABLE_PREFIX_DELEGATION set to true.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Decomposed part of https://github.com/pulumi/pulumi-eks/pull/683. (h/t @davidroth)

I'd like to cut a pre-release 0.39.0.beta1 with this change since there are some lingering concerns around stability due to https://github.com/aws/amazon-vpc-cni-k8s/issues/1847 and didn't want to get it out as part of 0.38.0.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Partially addresses #684 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
