### PR TITLE
change dnsSuffix for ec2 oidc

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -401,6 +401,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     };
 
     const partition = pulumi.output(aws.getPartition({ provider })).partition;
+    const dnsSuffix = pulumi.output(aws.getPartition({ provider })).dnsSuffix;
 
     // Configure default networking architecture.
     let vpcId: pulumi.Input<string> = args.vpcId!;
@@ -638,7 +639,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
         instanceRoles = pulumi.output([args.instanceRole]);
     } else {
         const instanceRole = (new ServiceRole(`${name}-instanceRole`, {
-            service: "ec2.amazonaws.com",
+            service: `ec2.${dnsSuffix}`,
             managedPolicyArns: [
                 {
                     id: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
@@ -787,7 +788,7 @@ export function createCore(name: string, args: ClusterOptions, parent: pulumi.Co
     if (args.createOidcProvider) {
         // Retrieve the OIDC provider URL's intermediate root CA fingerprint.
         const awsRegionName = pulumi.output(aws.getRegion({}, { parent, async: true })).name;
-        const eksOidcProviderUrl = pulumi.interpolate`https://oidc.eks.${awsRegionName}.amazonaws.com`;
+        const eksOidcProviderUrl = pulumi.interpolate`https://oidc.eks.${awsRegionName}.${dnsSuffix}`;
         const agent = createHttpAgent(args.proxy);
         const fingerprint = getIssuerCAThumbprint(eksOidcProviderUrl, agent);
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

For some service in CN region , the dnsSuffix end with '.cn' . 


```bash
aws:eks:NodeGroup (default):
    error: 1 error occurred:
        * error creating EKS Node Group (dev-cnn1:default20221014114406636600000007): InvalidParameterException: Following required service principals [[ec2.amazonaws.com.cn ](https://console.amazonaws.cn/support/ec2.amazonaws.com.cn)] were not found in the trusionships of nodeRole arn:aws-cn:iam::888888888888:role/dev-cnn1-instanceRole-role-963e580
    {
      RespMetadata: {
        StatusCode: 400,
        RequestID: "c8d401ae-bc7c-4039-9115-65d848c595d9"
      },
      ClusterName: "dev-cnn1",
      Message_: "Following required service principals [[ec2.amazonaws.com.cn ](https://console.amazonaws.cn/support/ec2.amazonaws.com.cn)] were not found in the trust relationships of nodeRole arn:aws-cn:iam::888888888888:role/dev-cnn1-instanceRole-role-963e580
      NodegroupName: "default20221014114406636600000007"
    }
```

### Related issues (optional)