### PR TITLE
feat: Dyamically fetch aws partition

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -281,15 +281,15 @@ export class ClusterCreationRoleProvider extends pulumi.ComponentResource implem
  * @returns partition
  */
 const getPartition = (
-    provider?: pulumi.ProviderResource
+    provider?: pulumi.ProviderResource,
 ): string => {
     let partition = "aws";
     aws.getPartition({provider, async: true}).then(partitionResult => {
         partition = partitionResult.partition;
-    })
+    });
     return partition;
-}
-//Grab the PARTITION once and use throughout
+};
+// Grab the PARTITION once and use throughout
 const PARTITION = getPartition();
 
 /**


### PR DESCRIPTION
Initial code to dynamically fetch the partition and interpolate that in place of the hardcoded IAM arns. This will allow gov cloud, china, and other regions that use different partitions to provision EKS clusters without having to use a transformation workaround which can be hard to implement in some languages like Golang

Related to #570,#534,#386

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
