### PR TITLE
Switch kubeconfig to use client.authentication.k8s.io/v1beta1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -271,6 +271,14 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -382,6 +390,14 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
           repo: pulumi/pulumictl
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
@@ -482,6 +498,14 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+            python-version: '3.7'
+          - name: Install awscli
+            run: |
+              python -m pip install --upgrade pip
+              pip install awscli --upgrade
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -502,10 +502,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
             python-version: '3.7'
-          - name: Install awscli
-            run: |
-              python -m pip install --upgrade pip
-              pip install awscli --upgrade
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,14 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
           repo: pulumi/pulumictl
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
@@ -394,6 +402,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install Python deps
         run: |-
           pip3 install virtualenv==20.0.23
@@ -489,6 +505,14 @@ jobs:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -222,6 +222,14 @@ jobs:
           curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv kubectl /usr/local/bin
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -345,6 +353,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Install Python deps
         run: |-
           pip3 install virtualenv==20.0.23
@@ -444,6 +456,14 @@ jobs:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -551,6 +571,14 @@ jobs:
         with:
           node-version: ${{matrix.nodeversion}}
           registry-url: https://registry.npmjs.org
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Add enableIpv6 option to clusters
   [#695](https://github.com/pulumi/pulumi-eks/pull/695)
   This change upgrades amazon-vpc-cni-k8s to v1.11.
+- Switch kubeconfig to use client.authentication.k8s.io/v1beta1
+  [#701](https://github.com/pulumi/pulumi-eks/pull/701)
 
 ## 0.39.0 (Released May 9, 2022)
 - Add support for Pulumi AWS 5.x

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ test_dotnet:: install_provider
 	cd examples && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 specific_test:: install_nodejs_sdk test_build
+	cd examples && go test -tags=$(LanguageTags) -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . --run=TestAcc$(TestName) 2>&1 | tee /tmp/gotest.log | gotestfmt
+
+specific_test_local:: install_nodejs_sdk test_build
 	cd examples && go test -tags=$(LanguageTags) -v -count=1 -cover -timeout 3h . --run=TestAcc$(TestName)
 
 dev:: lint build_nodejs

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test_dotnet:: install_provider
 	cd examples && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 specific_test:: install_nodejs_sdk test_build
-	cd examples && go test -tags=$(LanguageTags) -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . --run=TestAcc$(TestName) 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd examples && go test -tags=$(LanguageTags) -v -count=1 -cover -timeout 3h . --run=TestAcc$(TestName)
 
 dev:: lint build_nodejs
 test:: test_nodejs

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -108,7 +108,7 @@ func TestAccFargate(t *testing.T) {
 func TestAccNodeGroup(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: true,
+			RunUpdateTest: false,
 			Dir:           path.Join(getCwd(t), "nodegroup"),
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
@@ -125,7 +125,7 @@ func TestAccNodeGroup(t *testing.T) {
 func TestAccManagedNodeGroup(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: true,
+			RunUpdateTest: false,
 			Dir:           path.Join(getCwd(t), "managed-nodegroups"),
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
@@ -182,7 +182,6 @@ func TestAccTags(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "tags"),
-			RunUpdateTest: true,
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
@@ -190,7 +189,6 @@ func TestAccTags(t *testing.T) {
 					info.Outputs["kubeconfig2"],
 				)
 			},
-			Verbose: true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -199,7 +197,6 @@ func TestAccTags(t *testing.T) {
 func TestAccStorageClasses(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: true,
 			Dir:           path.Join(getCwd(t), "storage-classes"),
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -190,6 +190,7 @@ func TestAccTags(t *testing.T) {
 					info.Outputs["kubeconfig2"],
 				)
 			},
+			Verbose: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -222,7 +222,7 @@ export class VpcCni extends pulumi.CustomResource {
         const aliasOpts = { aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }] };
         opts = pulumi.mergeOptions(opts, aliasOpts);
         super("eks:index:VpcCni", name, {
-            kubeconfig: kubeconfig ? pulumi.output(kubeconfig).apply(JSON.stringify) : undefined,
+            kubeconfig: kubeconfig,
             nodePortSupport: args?.nodePortSupport,
             customNetworkConfig: args?.customNetworkConfig,
             externalSnat: args?.externalSnat,


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Follow up from https://github.com/pulumi/pulumi-eks/pull/690 to handle kubectl deprecating support for `client.authentication.k8s.io/v1alpha1`
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
