### PR TITLE
No longer set default value for AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-(None)
+- Fix issue with duplicated AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER env var on aws-node daemonset. 
+  [#737](https://github.com/pulumi/pulumi-eks/pull/737)
 
 ## 0.41.2 (Released Jul 12, 2022)
 - Allow removal of default Kubernetes addons

--- a/nodejs/eks/cmd/provider/cni.ts
+++ b/nodejs/eks/cmd/provider/cni.ts
@@ -142,8 +142,6 @@ function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
     }
     if (args.cniConfigureRpfilter) {
         env.push({ name: "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER", value: args.cniConfigureRpfilter ? "true" : "false" });
-    } else {
-        env.push({ name: "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER", value: "false" });
     }
     if (args.cniCustomNetworkCfg) {
         env.push({ name: "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG", value: args.cniCustomNetworkCfg ? "true" : "false" });


### PR DESCRIPTION
### Proposed changes

Fix an issue where the env var AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER can duplicated in aws-node daemonset and make helm apply fail. The regression has been introduced in 0.40.0.

Remove set default has it's already set in https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/cni/aws-k8s-cni.yaml


