### PR TITLE
Fix defaults v mutually exclusive args conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [Add support for non-default AWS partitions #788](https://github.com/pulumi/pulumi-eks/pull/788)
 - [Add support for launchTemplateTagSpecifications within NodeGroupV2 #810](https://github.com/pulumi/pulumi-eks/pull/810)
 - [Use pkg for packaging provider binary #776](https://github.com/pulumi/pulumi-eks/pull/776)
+- [Remove default for NodeRootVolumeSize that conflicted with NodeGroupOptions #813](https://github.com/pulumi/pulumi-eks/pull/813)
 
 ## 0.42.2 (Released Oct 12, 2022)
 - Fix internal registration of NodeGroupV2 resource.

--- a/examples/cluster-cs/Cluster.csproj
+++ b/examples/cluster-cs/Cluster.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi.Aws" Version="5.*" />
+    <PackageReference Include="Pulumi.Awsx" Version="1.0.0-beta.*" />
   </ItemGroup>
 
 </Project>

--- a/examples/cluster-cs/MyStack.cs
+++ b/examples/cluster-cs/MyStack.cs
@@ -1,14 +1,17 @@
 using Pulumi;
-using Pulumi.Eks;
+using Eks = Pulumi.Eks;
+using Awsx = Pulumi.Awsx;
 
 class MyStack : Stack
 {
     [Output("kubeconfig1")]
     public Output<object> Kubeconfig1 { get; set; }
 
-    // TODO
-    // [Output("kubeconfig2")]
-    // public Output<object> Kubeconfig2 { get; set; }
+    [Output("kubeconfig2")]
+    public Output<object> Kubeconfig2 { get; set; }
+
+    [Output("kubeconfig3")]
+    public Output<object> Kubeconfig3 { get; set; }
 
     public MyStack()
     {
@@ -16,29 +19,36 @@ class MyStack : Stack
 
         var cluster1 = new Cluster($"{projectName}-1");
 
-        // # TODO
-        // # // Create an EKS cluster with a non-default configuration.
-        // # const vpc = new awsx.ec2.Vpc(`${projectName}-2`, {
-        // #     tags: { "Name": `${projectName}-2` },
-        // # });
+        var vpc = new Awsx.Ec2.Vpc($"{projectName}-2");
 
-        // # const cluster2 = new eks.Cluster(`${projectName}-2`, {
-        // #     vpcId: vpc.id,
-        // #     publicSubnetIds: vpc.publicSubnetIds,
-        // #     desiredCapacity: 2,
-        // #     minSize: 2,
-        // #     maxSize: 2,
-        // #     deployDashboard: false,
-        // #     enabledClusterLogTypes: [
-        // #         "api",
-        // #         "audit",
-        // #         "authenticator",
-        // #     ],
-        // # });
+        var cluster2 = new Cluster($"{projectName}-2", new ClusterArgs {
+            VpcId = vpc.Id,
+            PublicSubnetIds = vpc.PublicSubnetIds,
+            DesiredCapacity = 2,
+            MinSize = 2,
+            MaxSize = 2,
+            DeployDashboard = false,
+            EnabledClusterLogTypes = {
+                "api",
+                "audit",
+                "authenticator",
+            }
+        });
+
+        var cluster3 = new Cluster($"{projectName}-3", new ClusterArgs {
+            VpcId = vpc.Id,
+            PublicSubnetIds = vpc.PublicSubnetIds,
+            NodeGroupOptions = new ClusterNodeGroupOptionsArgs {
+                DesiredCapacity = 1,
+                MinSize = 1,
+                MaxSize = 1,
+                InstanceType = "t2.small",
+            },
+        });
 
         // Export the clusters' kubeconfig.
         Kubeconfig1 = cluster1.Kubeconfig;
-        // TODO
-        // Kubeconfig2 = cluster2.kubeconfig;
+        Kubeconfig2 = cluster2.Kubeconfig;
+        Kubeconfig3 = cluster3.Kubeconfig;
     }
 }

--- a/examples/cluster-cs/MyStack.cs
+++ b/examples/cluster-cs/MyStack.cs
@@ -17,17 +17,16 @@ class MyStack : Stack
     {
         string projectName = Deployment.Instance.ProjectName;
 
-        var cluster1 = new Cluster($"{projectName}-1");
+        var cluster1 = new Eks.Cluster($"{projectName}-1");
 
         var vpc = new Awsx.Ec2.Vpc($"{projectName}-2");
 
-        var cluster2 = new Cluster($"{projectName}-2", new ClusterArgs {
-            VpcId = vpc.Id,
+        var cluster2 = new Eks.Cluster($"{projectName}-2", new Eks.ClusterArgs {
+            VpcId = vpc.VpcId,
             PublicSubnetIds = vpc.PublicSubnetIds,
             DesiredCapacity = 2,
             MinSize = 2,
             MaxSize = 2,
-            DeployDashboard = false,
             EnabledClusterLogTypes = {
                 "api",
                 "audit",
@@ -35,10 +34,10 @@ class MyStack : Stack
             }
         });
 
-        var cluster3 = new Cluster($"{projectName}-3", new ClusterArgs {
-            VpcId = vpc.Id,
+        var cluster3 = new Eks.Cluster($"{projectName}-3", new Eks.ClusterArgs {
+            VpcId = vpc.VpcId,
             PublicSubnetIds = vpc.PublicSubnetIds,
-            NodeGroupOptions = new ClusterNodeGroupOptionsArgs {
+            NodeGroupOptions = new Eks.Inputs.ClusterNodeGroupOptionsArgs {
                 DesiredCapacity = 1,
                 MinSize = 1,
                 MaxSize = 1,

--- a/examples/cluster-go/main.go
+++ b/examples/cluster-go/main.go
@@ -16,17 +16,33 @@ func main() {
 		// Create cluster with non-default settings
 		cluster2, err := eks.NewCluster(ctx, "example-cluster-2", &eks.ClusterArgs{
 			DesiredCapacity: pulumi.IntPtr(2),
-			MinSize: pulumi.IntPtr(2),
-			MaxSize: pulumi.IntPtr(2),
+			MinSize:         pulumi.IntPtr(2),
+			MaxSize:         pulumi.IntPtr(2),
 			EnabledClusterLogTypes: pulumi.StringArray{
 				pulumi.String("api"),
 				pulumi.String("audit"),
 				pulumi.String("authenticator"),
 			},
 		})
+		if err != nil {
+			return err
+		}
+
+		cluster3, err := eks.NewCluster(ctx, "example-cluster-3", &eks.ClusterArgs{
+			NodeGroupOptions: &eks.ClusterNodeGroupOptionsArgs{
+				DesiredCapacity: pulumi.IntPtr(2),
+				MinSize:         pulumi.IntPtr(2),
+				MaxSize:         pulumi.IntPtr(2),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
 		// Export the kubeconfig for clusters
 		ctx.Export("kubeconfig1", cluster1.Kubeconfig)
 		ctx.Export("kubeconfig2", cluster2.Kubeconfig)
+		ctx.Export("kubeconfig3", cluster3.Kubeconfig)
 		return nil
 	})
 }

--- a/examples/cluster-py/__main__.py
+++ b/examples/cluster-py/__main__.py
@@ -30,7 +30,20 @@ cluster2 = eks.Cluster('eks-cluster',
                               "authenticator",
                           ],)
 
+cluster3 = eks.Cluster(f"{project_name}-3",
+                            vpc_id=vpc.vpc_id,
+                            public_subnet_ids=vpc.public_subnet_ids,
+                            node_group_options=eks.ClusterNodeGroupOptionsArgs(
+                                desired_capacity=1,
+                                min_size=1,
+                                max_size=1,
+                                instance_type="t2.small"
+                            )
+)
+
+
 
 # Export the clusters' kubeconfig.
 pulumi.export("kubeconfig1", cluster1.kubeconfig)
 pulumi.export("kubeconfig2", cluster2.kubeconfig)
+pulumi.export("kubeconfig3", cluster3.kubeconfig)

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -29,7 +29,7 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
     },
 });
 
-const cluster3 = new eks.Cluster(`${projectName}-2`, {
+const cluster3 = new eks.Cluster(`${projectName}-3`, {
     vpcId: vpc.id,
     publicSubnetIds: vpc.publicSubnetIds,
     nodeGroupOptions: {

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -29,9 +29,21 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
     },
 });
 
+const cluster3 = new eks.Cluster(`${projectName}-2`, {
+    vpcId: vpc.id,
+    publicSubnetIds: vpc.publicSubnetIds,
+    nodeGroupOptions: {
+        desiredCapacity: 1,
+        minSize: 1,
+        maxSize: 1,
+        instanceType: "t2.small",
+    }
+})
+
 // Export the clusters' kubeconfig.
 export const kubeconfig1 = cluster1.kubeconfig;
 export const kubeconfig2 = cluster2.kubeconfig;
+export const kubeconfig3 = cluster3.kubeconfig;
 
 // export the IAM Role ARN of the cluster
 export const iamRoleArn = cluster1.core.clusterIamRole.arn;

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//go:build dotnet || all
 // +build dotnet all
 
 package example
@@ -31,8 +32,8 @@ func TestAccClusterCs(t *testing.T) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
 					info.Outputs["kubeconfig1"],
-					// TODO
-					// info.Outputs["kubeconfig2"],
+					info.Outputs["kubeconfig2"],
+					info.Outputs["kubeconfig3"],
 				)
 			},
 		})

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -34,6 +34,7 @@ func TestAccClusterGo(t *testing.T) {
 					info.Deployment.Resources,
 					info.Outputs["kubeconfig1"],
 					info.Outputs["kubeconfig2"],
+					info.Outputs["kubeconfig3"],
 				)
 			},
 		})

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -43,6 +43,7 @@ func TestAccCluster(t *testing.T) {
 					info.Deployment.Resources,
 					info.Outputs["kubeconfig1"],
 					info.Outputs["kubeconfig2"],
+					info.Outputs["kubeconfig3"],
 				)
 
 				// let's test there's a iamRoleArn specified for the cluster

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -67,8 +67,8 @@ func TestAccClusterPy(t *testing.T) {
 			// 	utils.RunEKSSmokeTest(t,
 			// 		info.Deployment.Resources,
 			// 		info.Outputs["kubeconfig1"],
-			// 		// TODO
-			// 		// info.Outputs["kubeconfig2"],
+			// 		info.Outputs["kubeconfig2"],
+			//		info.Outputs["kubeconfig3"],
 			// 	)
 			// },
 		})

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -400,12 +400,10 @@ func generateSchema() schema.PackageSpec {
 					"nodeRootVolumeDeleteOnTermination": {
 						TypeSpec:    schema.TypeSpec{Type: "boolean"},
 						Description: "Whether to delete a cluster node's root volume on termination. Defaults to true.",
-						Default:     true,
 					},
 					"nodeRootVolumeEncrypted": {
 						TypeSpec:    schema.TypeSpec{Type: "boolean"},
 						Description: "Whether to encrypt a cluster node's root volume. Defaults to false.",
-						Default:     false,
 					},
 					"nodeRootVolumeIops": {
 						TypeSpec:    schema.TypeSpec{Type: "integer"},
@@ -418,7 +416,6 @@ func generateSchema() schema.PackageSpec {
 					"nodeRootVolumeType": {
 						TypeSpec:    schema.TypeSpec{Type: "string"},
 						Description: "Configured EBS type for a cluster node's root volume. Default is gp2.",
-						Default:     "gp2",
 					},
 					"nodeUserData": {
 						TypeSpec: schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -396,7 +396,6 @@ func generateSchema() schema.PackageSpec {
 					"nodeRootVolumeSize": {
 						TypeSpec:    schema.TypeSpec{Type: "integer"},
 						Description: "The size in GiB of a cluster node's root volume. Defaults to 20.",
-						Default:     20,
 					},
 					"nodeRootVolumeDeleteOnTermination": {
 						TypeSpec:    schema.TypeSpec{Type: "boolean"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -734,13 +734,11 @@
                 },
                 "nodeRootVolumeDeleteOnTermination": {
                     "type": "boolean",
-                    "description": "Whether to delete a cluster node's root volume on termination. Defaults to true.",
-                    "default": true
+                    "description": "Whether to delete a cluster node's root volume on termination. Defaults to true."
                 },
                 "nodeRootVolumeEncrypted": {
                     "type": "boolean",
-                    "description": "Whether to encrypt a cluster node's root volume. Defaults to false.",
-                    "default": false
+                    "description": "Whether to encrypt a cluster node's root volume. Defaults to false."
                 },
                 "nodeRootVolumeIops": {
                     "type": "integer",
@@ -756,8 +754,7 @@
                 },
                 "nodeRootVolumeType": {
                     "type": "string",
-                    "description": "Configured EBS type for a cluster node's root volume. Default is gp2.",
-                    "default": "gp2"
+                    "description": "Configured EBS type for a cluster node's root volume. Default is gp2."
                 },
                 "nodeSecurityGroupTags": {
                     "type": "object",

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -748,8 +748,7 @@
                 },
                 "nodeRootVolumeSize": {
                     "type": "integer",
-                    "description": "The size in GiB of a cluster node's root volume. Defaults to 20.",
-                    "default": 20
+                    "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
                 },
                 "nodeRootVolumeThroughput": {
                     "type": "integer",

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -614,7 +614,6 @@ namespace Pulumi.Eks
         {
             NodeRootVolumeDeleteOnTermination = true;
             NodeRootVolumeEncrypted = false;
-            NodeRootVolumeSize = 20;
             NodeRootVolumeType = "gp2";
         }
     }

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -612,9 +612,6 @@ namespace Pulumi.Eks
 
         public ClusterArgs()
         {
-            NodeRootVolumeDeleteOnTermination = true;
-            NodeRootVolumeEncrypted = false;
-            NodeRootVolumeType = "gp2";
         }
     }
 

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -51,9 +51,6 @@ func NewCluster(ctx *pulumi.Context,
 	if isZero(args.NodeRootVolumeEncrypted) {
 		args.NodeRootVolumeEncrypted = pulumi.BoolPtr(false)
 	}
-	if isZero(args.NodeRootVolumeSize) {
-		args.NodeRootVolumeSize = pulumi.IntPtr(20)
-	}
 	if isZero(args.NodeRootVolumeType) {
 		args.NodeRootVolumeType = pulumi.StringPtr("gp2")
 	}

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -45,15 +45,6 @@ func NewCluster(ctx *pulumi.Context,
 		args = &ClusterArgs{}
 	}
 
-	if isZero(args.NodeRootVolumeDeleteOnTermination) {
-		args.NodeRootVolumeDeleteOnTermination = pulumi.BoolPtr(true)
-	}
-	if isZero(args.NodeRootVolumeEncrypted) {
-		args.NodeRootVolumeEncrypted = pulumi.BoolPtr(false)
-	}
-	if isZero(args.NodeRootVolumeType) {
-		args.NodeRootVolumeType = pulumi.StringPtr("gp2")
-	}
 	var resource Cluster
 	err := ctx.RegisterRemoteComponentResource("eks:index:Cluster", name, args, &resource, opts...)
 	if err != nil {

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -2564,7 +2564,6 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         public ClusterArgs build() {
             $.nodeRootVolumeDeleteOnTermination = Codegen.booleanProp("nodeRootVolumeDeleteOnTermination").output().arg($.nodeRootVolumeDeleteOnTermination).def(true).getNullable();
             $.nodeRootVolumeEncrypted = Codegen.booleanProp("nodeRootVolumeEncrypted").output().arg($.nodeRootVolumeEncrypted).def(false).getNullable();
-            $.nodeRootVolumeSize = Codegen.integerProp("nodeRootVolumeSize").output().arg($.nodeRootVolumeSize).def(20).getNullable();
             $.nodeRootVolumeType = Codegen.stringProp("nodeRootVolumeType").output().arg($.nodeRootVolumeType).def("gp2").getNullable();
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -8,7 +8,6 @@ import com.pulumi.aws.iam.Role;
 import com.pulumi.core.Either;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import com.pulumi.core.internal.Codegen;
 import com.pulumi.eks.inputs.ClusterNodeGroupOptionsArgs;
 import com.pulumi.eks.inputs.CreationRoleProviderArgs;
 import com.pulumi.eks.inputs.FargateProfileArgs;
@@ -2562,9 +2561,6 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ClusterArgs build() {
-            $.nodeRootVolumeDeleteOnTermination = Codegen.booleanProp("nodeRootVolumeDeleteOnTermination").output().arg($.nodeRootVolumeDeleteOnTermination).def(true).getNullable();
-            $.nodeRootVolumeEncrypted = Codegen.booleanProp("nodeRootVolumeEncrypted").output().arg($.nodeRootVolumeEncrypted).def(false).getNullable();
-            $.nodeRootVolumeType = Codegen.stringProp("nodeRootVolumeType").output().arg($.nodeRootVolumeType).def("gp2").getNullable();
             return $;
         }
     }

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -295,8 +295,6 @@ class ClusterArgs:
             pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
         if node_root_volume_iops is not None:
             pulumi.set(__self__, "node_root_volume_iops", node_root_volume_iops)
-        if node_root_volume_size is None:
-            node_root_volume_size = 20
         if node_root_volume_size is not None:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
         if node_root_volume_throughput is not None:
@@ -1413,8 +1411,6 @@ class Cluster(pulumi.ComponentResource):
                 node_root_volume_encrypted = False
             __props__.__dict__["node_root_volume_encrypted"] = node_root_volume_encrypted
             __props__.__dict__["node_root_volume_iops"] = node_root_volume_iops
-            if node_root_volume_size is None:
-                node_root_volume_size = 20
             __props__.__dict__["node_root_volume_size"] = node_root_volume_size
             __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
             if node_root_volume_type is None:

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -285,12 +285,8 @@ class ClusterArgs:
             pulumi.set(__self__, "node_group_options", node_group_options)
         if node_public_key is not None:
             pulumi.set(__self__, "node_public_key", node_public_key)
-        if node_root_volume_delete_on_termination is None:
-            node_root_volume_delete_on_termination = True
         if node_root_volume_delete_on_termination is not None:
             pulumi.set(__self__, "node_root_volume_delete_on_termination", node_root_volume_delete_on_termination)
-        if node_root_volume_encrypted is None:
-            node_root_volume_encrypted = False
         if node_root_volume_encrypted is not None:
             pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
         if node_root_volume_iops is not None:
@@ -299,8 +295,6 @@ class ClusterArgs:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
         if node_root_volume_throughput is not None:
             pulumi.set(__self__, "node_root_volume_throughput", node_root_volume_throughput)
-        if node_root_volume_type is None:
-            node_root_volume_type = 'gp2'
         if node_root_volume_type is not None:
             pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group_tags is not None:
@@ -1404,17 +1398,11 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["node_associate_public_ip_address"] = node_associate_public_ip_address
             __props__.__dict__["node_group_options"] = node_group_options
             __props__.__dict__["node_public_key"] = node_public_key
-            if node_root_volume_delete_on_termination is None:
-                node_root_volume_delete_on_termination = True
             __props__.__dict__["node_root_volume_delete_on_termination"] = node_root_volume_delete_on_termination
-            if node_root_volume_encrypted is None:
-                node_root_volume_encrypted = False
             __props__.__dict__["node_root_volume_encrypted"] = node_root_volume_encrypted
             __props__.__dict__["node_root_volume_iops"] = node_root_volume_iops
             __props__.__dict__["node_root_volume_size"] = node_root_volume_size
             __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
-            if node_root_volume_type is None:
-                node_root_volume_type = 'gp2'
             __props__.__dict__["node_root_volume_type"] = node_root_volume_type
             __props__.__dict__["node_security_group_tags"] = node_security_group_tags
             __props__.__dict__["node_subnet_ids"] = node_subnet_ids


### PR DESCRIPTION
PR #641 added a default value to the Cluster argument `nodeRootVolumeSize`, which causes all the generated SDKs to give this field a default value if not supplied. However, https://github.com/pulumi/pulumi-eks/blob/aab0ed9cd224a8b0a4d9f9edf65b535cfd36be38/nodejs/eks/cluster.ts#L231 checks that _either_ the argument `nodeGroupOptions` _or_ individual arguments including `nodeRootVolumeSize` are provided, and not both. Since `nodeRootVolumeSize` always has a value, this means that if you supply `nodeGroupOptions`, it will fail to create your cluster.

On the basis that the platform applies the default and the SDK does not need to, this PR removes the default for that specific field from the schema.

Fixes #643.