### PR TITLE
Export the ARN for the IAM Role attached to the EKS Cluster

### DIFF
--- a/dotnet/Inputs/CoreDataArgs.cs
+++ b/dotnet/Inputs/CoreDataArgs.cs
@@ -21,6 +21,12 @@ namespace Pulumi.Eks.Inputs
         [Input("cluster", required: true)]
         public Input<Pulumi.Aws.Eks.Cluster> Cluster { get; set; } = null!;
 
+        /// <summary>
+        /// The IAM Role attached to the EKS Cluster
+        /// </summary>
+        [Input("clusterIamRole", required: true)]
+        public Input<Pulumi.Aws.Iam.Role> ClusterIamRole { get; set; } = null!;
+
         [Input("clusterSecurityGroup", required: true)]
         public Input<Pulumi.Aws.Ec2.SecurityGroup> ClusterSecurityGroup { get; set; } = null!;
 

--- a/dotnet/Outputs/CoreData.cs
+++ b/dotnet/Outputs/CoreData.cs
@@ -18,6 +18,10 @@ namespace Pulumi.Eks.Outputs
     {
         public readonly Pulumi.Aws.Provider? AwsProvider;
         public readonly Pulumi.Aws.Eks.Cluster Cluster;
+        /// <summary>
+        /// The IAM Role attached to the EKS Cluster
+        /// </summary>
+        public readonly Pulumi.Aws.Iam.Role ClusterIamRole;
         public readonly Pulumi.Aws.Ec2.SecurityGroup ClusterSecurityGroup;
         public readonly Pulumi.Kubernetes.Core.V1.ConfigMap? EksNodeAccess;
         public readonly Pulumi.Aws.Eks.Outputs.ClusterEncryptionConfig? EncryptionConfig;
@@ -42,6 +46,8 @@ namespace Pulumi.Eks.Outputs
             Pulumi.Aws.Provider? awsProvider,
 
             Pulumi.Aws.Eks.Cluster cluster,
+
+            Pulumi.Aws.Iam.Role clusterIamRole,
 
             Pulumi.Aws.Ec2.SecurityGroup clusterSecurityGroup,
 
@@ -81,6 +87,7 @@ namespace Pulumi.Eks.Outputs
         {
             AwsProvider = awsProvider;
             Cluster = cluster;
+            ClusterIamRole = clusterIamRole;
             ClusterSecurityGroup = clusterSecurityGroup;
             EksNodeAccess = eksNodeAccess;
             EncryptionConfig = encryptionConfig;

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -32,3 +32,6 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
 // Export the clusters' kubeconfig.
 export const kubeconfig1 = cluster1.kubeconfig;
 export const kubeconfig2 = cluster2.kubeconfig;
+
+// export the IAM Role ARN of the cluster
+export const iamRoleArn = cluster1.core.clusterIamRole.arn;

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -44,6 +44,9 @@ func TestAccCluster(t *testing.T) {
 					info.Outputs["kubeconfig2"],
 				)
 
+				// let's test there's a iamRoleArn specified for the cluster
+				assert.NotEmpty(t, info.Outputs["iamRoleArn"])
+
 				assert.NoError(t, utils.ValidateDaemonSet(t, info.Outputs["kubeconfig2"], "kube-system", "aws-node", func(ds *appsv1.DaemonSet) {
 					for _, ic := range ds.Spec.Template.Spec.InitContainers {
 						assert.Equal(t, "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.0",

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -146,6 +146,7 @@ export interface CoreData {
     fargateProfile: pulumi.Output<aws.eks.FargateProfile | undefined>;
     oidcProvider?: aws.iam.OpenIdConnectProvider;
     encryptionConfig?: pulumi.Output<aws.types.output.eks.ClusterEncryptionConfig>;
+    clusterIamRole: pulumi.Output<aws.iam.Role>;
 }
 
 function createOrGetInstanceProfile(
@@ -800,6 +801,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         fargateProfile: fargateProfile,
         oidcProvider: oidcProvider,
         encryptionConfig: encryptionConfig,
+        clusterIamRole: eksRole,
     };
 }
 

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -950,6 +950,10 @@ func generateSchema() schema.PackageSpec {
 						"encryptionConfig": {
 							TypeSpec: schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FClusterEncryptionConfig:ClusterEncryptionConfig")},
 						},
+						"clusterIamRole": {
+							Description: "The IAM Role attached to the EKS Cluster",
+							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:iam%2Frole:Role")},
+						},
 					},
 					Required: []string{
 						"cluster",
@@ -960,6 +964,7 @@ func generateSchema() schema.PackageSpec {
 						"provider",
 						"instanceRoles",
 						"nodeGroupOptions",
+						"clusterIamRole",
 					},
 				},
 			},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -152,6 +152,10 @@
                 "cluster": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
                 },
+                "clusterIamRole": {
+                    "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "description": "The IAM Role attached to the EKS Cluster"
+                },
                 "clusterSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                 },
@@ -237,7 +241,8 @@
                 "clusterSecurityGroup",
                 "provider",
                 "instanceRoles",
-                "nodeGroupOptions"
+                "nodeGroupOptions",
+                "clusterIamRole"
             ]
         },
         "eks:index:CreationRoleProvider": {

--- a/python/pulumi_eks/_inputs.py
+++ b/python/pulumi_eks/_inputs.py
@@ -548,6 +548,7 @@ class ClusterNodeGroupOptionsArgs:
 class CoreDataArgs:
     def __init__(__self__, *,
                  cluster: pulumi.Input['pulumi_aws.eks.Cluster'],
+                 cluster_iam_role: pulumi.Input['pulumi_aws.iam.Role'],
                  cluster_security_group: pulumi.Input['pulumi_aws.ec2.SecurityGroup'],
                  endpoint: pulumi.Input[str],
                  instance_roles: pulumi.Input[Sequence[pulumi.Input['pulumi_aws.iam.Role']]],
@@ -569,8 +570,10 @@ class CoreDataArgs:
                  vpc_cni: Optional[pulumi.Input['VpcCni']] = None):
         """
         Defines the core set of data associated with an EKS cluster, including the network in which it runs.
+        :param pulumi.Input['pulumi_aws.iam.Role'] cluster_iam_role: The IAM Role attached to the EKS Cluster
         """
         pulumi.set(__self__, "cluster", cluster)
+        pulumi.set(__self__, "cluster_iam_role", cluster_iam_role)
         pulumi.set(__self__, "cluster_security_group", cluster_security_group)
         pulumi.set(__self__, "endpoint", endpoint)
         pulumi.set(__self__, "instance_roles", instance_roles)
@@ -611,6 +614,18 @@ class CoreDataArgs:
     @cluster.setter
     def cluster(self, value: pulumi.Input['pulumi_aws.eks.Cluster']):
         pulumi.set(self, "cluster", value)
+
+    @property
+    @pulumi.getter(name="clusterIamRole")
+    def cluster_iam_role(self) -> pulumi.Input['pulumi_aws.iam.Role']:
+        """
+        The IAM Role attached to the EKS Cluster
+        """
+        return pulumi.get(self, "cluster_iam_role")
+
+    @cluster_iam_role.setter
+    def cluster_iam_role(self, value: pulumi.Input['pulumi_aws.iam.Role']):
+        pulumi.set(self, "cluster_iam_role", value)
 
     @property
     @pulumi.getter(name="clusterSecurityGroup")

--- a/python/pulumi_eks/outputs.py
+++ b/python/pulumi_eks/outputs.py
@@ -503,7 +503,9 @@ class CoreData(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "clusterSecurityGroup":
+        if key == "clusterIamRole":
+            suggest = "cluster_iam_role"
+        elif key == "clusterSecurityGroup":
             suggest = "cluster_security_group"
         elif key == "instanceRoles":
             suggest = "instance_roles"
@@ -547,6 +549,7 @@ class CoreData(dict):
 
     def __init__(__self__, *,
                  cluster: 'pulumi_aws.eks.Cluster',
+                 cluster_iam_role: 'pulumi_aws.iam.Role',
                  cluster_security_group: 'pulumi_aws.ec2.SecurityGroup',
                  endpoint: str,
                  instance_roles: Sequence['pulumi_aws.iam.Role'],
@@ -568,8 +571,10 @@ class CoreData(dict):
                  vpc_cni: Optional['VpcCni'] = None):
         """
         Defines the core set of data associated with an EKS cluster, including the network in which it runs.
+        :param 'pulumi_aws.iam.Role' cluster_iam_role: The IAM Role attached to the EKS Cluster
         """
         pulumi.set(__self__, "cluster", cluster)
+        pulumi.set(__self__, "cluster_iam_role", cluster_iam_role)
         pulumi.set(__self__, "cluster_security_group", cluster_security_group)
         pulumi.set(__self__, "endpoint", endpoint)
         pulumi.set(__self__, "instance_roles", instance_roles)
@@ -606,6 +611,14 @@ class CoreData(dict):
     @pulumi.getter
     def cluster(self) -> 'pulumi_aws.eks.Cluster':
         return pulumi.get(self, "cluster")
+
+    @property
+    @pulumi.getter(name="clusterIamRole")
+    def cluster_iam_role(self) -> 'pulumi_aws.iam.Role':
+        """
+        The IAM Role attached to the EKS Cluster
+        """
+        return pulumi.get(self, "cluster_iam_role")
 
     @property
     @pulumi.getter(name="clusterSecurityGroup")

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -815,8 +815,10 @@ func (o ClusterNodeGroupOptionsPtrOutput) Version() pulumi.StringPtrOutput {
 
 // Defines the core set of data associated with an EKS cluster, including the network in which it runs.
 type CoreData struct {
-	AwsProvider           *aws.Provider                      `pulumi:"awsProvider"`
-	Cluster               *eks.Cluster                       `pulumi:"cluster"`
+	AwsProvider *aws.Provider `pulumi:"awsProvider"`
+	Cluster     *eks.Cluster  `pulumi:"cluster"`
+	// The IAM Role attached to the EKS Cluster
+	ClusterIamRole        *iam.Role                          `pulumi:"clusterIamRole"`
 	ClusterSecurityGroup  *ec2.SecurityGroup                 `pulumi:"clusterSecurityGroup"`
 	EksNodeAccess         *corev1.ConfigMap                  `pulumi:"eksNodeAccess"`
 	EncryptionConfig      *eks.ClusterEncryptionConfig       `pulumi:"encryptionConfig"`
@@ -850,8 +852,10 @@ type CoreDataInput interface {
 
 // Defines the core set of data associated with an EKS cluster, including the network in which it runs.
 type CoreDataArgs struct {
-	AwsProvider           aws.ProviderInput                   `pulumi:"awsProvider"`
-	Cluster               eks.ClusterInput                    `pulumi:"cluster"`
+	AwsProvider aws.ProviderInput `pulumi:"awsProvider"`
+	Cluster     eks.ClusterInput  `pulumi:"cluster"`
+	// The IAM Role attached to the EKS Cluster
+	ClusterIamRole        iam.RoleInput                       `pulumi:"clusterIamRole"`
 	ClusterSecurityGroup  ec2.SecurityGroupInput              `pulumi:"clusterSecurityGroup"`
 	EksNodeAccess         corev1.ConfigMapInput               `pulumi:"eksNodeAccess"`
 	EncryptionConfig      eks.ClusterEncryptionConfigPtrInput `pulumi:"encryptionConfig"`
@@ -905,6 +909,11 @@ func (o CoreDataOutput) AwsProvider() aws.ProviderOutput {
 
 func (o CoreDataOutput) Cluster() eks.ClusterOutput {
 	return o.ApplyT(func(v CoreData) *eks.Cluster { return v.Cluster }).(eks.ClusterOutput)
+}
+
+// The IAM Role attached to the EKS Cluster
+func (o CoreDataOutput) ClusterIamRole() iam.RoleOutput {
+	return o.ApplyT(func(v CoreData) *iam.Role { return v.ClusterIamRole }).(iam.RoleOutput)
 }
 
 func (o CoreDataOutput) ClusterSecurityGroup() ec2.SecurityGroupOutput {


### PR DESCRIPTION
Fixes: #727

In #670, we removed the deprecated IAM Role Policy `AmazonEKSServicePolicy`.
Unfortunately, this has broken clusters older than 16th April 2020

Rather than adding this policy back by default, we now expose the
ARN of the IAM Role for the cluster so that a user can do as follows:

```
const cluster1 = new eks.Cluster(`${projectName}-1`);

const iamRole = cluster1.core.clusterIamRole;

const rpa = new aws.iam.RolePolicyAttachment("rpa", {
  role: iamRole.name,
  policy: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
})
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
