### PR TITLE
Reverts #670 for clusters older than 4-16-2020, fixes #727

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
-(None)
+
+- Reverts #670 for clusters older than 4-16-2020. Adds back in "arn:aws:iam::aws:policy/AmazonEKSServicePolicy".
+  [#729](https://github.com/pulumi/pulumi-eks/pull/729)
 
 ## 0.41.0 (Released Jun 21, 2022)
 - Add checks to validate versions of kubectl and aws-cli installed

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -434,6 +434,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
             description: "Allows EKS to manage clusters on your behalf.",
             managedPolicyArns: [
                 "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+                "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
             ],
         }, { parent, provider })).role;
     }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This reverts the changes in #670 as clusters createdAt 04162020 or earlier still need this policy. This will need a guard before re-releasing. 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
