### PR TITLE
Adopt plain types in the schema to match the implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Remove default for NodeRootVolumeSize that conflicted with NodeGroupOptions #813](https://github.com/pulumi/pulumi-eks/pull/813)
 - [Add support for passing Cluster to NodeGroup/NodeGroupV2/ManagedNodeGroup in all languages #815](https://github.com/pulumi/pulumi-eks/pull/815)
 - [Add kubeconfigJson output property to Cluster #815](https://github.com/pulumi/pulumi-eks/pull/815)
+- [Adopt plain types in the schema to match the implementation #819](https://github.com/pulumi/pulumi-eks/pull/819)
 
 ## 0.42.2 (Released Oct 12, 2022)
 - Fix internal registration of NodeGroupV2 resource.

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -242,8 +242,8 @@ export function generateKubeconfig(
 }
 
 export interface ClusterCreationRoleProviderOptions {
-    region?: aws.Region;
-    profile?: string;
+    region?: pulumi.Input<aws.Region>;
+    profile?: pulumi.Input<string>;
 }
 
 /**
@@ -282,8 +282,8 @@ export class ClusterCreationRoleProvider extends pulumi.ComponentResource implem
  */
 export function getRoleProvider(
     name: string,
-    region?: aws.Region,
-    profile?: string,
+    region?: pulumi.Input<aws.Region>,
+    profile?: pulumi.Input<string>,
     parent?: pulumi.ComponentResource,
     provider?: pulumi.ProviderResource,
 ): CreationRoleProvider {

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -276,11 +276,17 @@ func generateSchema() schema.PackageSpec {
 							"Also consider setting `nodeAssociatePublicIpAddress: false` for fully private workers.",
 					},
 					"nodeGroupOptions": {
-						TypeSpec:    schema.TypeSpec{Ref: "#/types/eks:index:ClusterNodeGroupOptions"},
+						TypeSpec: schema.TypeSpec{
+							Ref:   "#/types/eks:index:ClusterNodeGroupOptions",
+							Plain: true,
+						},
 						Description: "The common configuration settings for NodeGroups.",
 					},
 					"nodeAssociatePublicIpAddress": {
-						TypeSpec: schema.TypeSpec{Type: "boolean"},
+						TypeSpec: schema.TypeSpec{
+							Type:  "boolean",
+							Plain: true,
+						},
 						Description: "Whether or not to auto-assign the EKS worker nodes public IP addresses. If " +
 							"this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, " +
 							"they will not be auto-assigned public IPs.",
@@ -300,12 +306,18 @@ func generateSchema() schema.PackageSpec {
 						Description: "Optional mappings from AWS IAM users to Kubernetes users and groups.",
 					},
 					"vpcCniOptions": {
-						TypeSpec: schema.TypeSpec{Ref: "#/types/eks:index:VpcCniOptions"},
+						TypeSpec: schema.TypeSpec{
+							Ref:   "#/types/eks:index:VpcCniOptions",
+							Plain: true,
+						},
 						Description: "The configuration of the Amazon VPC CNI plugin for this instance. Defaults are " +
 							"described in the documentation for the VpcCniOptions type.",
 					},
 					"useDefaultVpcCni": {
-						TypeSpec:    schema.TypeSpec{Type: "boolean"},
+						TypeSpec: schema.TypeSpec{
+							Type:  "boolean",
+							Plain: true,
+						},
 						Description: "Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.",
 					},
 					"instanceType": {
@@ -330,7 +342,10 @@ func generateSchema() schema.PackageSpec {
 					},
 					"creationRoleProvider": {
 						// Note: It'd be nice if we could pass the ClusterCreationRoleProvider component here.
-						TypeSpec: schema.TypeSpec{Ref: "#/types/eks:index:CreationRoleProvider"},
+						TypeSpec: schema.TypeSpec{
+							Ref:   "#/types/eks:index:CreationRoleProvider",
+							Plain: true,
+						},
 						Description: "The IAM Role Provider used to create & authenticate against the EKS cluster. " +
 							"This role is given `[system:masters]` permission in K8S, See: " +
 							"https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
@@ -374,7 +389,10 @@ func generateSchema() schema.PackageSpec {
 						Description: "The subnets to use for worker nodes. Defaults to the value of subnetIds.",
 					},
 					"clusterSecurityGroup": {
-						TypeSpec: schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup")},
+						TypeSpec: schema.TypeSpec{
+							Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
+							Plain: true,
+						},
 						Description: "The security group to use for the cluster API endpoint. If not provided, a new " +
 							"security group will be created with full internet egress and ingress from node groups.",
 					},
@@ -444,9 +462,20 @@ func generateSchema() schema.PackageSpec {
 					"storageClasses": {
 						TypeSpec: schema.TypeSpec{
 							OneOf: []schema.TypeSpec{
-								{Type: "string"}, // TODO: EBSVolumeType enum "io1" | "gp2" | "sc1" | "st1"
-								{Type: "object", AdditionalProperties: &schema.TypeSpec{Ref: "#/types/eks:index:StorageClass"}},
+								{
+									Type:  "string", // TODO: EBSVolumeType enum "io1" | "gp2" | "sc1" | "st1"
+									Plain: true,
+								},
+								{
+									Type: "object",
+									AdditionalProperties: &schema.TypeSpec{
+										Ref:   "#/types/eks:index:StorageClass",
+										Plain: true,
+									},
+									Plain: true,
+								},
 							},
+							Plain: true,
 						},
 						Description: "An optional set of StorageClasses to enable for the cluster. If this is a " +
 							"single volume type rather than a map, a single StorageClass will be created for that " +
@@ -456,7 +485,10 @@ func generateSchema() schema.PackageSpec {
 							"https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html",
 					},
 					"skipDefaultNodeGroup": {
-						TypeSpec: schema.TypeSpec{Type: "boolean"},
+						TypeSpec: schema.TypeSpec{
+							Type:  "boolean",
+							Plain: true,
+						},
 						Description: "If this toggle is set to true, the EKS cluster will be created without node " +
 							"group attached. Defaults to false, unless `fargate` input is provided.",
 					},
@@ -544,7 +576,10 @@ func generateSchema() schema.PackageSpec {
 							"https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming",
 					},
 					"proxy": {
-						TypeSpec: schema.TypeSpec{Type: "string"},
+						TypeSpec: schema.TypeSpec{
+							Type:  "string",
+							Plain: true,
+						},
 						Description: "The HTTP(S) proxy to use within a proxied environment.\n\n The proxy is used " +
 							"during cluster creation, and OIDC configuration.\n\nThis is an alternative option to " +
 							"setting the proxy environment variables: HTTP(S)_PROXY and/or http(s)_proxy.\n\nThis " +
@@ -1021,10 +1056,16 @@ func generateSchema() schema.PackageSpec {
 						"https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
 					Properties: map[string]schema.PropertySpec{
 						"role": {
-							TypeSpec: schema.TypeSpec{Ref: awsRef("#/resources/aws:iam%2Frole:Role")},
+							TypeSpec: schema.TypeSpec{
+								Ref:   awsRef("#/resources/aws:iam%2Frole:Role"),
+								Plain: true,
+							},
 						},
 						"provider": {
-							TypeSpec: schema.TypeSpec{Ref: awsRef("#/provider")},
+							TypeSpec: schema.TypeSpec{
+								Ref:   awsRef("#/provider"),
+								Plain: true,
+							},
 						},
 					},
 					Required: []string{
@@ -1243,11 +1284,17 @@ func generateSchema() schema.PackageSpec {
 						"See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.",
 					Properties: map[string]schema.PropertySpec{
 						"value": {
-							TypeSpec:    schema.TypeSpec{Type: "string"},
+							TypeSpec: schema.TypeSpec{
+								Type:  "string",
+								Plain: true,
+							},
 							Description: "The value of the taint.",
 						},
 						"effect": {
-							TypeSpec:    schema.TypeSpec{Type: "string"}, // TODO strict string enum: "NoSchedule" | "NoExecute" | "PreferNoSchedule".
+							TypeSpec: schema.TypeSpec{
+								Type:  "string", // TODO strict string enum: "NoSchedule" | "NoExecute" | "PreferNoSchedule".
+								Plain: true,
+							},
 							Description: "The effect of the taint.",
 						},
 					},
@@ -1372,7 +1419,10 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"worker node.",
 		},
 		"nodeSecurityGroup": {
-			TypeSpec: schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup")},
+			TypeSpec: schema.TypeSpec{
+				Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
+				Plain: true,
+			},
 			Description: "The security group for the worker node group to communicate with the cluster.\n\n" +
 				"This security group requires specific inbound and outbound rules.\n\n" +
 				"See for more details:\n" +
@@ -1381,13 +1431,20 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"mutually exclusive.",
 		},
 		"clusterIngressRule": {
-			TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule")},
+			TypeSpec: schema.TypeSpec{
+				Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule"),
+				Plain: true,
+			},
 			Description: "The ingress rule that gives node group access.",
 		},
 		"extraNodeSecurityGroups": {
 			TypeSpec: schema.TypeSpec{
-				Type:  "array",
-				Items: &schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup")},
+				Type: "array",
+				Items: &schema.TypeSpec{
+					Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
+					Plain: true,
+				},
+				Plain: true,
 			},
 			Description: "Extra security groups to attach on all nodes in this worker node group.\n\n" +
 				"This additional set of security groups captures any user application rules that will be " +
@@ -1460,22 +1517,33 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		},
 		"labels": {
 			TypeSpec: schema.TypeSpec{
-				Type:                 "object",
-				AdditionalProperties: &schema.TypeSpec{Type: "string"},
+				Type: "object",
+				AdditionalProperties: &schema.TypeSpec{
+					Type:  "string",
+					Plain: true,
+				},
+				Plain: true,
 			},
 			Description: "Custom k8s node labels to be attached to each worker node. Adds the given " +
 				"key/value pairs to the `--node-labels` kubelet argument.",
 		},
 		"taints": {
 			TypeSpec: schema.TypeSpec{
-				Type:                 "object",
-				AdditionalProperties: &schema.TypeSpec{Ref: "#/types/eks:index:Taint"},
+				Type: "object",
+				AdditionalProperties: &schema.TypeSpec{
+					Ref:   "#/types/eks:index:Taint",
+					Plain: true,
+				},
+				Plain: true,
 			},
 			Description: "Custom k8s node taints to be attached to each worker node. Adds the given " +
 				"taints to the `--register-with-taints` kubelet argument",
 		},
 		"kubeletExtraArgs": {
-			TypeSpec: schema.TypeSpec{Type: "string"},
+			TypeSpec: schema.TypeSpec{
+				Type:  "string",
+				Plain: true,
+			},
 			Description: "Extra args to pass to the Kubelet. Corresponds to the options passed in the " +
 				"`--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, " +
 				"'--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will " +
@@ -1483,7 +1551,10 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"respectively) after to the explicit `kubeletExtraArgs`.",
 		},
 		"bootstrapExtraArgs": {
-			TypeSpec: schema.TypeSpec{Type: "string"},
+			TypeSpec: schema.TypeSpec{
+				Type:  "string",
+				Plain: true,
+			},
 			Description: "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on " +
 				"available options, see: " +
 				"https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. " +
@@ -1491,7 +1562,10 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"flags are included automatically based on other configuration parameters.",
 		},
 		"nodeAssociatePublicIpAddress": {
-			TypeSpec: schema.TypeSpec{Type: "boolean"},
+			TypeSpec: schema.TypeSpec{
+				Type:  "boolean",
+				Plain: true,
+			},
 			Description: "Whether or not to auto-assign public IP addresses on the EKS worker nodes. If " +
 				"this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, " +
 				"they will not be auto-assigned public IPs.",
@@ -1502,7 +1576,10 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"value, the latest available version is used.",
 		},
 		"instanceProfile": {
-			TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:iam%2FinstanceProfile:InstanceProfile")},
+			TypeSpec: schema.TypeSpec{
+				Ref:   awsRef("#/resources/aws:iam%2FinstanceProfile:InstanceProfile"),
+				Plain: true,
+			},
 			Description: "The ingress rule that gives node group access.",
 		},
 		"autoScalingGroupTags": {

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -31,6 +31,7 @@
                 },
                 "bootstrapExtraArgs": {
                     "type": "string",
+                    "plain": true,
                     "description": "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters."
                 },
                 "cloudFormationTags": {
@@ -42,6 +43,7 @@
                 },
                 "clusterIngressRule": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
@@ -55,8 +57,10 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
                 "gpu": {
@@ -65,6 +69,7 @@
                 },
                 "instanceProfile": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "instanceType": {
@@ -77,13 +82,16 @@
                 },
                 "kubeletExtraArgs": {
                     "type": "string",
+                    "plain": true,
                     "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`."
                 },
                 "labels": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument."
                 },
                 "maxSize": {
@@ -96,6 +104,7 @@
                 },
                 "nodeAssociatePublicIpAddress": {
                     "type": "boolean",
+                    "plain": true,
                     "description": "Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
                 },
                 "nodePublicKey": {
@@ -108,6 +117,7 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "plain": true,
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
@@ -132,8 +142,10 @@
                 "taints": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/types/eks:index:Taint"
+                        "$ref": "#/types/eks:index:Taint",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument"
                 },
                 "version": {
@@ -249,10 +261,12 @@
             "description": "Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
             "properties": {
                 "provider": {
-                    "$ref": "/aws/v5.4.0/schema.json#/provider"
+                    "$ref": "/aws/v5.4.0/schema.json#/provider",
+                    "plain": true
                 },
                 "role": {
-                    "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2Frole:Role"
+                    "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "plain": true
                 }
             },
             "type": "object",
@@ -420,10 +434,12 @@
             "properties": {
                 "effect": {
                     "type": "string",
+                    "plain": true,
                     "description": "The effect of the taint."
                 },
                 "value": {
                     "type": "string",
+                    "plain": true,
                     "description": "The value of the taint."
                 }
             },
@@ -613,6 +629,7 @@
             "inputProperties": {
                 "clusterSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "plain": true,
                     "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups."
                 },
                 "clusterSecurityGroupTags": {
@@ -635,6 +652,7 @@
                 },
                 "creationRoleProvider": {
                     "$ref": "#/types/eks:index:CreationRoleProvider",
+                    "plain": true,
                     "description": "The IAM Role Provider used to create \u0026 authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html"
                 },
                 "defaultAddonsToRemove": {
@@ -727,10 +745,12 @@
                 },
                 "nodeAssociatePublicIpAddress": {
                     "type": "boolean",
+                    "plain": true,
                     "description": "Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
                 },
                 "nodeGroupOptions": {
                     "$ref": "#/types/eks:index:ClusterNodeGroupOptions",
+                    "plain": true,
                     "description": "The common configuration settings for NodeGroups."
                 },
                 "nodePublicKey": {
@@ -792,6 +812,7 @@
                 },
                 "proxy": {
                     "type": "string",
+                    "plain": true,
                     "description": "The HTTP(S) proxy to use within a proxied environment.\n\n The proxy is used during cluster creation, and OIDC configuration.\n\nThis is an alternative option to setting the proxy environment variables: HTTP(S)_PROXY and/or http(s)_proxy.\n\nThis option is required iff the proxy environment variables are not set.\n\nFormat:      \u003cprotocol\u003e://\u003chost\u003e:\u003cport\u003e\nAuth Format: \u003cprotocol\u003e://\u003cusername\u003e:\u003cpassword\u003e@\u003chost\u003e:\u003cport\u003e\n\nEx:\n  - \"http://proxy.example.com:3128\"\n  - \"https://proxy.example.com\"\n  - \"http://username:password@proxy.example.com:3128\""
                 },
                 "publicAccessCidrs": {
@@ -821,20 +842,25 @@
                 },
                 "skipDefaultNodeGroup": {
                     "type": "boolean",
+                    "plain": true,
                     "description": "If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided."
                 },
                 "storageClasses": {
                     "oneOf": [
                         {
-                            "type": "string"
+                            "type": "string",
+                            "plain": true
                         },
                         {
                             "type": "object",
                             "additionalProperties": {
-                                "$ref": "#/types/eks:index:StorageClass"
-                            }
+                                "$ref": "#/types/eks:index:StorageClass",
+                                "plain": true
+                            },
+                            "plain": true
                         }
                     ],
+                    "plain": true,
                     "description": "An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.\n\nNote: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html"
                 },
                 "subnetIds": {
@@ -853,6 +879,7 @@
                 },
                 "useDefaultVpcCni": {
                     "type": "boolean",
+                    "plain": true,
                     "description": "Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`."
                 },
                 "userMappings": {
@@ -868,6 +895,7 @@
                 },
                 "vpcCniOptions": {
                     "$ref": "#/types/eks:index:VpcCniOptions",
+                    "plain": true,
                     "description": "The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type."
                 },
                 "vpcId": {
@@ -1070,6 +1098,7 @@
                 },
                 "bootstrapExtraArgs": {
                     "type": "string",
+                    "plain": true,
                     "description": "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters."
                 },
                 "cloudFormationTags": {
@@ -1092,6 +1121,7 @@
                 },
                 "clusterIngressRule": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
@@ -1105,8 +1135,10 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
                 "gpu": {
@@ -1115,6 +1147,7 @@
                 },
                 "instanceProfile": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "instanceType": {
@@ -1127,13 +1160,16 @@
                 },
                 "kubeletExtraArgs": {
                     "type": "string",
+                    "plain": true,
                     "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`."
                 },
                 "labels": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument."
                 },
                 "maxSize": {
@@ -1146,6 +1182,7 @@
                 },
                 "nodeAssociatePublicIpAddress": {
                     "type": "boolean",
+                    "plain": true,
                     "description": "Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
                 },
                 "nodePublicKey": {
@@ -1158,6 +1195,7 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "plain": true,
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
@@ -1182,8 +1220,10 @@
                 "taints": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/types/eks:index:Taint"
+                        "$ref": "#/types/eks:index:Taint",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument"
                 },
                 "version": {
@@ -1282,6 +1322,7 @@
                 },
                 "bootstrapExtraArgs": {
                     "type": "string",
+                    "plain": true,
                     "description": "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters."
                 },
                 "cloudFormationTags": {
@@ -1304,6 +1345,7 @@
                 },
                 "clusterIngressRule": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
@@ -1317,8 +1359,10 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
                 "gpu": {
@@ -1327,6 +1371,7 @@
                 },
                 "instanceProfile": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "instanceType": {
@@ -1339,13 +1384,16 @@
                 },
                 "kubeletExtraArgs": {
                     "type": "string",
+                    "plain": true,
                     "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`."
                 },
                 "labels": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument."
                 },
                 "launchTemplateTagSpecifications": {
@@ -1369,6 +1417,7 @@
                 },
                 "nodeAssociatePublicIpAddress": {
                     "type": "boolean",
+                    "plain": true,
                     "description": "Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs."
                 },
                 "nodePublicKey": {
@@ -1381,6 +1430,7 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "plain": true,
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
@@ -1405,8 +1455,10 @@
                 "taints": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/types/eks:index:Taint"
+                        "$ref": "#/types/eks:index:Taint",
+                        "plain": true
                     },
+                    "plain": true,
                     "description": "Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument"
                 },
                 "version": {

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -120,7 +120,7 @@ namespace Pulumi.Eks
         /// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         /// </summary>
         [Input("clusterSecurityGroup")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroup>? ClusterSecurityGroup { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroup? ClusterSecurityGroup { get; set; }
 
         [Input("clusterSecurityGroupTags")]
         private InputMap<string>? _clusterSecurityGroupTags;
@@ -164,7 +164,7 @@ namespace Pulumi.Eks
         /// The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         /// </summary>
         [Input("creationRoleProvider")]
-        public Input<Inputs.CreationRoleProviderArgs>? CreationRoleProvider { get; set; }
+        public Inputs.CreationRoleProviderArgs? CreationRoleProvider { get; set; }
 
         [Input("defaultAddonsToRemove")]
         private InputList<string>? _defaultAddonsToRemove;
@@ -332,13 +332,13 @@ namespace Pulumi.Eks
         /// Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         /// </summary>
         [Input("nodeAssociatePublicIpAddress")]
-        public Input<bool>? NodeAssociatePublicIpAddress { get; set; }
+        public bool? NodeAssociatePublicIpAddress { get; set; }
 
         /// <summary>
         /// The common configuration settings for NodeGroups.
         /// </summary>
         [Input("nodeGroupOptions")]
-        public Input<Inputs.ClusterNodeGroupOptionsArgs>? NodeGroupOptions { get; set; }
+        public Inputs.ClusterNodeGroupOptionsArgs? NodeGroupOptions { get; set; }
 
         /// <summary>
         /// Public key material for SSH access to worker nodes. See allowed formats at:
@@ -478,7 +478,7 @@ namespace Pulumi.Eks
         ///   - "http://username:password@proxy.example.com:3128"
         /// </summary>
         [Input("proxy")]
-        public Input<string>? Proxy { get; set; }
+        public string? Proxy { get; set; }
 
         [Input("publicAccessCidrs")]
         private InputList<string>? _publicAccessCidrs;
@@ -538,7 +538,7 @@ namespace Pulumi.Eks
         /// If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
         /// </summary>
         [Input("skipDefaultNodeGroup")]
-        public Input<bool>? SkipDefaultNodeGroup { get; set; }
+        public bool? SkipDefaultNodeGroup { get; set; }
 
         /// <summary>
         /// An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
@@ -546,7 +546,7 @@ namespace Pulumi.Eks
         /// Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
         /// </summary>
         [Input("storageClasses")]
-        public InputUnion<string, ImmutableDictionary<string, Inputs.StorageClassArgs>>? StorageClasses { get; set; }
+        public Union<string, ImmutableDictionary<string, Inputs.StorageClassArgs>>? StorageClasses { get; set; }
 
         [Input("subnetIds")]
         private InputList<string>? _subnetIds;
@@ -584,7 +584,7 @@ namespace Pulumi.Eks
         /// Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
         /// </summary>
         [Input("useDefaultVpcCni")]
-        public Input<bool>? UseDefaultVpcCni { get; set; }
+        public bool? UseDefaultVpcCni { get; set; }
 
         [Input("userMappings")]
         private InputList<Inputs.UserMappingArgs>? _userMappings;
@@ -608,7 +608,7 @@ namespace Pulumi.Eks
         /// The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
         /// </summary>
         [Input("vpcCniOptions")]
-        public Input<Inputs.VpcCniOptionsArgs>? VpcCniOptions { get; set; }
+        public Inputs.VpcCniOptionsArgs? VpcCniOptions { get; set; }
 
         /// <summary>
         /// The VPC in which to create the cluster and its worker nodes. If unset, the cluster will be created in the default VPC.

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -58,7 +58,7 @@ namespace Pulumi.Eks.Inputs
         /// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         /// </summary>
         [Input("bootstrapExtraArgs")]
-        public Input<string>? BootstrapExtraArgs { get; set; }
+        public string? BootstrapExtraArgs { get; set; }
 
         [Input("cloudFormationTags")]
         private InputMap<string>? _cloudFormationTags;
@@ -78,7 +78,7 @@ namespace Pulumi.Eks.Inputs
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("clusterIngressRule")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -93,16 +93,16 @@ namespace Pulumi.Eks.Inputs
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private InputList<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
+        private List<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public InputList<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
+        public List<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new InputList<Pulumi.Aws.Ec2.SecurityGroup>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Pulumi.Aws.Ec2.SecurityGroup>());
             set => _extraNodeSecurityGroups = value;
         }
 
@@ -124,7 +124,7 @@ namespace Pulumi.Eks.Inputs
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("instanceProfile")]
-        public Input<Pulumi.Aws.Iam.InstanceProfile>? InstanceProfile { get; set; }
+        public Pulumi.Aws.Iam.InstanceProfile? InstanceProfile { get; set; }
 
         /// <summary>
         /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
@@ -142,17 +142,17 @@ namespace Pulumi.Eks.Inputs
         /// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         /// </summary>
         [Input("kubeletExtraArgs")]
-        public Input<string>? KubeletExtraArgs { get; set; }
+        public string? KubeletExtraArgs { get; set; }
 
         [Input("labels")]
-        private InputMap<string>? _labels;
+        private Dictionary<string, string>? _labels;
 
         /// <summary>
         /// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         /// </summary>
-        public InputMap<string> Labels
+        public Dictionary<string, string> Labels
         {
-            get => _labels ?? (_labels = new InputMap<string>());
+            get => _labels ?? (_labels = new Dictionary<string, string>());
             set => _labels = value;
         }
 
@@ -172,7 +172,7 @@ namespace Pulumi.Eks.Inputs
         /// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         /// </summary>
         [Input("nodeAssociatePublicIpAddress")]
-        public Input<bool>? NodeAssociatePublicIpAddress { get; set; }
+        public bool? NodeAssociatePublicIpAddress { get; set; }
 
         /// <summary>
         /// Public key material for SSH access to worker nodes. See allowed formats at:
@@ -199,7 +199,7 @@ namespace Pulumi.Eks.Inputs
         /// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         /// </summary>
         [Input("nodeSecurityGroup")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;
@@ -236,14 +236,14 @@ namespace Pulumi.Eks.Inputs
         public Input<string>? SpotPrice { get; set; }
 
         [Input("taints")]
-        private InputMap<Inputs.TaintArgs>? _taints;
+        private Dictionary<string, Inputs.TaintArgs>? _taints;
 
         /// <summary>
         /// Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         /// </summary>
-        public InputMap<Inputs.TaintArgs> Taints
+        public Dictionary<string, Inputs.TaintArgs> Taints
         {
-            get => _taints ?? (_taints = new InputMap<Inputs.TaintArgs>());
+            get => _taints ?? (_taints = new Dictionary<string, Inputs.TaintArgs>());
             set => _taints = value;
         }
 

--- a/sdk/dotnet/Inputs/CreationRoleProviderArgs.cs
+++ b/sdk/dotnet/Inputs/CreationRoleProviderArgs.cs
@@ -16,10 +16,10 @@ namespace Pulumi.Eks.Inputs
     public sealed class CreationRoleProviderArgs : Pulumi.ResourceArgs
     {
         [Input("provider", required: true)]
-        public Input<Pulumi.Aws.Provider> Provider { get; set; } = null!;
+        public Pulumi.Aws.Provider Provider { get; set; } = null!;
 
         [Input("role", required: true)]
-        public Input<Pulumi.Aws.Iam.Role> Role { get; set; } = null!;
+        public Pulumi.Aws.Iam.Role Role { get; set; } = null!;
 
         public CreationRoleProviderArgs()
         {

--- a/sdk/dotnet/Inputs/TaintArgs.cs
+++ b/sdk/dotnet/Inputs/TaintArgs.cs
@@ -19,13 +19,13 @@ namespace Pulumi.Eks.Inputs
         /// The effect of the taint.
         /// </summary>
         [Input("effect", required: true)]
-        public Input<string> Effect { get; set; } = null!;
+        public string Effect { get; set; } = null!;
 
         /// <summary>
         /// The value of the taint.
         /// </summary>
         [Input("value", required: true)]
-        public Input<string> Value { get; set; } = null!;
+        public string Value { get; set; } = null!;
 
         public TaintArgs()
         {

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -110,7 +110,7 @@ namespace Pulumi.Eks
         /// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         /// </summary>
         [Input("bootstrapExtraArgs")]
-        public Input<string>? BootstrapExtraArgs { get; set; }
+        public string? BootstrapExtraArgs { get; set; }
 
         [Input("cloudFormationTags")]
         private InputMap<string>? _cloudFormationTags;
@@ -136,7 +136,7 @@ namespace Pulumi.Eks
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("clusterIngressRule")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -151,16 +151,16 @@ namespace Pulumi.Eks
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private InputList<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
+        private List<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public InputList<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
+        public List<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new InputList<Pulumi.Aws.Ec2.SecurityGroup>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Pulumi.Aws.Ec2.SecurityGroup>());
             set => _extraNodeSecurityGroups = value;
         }
 
@@ -182,7 +182,7 @@ namespace Pulumi.Eks
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("instanceProfile")]
-        public Input<Pulumi.Aws.Iam.InstanceProfile>? InstanceProfile { get; set; }
+        public Pulumi.Aws.Iam.InstanceProfile? InstanceProfile { get; set; }
 
         /// <summary>
         /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
@@ -200,17 +200,17 @@ namespace Pulumi.Eks
         /// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         /// </summary>
         [Input("kubeletExtraArgs")]
-        public Input<string>? KubeletExtraArgs { get; set; }
+        public string? KubeletExtraArgs { get; set; }
 
         [Input("labels")]
-        private InputMap<string>? _labels;
+        private Dictionary<string, string>? _labels;
 
         /// <summary>
         /// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         /// </summary>
-        public InputMap<string> Labels
+        public Dictionary<string, string> Labels
         {
-            get => _labels ?? (_labels = new InputMap<string>());
+            get => _labels ?? (_labels = new Dictionary<string, string>());
             set => _labels = value;
         }
 
@@ -230,7 +230,7 @@ namespace Pulumi.Eks
         /// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         /// </summary>
         [Input("nodeAssociatePublicIpAddress")]
-        public Input<bool>? NodeAssociatePublicIpAddress { get; set; }
+        public bool? NodeAssociatePublicIpAddress { get; set; }
 
         /// <summary>
         /// Public key material for SSH access to worker nodes. See allowed formats at:
@@ -257,7 +257,7 @@ namespace Pulumi.Eks
         /// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         /// </summary>
         [Input("nodeSecurityGroup")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;
@@ -294,14 +294,14 @@ namespace Pulumi.Eks
         public Input<string>? SpotPrice { get; set; }
 
         [Input("taints")]
-        private InputMap<Inputs.TaintArgs>? _taints;
+        private Dictionary<string, Inputs.TaintArgs>? _taints;
 
         /// <summary>
         /// Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         /// </summary>
-        public InputMap<Inputs.TaintArgs> Taints
+        public Dictionary<string, Inputs.TaintArgs> Taints
         {
-            get => _taints ?? (_taints = new InputMap<Inputs.TaintArgs>());
+            get => _taints ?? (_taints = new Dictionary<string, Inputs.TaintArgs>());
             set => _taints = value;
         }
 

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -104,7 +104,7 @@ namespace Pulumi.Eks
         /// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         /// </summary>
         [Input("bootstrapExtraArgs")]
-        public Input<string>? BootstrapExtraArgs { get; set; }
+        public string? BootstrapExtraArgs { get; set; }
 
         [Input("cloudFormationTags")]
         private InputMap<string>? _cloudFormationTags;
@@ -130,7 +130,7 @@ namespace Pulumi.Eks
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("clusterIngressRule")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -145,16 +145,16 @@ namespace Pulumi.Eks
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private InputList<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
+        private List<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public InputList<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
+        public List<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new InputList<Pulumi.Aws.Ec2.SecurityGroup>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Pulumi.Aws.Ec2.SecurityGroup>());
             set => _extraNodeSecurityGroups = value;
         }
 
@@ -176,7 +176,7 @@ namespace Pulumi.Eks
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("instanceProfile")]
-        public Input<Pulumi.Aws.Iam.InstanceProfile>? InstanceProfile { get; set; }
+        public Pulumi.Aws.Iam.InstanceProfile? InstanceProfile { get; set; }
 
         /// <summary>
         /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
@@ -194,17 +194,17 @@ namespace Pulumi.Eks
         /// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         /// </summary>
         [Input("kubeletExtraArgs")]
-        public Input<string>? KubeletExtraArgs { get; set; }
+        public string? KubeletExtraArgs { get; set; }
 
         [Input("labels")]
-        private InputMap<string>? _labels;
+        private Dictionary<string, string>? _labels;
 
         /// <summary>
         /// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         /// </summary>
-        public InputMap<string> Labels
+        public Dictionary<string, string> Labels
         {
-            get => _labels ?? (_labels = new InputMap<string>());
+            get => _labels ?? (_labels = new Dictionary<string, string>());
             set => _labels = value;
         }
 
@@ -242,7 +242,7 @@ namespace Pulumi.Eks
         /// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         /// </summary>
         [Input("nodeAssociatePublicIpAddress")]
-        public Input<bool>? NodeAssociatePublicIpAddress { get; set; }
+        public bool? NodeAssociatePublicIpAddress { get; set; }
 
         /// <summary>
         /// Public key material for SSH access to worker nodes. See allowed formats at:
@@ -269,7 +269,7 @@ namespace Pulumi.Eks
         /// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         /// </summary>
         [Input("nodeSecurityGroup")]
-        public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
+        public Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;
@@ -306,14 +306,14 @@ namespace Pulumi.Eks
         public Input<string>? SpotPrice { get; set; }
 
         [Input("taints")]
-        private InputMap<Inputs.TaintArgs>? _taints;
+        private Dictionary<string, Inputs.TaintArgs>? _taints;
 
         /// <summary>
         /// Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         /// </summary>
-        public InputMap<Inputs.TaintArgs> Taints
+        public Dictionary<string, Inputs.TaintArgs> Taints
         {
-            get => _taints ?? (_taints = new InputMap<Inputs.TaintArgs>());
+            get => _taints ?? (_taints = new Dictionary<string, Inputs.TaintArgs>());
             set => _taints = value;
         }
 

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -273,7 +273,7 @@ type clusterArgs struct {
 // The set of arguments for constructing a Cluster resource.
 type ClusterArgs struct {
 	// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
-	ClusterSecurityGroup ec2.SecurityGroupInput
+	ClusterSecurityGroup *ec2.SecurityGroup
 	// The tags to apply to the cluster security group.
 	ClusterSecurityGroupTags pulumi.StringMapInput
 	// The tags to apply to the EKS cluster.
@@ -289,7 +289,7 @@ type ClusterArgs struct {
 	//  - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
 	CreateOidcProvider pulumi.BoolPtrInput
 	// The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
-	CreationRoleProvider CreationRoleProviderPtrInput
+	CreationRoleProvider *CreationRoleProviderArgs
 	// List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
 	DefaultAddonsToRemove pulumi.StringArrayInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -363,9 +363,9 @@ type ClusterArgs struct {
 	// - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html.
 	NodeAmiId pulumi.StringPtrInput
 	// Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-	NodeAssociatePublicIpAddress pulumi.BoolPtrInput
+	NodeAssociatePublicIpAddress *bool
 	// The common configuration settings for NodeGroups.
-	NodeGroupOptions ClusterNodeGroupOptionsPtrInput
+	NodeGroupOptions *ClusterNodeGroupOptionsArgs
 	// Public key material for SSH access to worker nodes. See allowed formats at:
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
@@ -435,7 +435,7 @@ type ClusterArgs struct {
 	//   - "http://proxy.example.com:3128"
 	//   - "https://proxy.example.com"
 	//   - "http://username:password@proxy.example.com:3128"
-	Proxy pulumi.StringPtrInput
+	Proxy *string
 	// Indicates which CIDR blocks can access the Amazon EKS public API server endpoint.
 	PublicAccessCidrs pulumi.StringArrayInput
 	// The set of public subnets to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.
@@ -457,11 +457,11 @@ type ClusterArgs struct {
 	// IAM Service Role for EKS to use to manage the cluster.
 	ServiceRole iam.RoleInput
 	// If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
-	SkipDefaultNodeGroup pulumi.BoolPtrInput
+	SkipDefaultNodeGroup *bool
 	// An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
 	//
 	// Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
-	StorageClasses pulumi.Input
+	StorageClasses interface{}
 	// The set of all subnets, public and private, to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.
 	//
 	// If `vpcId` is not set, the cluster will use the AWS account's default VPC subnets.
@@ -475,13 +475,13 @@ type ClusterArgs struct {
 	// Key-value mapping of tags that are automatically applied to all AWS resources directly under management with this cluster, which support tagging.
 	Tags pulumi.StringMapInput
 	// Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
-	UseDefaultVpcCni pulumi.BoolPtrInput
+	UseDefaultVpcCni *bool
 	// Optional mappings from AWS IAM users to Kubernetes users and groups.
 	UserMappings UserMappingArrayInput
 	// Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
 	Version pulumi.StringPtrInput
 	// The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
-	VpcCniOptions VpcCniOptionsPtrInput
+	VpcCniOptions *VpcCniOptionsArgs
 	// The VPC in which to create the cluster and its worker nodes. If unset, the cluster will be created in the default VPC.
 	VpcId pulumi.StringPtrInput
 }

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -169,7 +169,7 @@ type NodeGroupArgs struct {
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
 	AutoScalingGroupTags pulumi.StringMapInput
 	// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
-	BootstrapExtraArgs pulumi.StringPtrInput
+	BootstrapExtraArgs *string
 	// The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
 	//
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
@@ -177,7 +177,7 @@ type NodeGroupArgs struct {
 	// The target EKS cluster.
 	Cluster pulumi.Input
 	// The ingress rule that gives node group access.
-	ClusterIngressRule ec2.SecurityGroupRuleInput
+	ClusterIngressRule *ec2.SecurityGroupRule
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
 	// Encrypt the root block device of the nodes in the node group.
@@ -185,7 +185,7 @@ type NodeGroupArgs struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups ec2.SecurityGroupArrayInput
+	ExtraNodeSecurityGroups []*ec2.SecurityGroup
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.
@@ -197,21 +197,21 @@ type NodeGroupArgs struct {
 	// - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
 	Gpu pulumi.BoolPtrInput
 	// The ingress rule that gives node group access.
-	InstanceProfile iam.InstanceProfileInput
+	InstanceProfile *iam.InstanceProfile
 	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 	InstanceType pulumi.StringPtrInput
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName pulumi.StringPtrInput
 	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-	KubeletExtraArgs pulumi.StringPtrInput
+	KubeletExtraArgs *string
 	// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
-	Labels pulumi.StringMapInput
+	Labels map[string]string
 	// The maximum number of worker nodes running in the cluster. Defaults to 2.
 	MaxSize pulumi.IntPtrInput
 	// The minimum number of worker nodes running in the cluster. Defaults to 1.
 	MinSize pulumi.IntPtrInput
 	// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-	NodeAssociatePublicIpAddress pulumi.BoolPtrInput
+	NodeAssociatePublicIpAddress *bool
 	// Public key material for SSH access to worker nodes. See allowed formats at:
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
@@ -226,7 +226,7 @@ type NodeGroupArgs struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-	NodeSecurityGroup ec2.SecurityGroupInput
+	NodeSecurityGroup *ec2.SecurityGroup
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -240,7 +240,7 @@ type NodeGroupArgs struct {
 	// Bidding price for spot instance. If set, only spot instances will be added as worker node.
 	SpotPrice pulumi.StringPtrInput
 	// Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
-	Taints TaintMapInput
+	Taints map[string]TaintArgs
 	// Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
 	Version pulumi.StringPtrInput
 }

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -171,7 +171,7 @@ type NodeGroupV2Args struct {
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
 	AutoScalingGroupTags pulumi.StringMapInput
 	// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
-	BootstrapExtraArgs pulumi.StringPtrInput
+	BootstrapExtraArgs *string
 	// The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
 	//
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
@@ -179,7 +179,7 @@ type NodeGroupV2Args struct {
 	// The target EKS cluster.
 	Cluster pulumi.Input
 	// The ingress rule that gives node group access.
-	ClusterIngressRule ec2.SecurityGroupRuleInput
+	ClusterIngressRule *ec2.SecurityGroupRule
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
 	// Encrypt the root block device of the nodes in the node group.
@@ -187,7 +187,7 @@ type NodeGroupV2Args struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups ec2.SecurityGroupArrayInput
+	ExtraNodeSecurityGroups []*ec2.SecurityGroup
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.
@@ -199,15 +199,15 @@ type NodeGroupV2Args struct {
 	// - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
 	Gpu pulumi.BoolPtrInput
 	// The ingress rule that gives node group access.
-	InstanceProfile iam.InstanceProfileInput
+	InstanceProfile *iam.InstanceProfile
 	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 	InstanceType pulumi.StringPtrInput
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName pulumi.StringPtrInput
 	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-	KubeletExtraArgs pulumi.StringPtrInput
+	KubeletExtraArgs *string
 	// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
-	Labels pulumi.StringMapInput
+	Labels map[string]string
 	// The tag specifications to apply to the launch template.
 	LaunchTemplateTagSpecifications ec2.LaunchTemplateTagSpecificationArrayInput
 	// The maximum number of worker nodes running in the cluster. Defaults to 2.
@@ -217,7 +217,7 @@ type NodeGroupV2Args struct {
 	// The minimum number of worker nodes running in the cluster. Defaults to 1.
 	MinSize pulumi.IntPtrInput
 	// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-	NodeAssociatePublicIpAddress pulumi.BoolPtrInput
+	NodeAssociatePublicIpAddress *bool
 	// Public key material for SSH access to worker nodes. See allowed formats at:
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
@@ -232,7 +232,7 @@ type NodeGroupV2Args struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-	NodeSecurityGroup ec2.SecurityGroupInput
+	NodeSecurityGroup *ec2.SecurityGroup
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -246,7 +246,7 @@ type NodeGroupV2Args struct {
 	// Bidding price for spot instance. If set, only spot instances will be added as worker node.
 	SpotPrice pulumi.StringPtrInput
 	// Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
-	Taints TaintMapInput
+	Taints map[string]TaintArgs
 	// Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
 	Version pulumi.StringPtrInput
 }

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -152,13 +152,13 @@ type ClusterNodeGroupOptionsArgs struct {
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
 	AutoScalingGroupTags pulumi.StringMapInput `pulumi:"autoScalingGroupTags"`
 	// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
-	BootstrapExtraArgs pulumi.StringPtrInput `pulumi:"bootstrapExtraArgs"`
+	BootstrapExtraArgs *string `pulumi:"bootstrapExtraArgs"`
 	// The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
 	//
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
 	CloudFormationTags pulumi.StringMapInput `pulumi:"cloudFormationTags"`
 	// The ingress rule that gives node group access.
-	ClusterIngressRule ec2.SecurityGroupRuleInput `pulumi:"clusterIngressRule"`
+	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput `pulumi:"desiredCapacity"`
 	// Encrypt the root block device of the nodes in the node group.
@@ -166,7 +166,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups ec2.SecurityGroupArrayInput `pulumi:"extraNodeSecurityGroups"`
+	ExtraNodeSecurityGroups []*ec2.SecurityGroup `pulumi:"extraNodeSecurityGroups"`
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.
@@ -178,21 +178,21 @@ type ClusterNodeGroupOptionsArgs struct {
 	// - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
 	Gpu pulumi.BoolPtrInput `pulumi:"gpu"`
 	// The ingress rule that gives node group access.
-	InstanceProfile iam.InstanceProfileInput `pulumi:"instanceProfile"`
+	InstanceProfile *iam.InstanceProfile `pulumi:"instanceProfile"`
 	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
 	InstanceType pulumi.StringPtrInput `pulumi:"instanceType"`
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName pulumi.StringPtrInput `pulumi:"keyName"`
 	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-	KubeletExtraArgs pulumi.StringPtrInput `pulumi:"kubeletExtraArgs"`
+	KubeletExtraArgs *string `pulumi:"kubeletExtraArgs"`
 	// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
-	Labels pulumi.StringMapInput `pulumi:"labels"`
+	Labels map[string]string `pulumi:"labels"`
 	// The maximum number of worker nodes running in the cluster. Defaults to 2.
 	MaxSize pulumi.IntPtrInput `pulumi:"maxSize"`
 	// The minimum number of worker nodes running in the cluster. Defaults to 1.
 	MinSize pulumi.IntPtrInput `pulumi:"minSize"`
 	// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-	NodeAssociatePublicIpAddress pulumi.BoolPtrInput `pulumi:"nodeAssociatePublicIpAddress"`
+	NodeAssociatePublicIpAddress *bool `pulumi:"nodeAssociatePublicIpAddress"`
 	// Public key material for SSH access to worker nodes. See allowed formats at:
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
@@ -207,7 +207,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-	NodeSecurityGroup ec2.SecurityGroupInput `pulumi:"nodeSecurityGroup"`
+	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -221,7 +221,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// Bidding price for spot instance. If set, only spot instances will be added as worker node.
 	SpotPrice pulumi.StringPtrInput `pulumi:"spotPrice"`
 	// Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
-	Taints TaintMapInput `pulumi:"taints"`
+	Taints map[string]TaintArgs `pulumi:"taints"`
 	// Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
 	Version pulumi.StringPtrInput `pulumi:"version"`
 }
@@ -958,8 +958,8 @@ type CreationRoleProviderInput interface {
 
 // Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
 type CreationRoleProviderArgs struct {
-	Provider aws.ProviderInput `pulumi:"provider"`
-	Role     iam.RoleInput     `pulumi:"role"`
+	Provider *aws.Provider `pulumi:"provider"`
+	Role     *iam.Role     `pulumi:"role"`
 }
 
 func (CreationRoleProviderArgs) ElementType() reflect.Type {
@@ -1601,9 +1601,9 @@ type TaintInput interface {
 // Represents a Kubernetes `taint` to apply to all Nodes in a NodeGroup. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
 type TaintArgs struct {
 	// The effect of the taint.
-	Effect pulumi.StringInput `pulumi:"effect"`
+	Effect string `pulumi:"effect"`
 	// The value of the taint.
-	Value pulumi.StringInput `pulumi:"value"`
+	Value string `pulumi:"value"`
 }
 
 func (TaintArgs) ElementType() reflect.Type {

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -35,13 +35,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="clusterSecurityGroup")
-    private @Nullable Output<SecurityGroup> clusterSecurityGroup;
+    private @Nullable SecurityGroup clusterSecurityGroup;
 
     /**
      * @return The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
      * 
      */
-    public Optional<Output<SecurityGroup>> clusterSecurityGroup() {
+    public Optional<SecurityGroup> clusterSecurityGroup() {
         return Optional.ofNullable(this.clusterSecurityGroup);
     }
 
@@ -111,13 +111,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="creationRoleProvider")
-    private @Nullable Output<CreationRoleProviderArgs> creationRoleProvider;
+    private @Nullable CreationRoleProviderArgs creationRoleProvider;
 
     /**
      * @return The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
      * 
      */
-    public Optional<Output<CreationRoleProviderArgs>> creationRoleProvider() {
+    public Optional<CreationRoleProviderArgs> creationRoleProvider() {
         return Optional.ofNullable(this.creationRoleProvider);
     }
 
@@ -468,13 +468,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeAssociatePublicIpAddress")
-    private @Nullable Output<Boolean> nodeAssociatePublicIpAddress;
+    private @Nullable Boolean nodeAssociatePublicIpAddress;
 
     /**
      * @return Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
      * 
      */
-    public Optional<Output<Boolean>> nodeAssociatePublicIpAddress() {
+    public Optional<Boolean> nodeAssociatePublicIpAddress() {
         return Optional.ofNullable(this.nodeAssociatePublicIpAddress);
     }
 
@@ -483,13 +483,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeGroupOptions")
-    private @Nullable Output<ClusterNodeGroupOptionsArgs> nodeGroupOptions;
+    private @Nullable ClusterNodeGroupOptionsArgs nodeGroupOptions;
 
     /**
      * @return The common configuration settings for NodeGroups.
      * 
      */
-    public Optional<Output<ClusterNodeGroupOptionsArgs>> nodeGroupOptions() {
+    public Optional<ClusterNodeGroupOptionsArgs> nodeGroupOptions() {
         return Optional.ofNullable(this.nodeGroupOptions);
     }
 
@@ -752,7 +752,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="proxy")
-    private @Nullable Output<String> proxy;
+    private @Nullable String proxy;
 
     /**
      * @return The HTTP(S) proxy to use within a proxied environment.
@@ -772,7 +772,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      *   - &#34;http://username:password@proxy.example.com:3128&#34;
      * 
      */
-    public Optional<Output<String>> proxy() {
+    public Optional<String> proxy() {
         return Optional.ofNullable(this.proxy);
     }
 
@@ -865,13 +865,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="skipDefaultNodeGroup")
-    private @Nullable Output<Boolean> skipDefaultNodeGroup;
+    private @Nullable Boolean skipDefaultNodeGroup;
 
     /**
      * @return If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
      * 
      */
-    public Optional<Output<Boolean>> skipDefaultNodeGroup() {
+    public Optional<Boolean> skipDefaultNodeGroup() {
         return Optional.ofNullable(this.skipDefaultNodeGroup);
     }
 
@@ -882,7 +882,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="storageClasses")
-    private @Nullable Output<Either<String,Map<String,StorageClassArgs>>> storageClasses;
+    private @Nullable Either<String,Map<String,StorageClassArgs>> storageClasses;
 
     /**
      * @return An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
@@ -890,7 +890,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
      * 
      */
-    public Optional<Output<Either<String,Map<String,StorageClassArgs>>>> storageClasses() {
+    public Optional<Either<String,Map<String,StorageClassArgs>>> storageClasses() {
         return Optional.ofNullable(this.storageClasses);
     }
 
@@ -945,13 +945,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="useDefaultVpcCni")
-    private @Nullable Output<Boolean> useDefaultVpcCni;
+    private @Nullable Boolean useDefaultVpcCni;
 
     /**
      * @return Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
      * 
      */
-    public Optional<Output<Boolean>> useDefaultVpcCni() {
+    public Optional<Boolean> useDefaultVpcCni() {
         return Optional.ofNullable(this.useDefaultVpcCni);
     }
 
@@ -990,13 +990,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="vpcCniOptions")
-    private @Nullable Output<VpcCniOptionsArgs> vpcCniOptions;
+    private @Nullable VpcCniOptionsArgs vpcCniOptions;
 
     /**
      * @return The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
      * 
      */
-    public Optional<Output<VpcCniOptionsArgs>> vpcCniOptions() {
+    public Optional<VpcCniOptionsArgs> vpcCniOptions() {
         return Optional.ofNullable(this.vpcCniOptions);
     }
 
@@ -1095,19 +1095,9 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder clusterSecurityGroup(@Nullable Output<SecurityGroup> clusterSecurityGroup) {
+        public Builder clusterSecurityGroup(@Nullable SecurityGroup clusterSecurityGroup) {
             $.clusterSecurityGroup = clusterSecurityGroup;
             return this;
-        }
-
-        /**
-         * @param clusterSecurityGroup The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder clusterSecurityGroup(SecurityGroup clusterSecurityGroup) {
-            return clusterSecurityGroup(Output.of(clusterSecurityGroup));
         }
 
         /**
@@ -1195,19 +1185,9 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder creationRoleProvider(@Nullable Output<CreationRoleProviderArgs> creationRoleProvider) {
+        public Builder creationRoleProvider(@Nullable CreationRoleProviderArgs creationRoleProvider) {
             $.creationRoleProvider = creationRoleProvider;
             return this;
-        }
-
-        /**
-         * @param creationRoleProvider The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
-         * 
-         * @return builder
-         * 
-         */
-        public Builder creationRoleProvider(CreationRoleProviderArgs creationRoleProvider) {
-            return creationRoleProvider(Output.of(creationRoleProvider));
         }
 
         /**
@@ -1718,40 +1698,20 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeAssociatePublicIpAddress(@Nullable Output<Boolean> nodeAssociatePublicIpAddress) {
+        public Builder nodeAssociatePublicIpAddress(@Nullable Boolean nodeAssociatePublicIpAddress) {
             $.nodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             return this;
         }
 
         /**
-         * @param nodeAssociatePublicIpAddress Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeAssociatePublicIpAddress(Boolean nodeAssociatePublicIpAddress) {
-            return nodeAssociatePublicIpAddress(Output.of(nodeAssociatePublicIpAddress));
-        }
-
-        /**
          * @param nodeGroupOptions The common configuration settings for NodeGroups.
          * 
          * @return builder
          * 
          */
-        public Builder nodeGroupOptions(@Nullable Output<ClusterNodeGroupOptionsArgs> nodeGroupOptions) {
+        public Builder nodeGroupOptions(@Nullable ClusterNodeGroupOptionsArgs nodeGroupOptions) {
             $.nodeGroupOptions = nodeGroupOptions;
             return this;
-        }
-
-        /**
-         * @param nodeGroupOptions The common configuration settings for NodeGroups.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeGroupOptions(ClusterNodeGroupOptionsArgs nodeGroupOptions) {
-            return nodeGroupOptions(Output.of(nodeGroupOptions));
         }
 
         /**
@@ -2120,33 +2080,9 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder proxy(@Nullable Output<String> proxy) {
+        public Builder proxy(@Nullable String proxy) {
             $.proxy = proxy;
             return this;
-        }
-
-        /**
-         * @param proxy The HTTP(S) proxy to use within a proxied environment.
-         * 
-         *  The proxy is used during cluster creation, and OIDC configuration.
-         * 
-         * This is an alternative option to setting the proxy environment variables: HTTP(S)_PROXY and/or http(s)_proxy.
-         * 
-         * This option is required iff the proxy environment variables are not set.
-         * 
-         * Format:      &lt;protocol&gt;://&lt;host&gt;:&lt;port&gt;
-         * Auth Format: &lt;protocol&gt;://&lt;username&gt;:&lt;password&gt;@&lt;host&gt;:&lt;port&gt;
-         * 
-         * Ex:
-         *   - &#34;http://proxy.example.com:3128&#34;
-         *   - &#34;https://proxy.example.com&#34;
-         *   - &#34;http://username:password@proxy.example.com:3128&#34;
-         * 
-         * @return builder
-         * 
-         */
-        public Builder proxy(String proxy) {
-            return proxy(Output.of(proxy));
         }
 
         /**
@@ -2305,22 +2241,12 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder skipDefaultNodeGroup(@Nullable Output<Boolean> skipDefaultNodeGroup) {
+        public Builder skipDefaultNodeGroup(@Nullable Boolean skipDefaultNodeGroup) {
             $.skipDefaultNodeGroup = skipDefaultNodeGroup;
             return this;
         }
 
         /**
-         * @param skipDefaultNodeGroup If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder skipDefaultNodeGroup(Boolean skipDefaultNodeGroup) {
-            return skipDefaultNodeGroup(Output.of(skipDefaultNodeGroup));
-        }
-
-        /**
          * @param storageClasses An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
          * 
          * Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
@@ -2328,21 +2254,9 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder storageClasses(@Nullable Output<Either<String,Map<String,StorageClassArgs>>> storageClasses) {
+        public Builder storageClasses(@Nullable Either<String,Map<String,StorageClassArgs>> storageClasses) {
             $.storageClasses = storageClasses;
             return this;
-        }
-
-        /**
-         * @param storageClasses An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
-         * 
-         * Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
-         * 
-         * @return builder
-         * 
-         */
-        public Builder storageClasses(Either<String,Map<String,StorageClassArgs>> storageClasses) {
-            return storageClasses(Output.of(storageClasses));
         }
 
         /**
@@ -2451,19 +2365,9 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder useDefaultVpcCni(@Nullable Output<Boolean> useDefaultVpcCni) {
+        public Builder useDefaultVpcCni(@Nullable Boolean useDefaultVpcCni) {
             $.useDefaultVpcCni = useDefaultVpcCni;
             return this;
-        }
-
-        /**
-         * @param useDefaultVpcCni Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder useDefaultVpcCni(Boolean useDefaultVpcCni) {
-            return useDefaultVpcCni(Output.of(useDefaultVpcCni));
         }
 
         /**
@@ -2524,19 +2428,9 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder vpcCniOptions(@Nullable Output<VpcCniOptionsArgs> vpcCniOptions) {
+        public Builder vpcCniOptions(@Nullable VpcCniOptionsArgs vpcCniOptions) {
             $.vpcCniOptions = vpcCniOptions;
             return this;
-        }
-
-        /**
-         * @param vpcCniOptions The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder vpcCniOptions(VpcCniOptionsArgs vpcCniOptions) {
-            return vpcCniOptions(Output.of(vpcCniOptions));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -106,13 +106,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="bootstrapExtraArgs")
-    private @Nullable Output<String> bootstrapExtraArgs;
+    private @Nullable String bootstrapExtraArgs;
 
     /**
      * @return Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
      * 
      */
-    public Optional<Output<String>> bootstrapExtraArgs() {
+    public Optional<String> bootstrapExtraArgs() {
         return Optional.ofNullable(this.bootstrapExtraArgs);
     }
 
@@ -155,13 +155,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="clusterIngressRule")
-    private @Nullable Output<SecurityGroupRule> clusterIngressRule;
+    private @Nullable SecurityGroupRule clusterIngressRule;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<Output<SecurityGroupRule>> clusterIngressRule() {
+    public Optional<SecurityGroupRule> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
     }
 
@@ -202,7 +202,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="extraNodeSecurityGroups")
-    private @Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups;
+    private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
 
     /**
      * @return Extra security groups to attach on all nodes in this worker node group.
@@ -210,7 +210,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * This additional set of security groups captures any user application rules that will be needed for the nodes.
      * 
      */
-    public Optional<Output<List<SecurityGroup>>> extraNodeSecurityGroups() {
+    public Optional<List<SecurityGroup>> extraNodeSecurityGroups() {
         return Optional.ofNullable(this.extraNodeSecurityGroups);
     }
 
@@ -250,13 +250,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="instanceProfile")
-    private @Nullable Output<InstanceProfile> instanceProfile;
+    private @Nullable InstanceProfile instanceProfile;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<Output<InstanceProfile>> instanceProfile() {
+    public Optional<InstanceProfile> instanceProfile() {
         return Optional.ofNullable(this.instanceProfile);
     }
 
@@ -295,13 +295,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="kubeletExtraArgs")
-    private @Nullable Output<String> kubeletExtraArgs;
+    private @Nullable String kubeletExtraArgs;
 
     /**
      * @return Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
      * 
      */
-    public Optional<Output<String>> kubeletExtraArgs() {
+    public Optional<String> kubeletExtraArgs() {
         return Optional.ofNullable(this.kubeletExtraArgs);
     }
 
@@ -310,13 +310,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="labels")
-    private @Nullable Output<Map<String,String>> labels;
+    private @Nullable Map<String,String> labels;
 
     /**
      * @return Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
      * 
      */
-    public Optional<Output<Map<String,String>>> labels() {
+    public Optional<Map<String,String>> labels() {
         return Optional.ofNullable(this.labels);
     }
 
@@ -355,13 +355,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeAssociatePublicIpAddress")
-    private @Nullable Output<Boolean> nodeAssociatePublicIpAddress;
+    private @Nullable Boolean nodeAssociatePublicIpAddress;
 
     /**
      * @return Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
      * 
      */
-    public Optional<Output<Boolean>> nodeAssociatePublicIpAddress() {
+    public Optional<Boolean> nodeAssociatePublicIpAddress() {
         return Optional.ofNullable(this.nodeAssociatePublicIpAddress);
     }
 
@@ -411,7 +411,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeSecurityGroup")
-    private @Nullable Output<SecurityGroup> nodeSecurityGroup;
+    private @Nullable SecurityGroup nodeSecurityGroup;
 
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -424,7 +424,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      * 
      */
-    public Optional<Output<SecurityGroup>> nodeSecurityGroup() {
+    public Optional<SecurityGroup> nodeSecurityGroup() {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
 
@@ -501,13 +501,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="taints")
-    private @Nullable Output<Map<String,TaintArgs>> taints;
+    private @Nullable Map<String,TaintArgs> taints;
 
     /**
      * @return Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
      * 
      */
-    public Optional<Output<Map<String,TaintArgs>>> taints() {
+    public Optional<Map<String,TaintArgs>> taints() {
         return Optional.ofNullable(this.taints);
     }
 
@@ -676,19 +676,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder bootstrapExtraArgs(@Nullable Output<String> bootstrapExtraArgs) {
+        public Builder bootstrapExtraArgs(@Nullable String bootstrapExtraArgs) {
             $.bootstrapExtraArgs = bootstrapExtraArgs;
             return this;
-        }
-
-        /**
-         * @param bootstrapExtraArgs Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder bootstrapExtraArgs(String bootstrapExtraArgs) {
-            return bootstrapExtraArgs(Output.of(bootstrapExtraArgs));
         }
 
         /**
@@ -763,19 +753,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder clusterIngressRule(@Nullable Output<SecurityGroupRule> clusterIngressRule) {
+        public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
             $.clusterIngressRule = clusterIngressRule;
             return this;
-        }
-
-        /**
-         * @param clusterIngressRule The ingress rule that gives node group access.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
-            return clusterIngressRule(Output.of(clusterIngressRule));
         }
 
         /**
@@ -828,21 +808,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder extraNodeSecurityGroups(@Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups) {
+        public Builder extraNodeSecurityGroups(@Nullable List<SecurityGroup> extraNodeSecurityGroups) {
             $.extraNodeSecurityGroups = extraNodeSecurityGroups;
             return this;
-        }
-
-        /**
-         * @param extraNodeSecurityGroups Extra security groups to attach on all nodes in this worker node group.
-         * 
-         * This additional set of security groups captures any user application rules that will be needed for the nodes.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraNodeSecurityGroups(List<SecurityGroup> extraNodeSecurityGroups) {
-            return extraNodeSecurityGroups(Output.of(extraNodeSecurityGroups));
         }
 
         /**
@@ -900,19 +868,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder instanceProfile(@Nullable Output<InstanceProfile> instanceProfile) {
+        public Builder instanceProfile(@Nullable InstanceProfile instanceProfile) {
             $.instanceProfile = instanceProfile;
             return this;
-        }
-
-        /**
-         * @param instanceProfile The ingress rule that gives node group access.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder instanceProfile(InstanceProfile instanceProfile) {
-            return instanceProfile(Output.of(instanceProfile));
         }
 
         /**
@@ -963,40 +921,20 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder kubeletExtraArgs(@Nullable Output<String> kubeletExtraArgs) {
+        public Builder kubeletExtraArgs(@Nullable String kubeletExtraArgs) {
             $.kubeletExtraArgs = kubeletExtraArgs;
             return this;
         }
 
         /**
-         * @param kubeletExtraArgs Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder kubeletExtraArgs(String kubeletExtraArgs) {
-            return kubeletExtraArgs(Output.of(kubeletExtraArgs));
-        }
-
-        /**
          * @param labels Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
          * 
          * @return builder
          * 
          */
-        public Builder labels(@Nullable Output<Map<String,String>> labels) {
+        public Builder labels(@Nullable Map<String,String> labels) {
             $.labels = labels;
             return this;
-        }
-
-        /**
-         * @param labels Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder labels(Map<String,String> labels) {
-            return labels(Output.of(labels));
         }
 
         /**
@@ -1047,19 +985,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeAssociatePublicIpAddress(@Nullable Output<Boolean> nodeAssociatePublicIpAddress) {
+        public Builder nodeAssociatePublicIpAddress(@Nullable Boolean nodeAssociatePublicIpAddress) {
             $.nodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             return this;
-        }
-
-        /**
-         * @param nodeAssociatePublicIpAddress Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeAssociatePublicIpAddress(Boolean nodeAssociatePublicIpAddress) {
-            return nodeAssociatePublicIpAddress(Output.of(nodeAssociatePublicIpAddress));
         }
 
         /**
@@ -1121,26 +1049,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeSecurityGroup(@Nullable Output<SecurityGroup> nodeSecurityGroup) {
+        public Builder nodeSecurityGroup(@Nullable SecurityGroup nodeSecurityGroup) {
             $.nodeSecurityGroup = nodeSecurityGroup;
             return this;
-        }
-
-        /**
-         * @param nodeSecurityGroup The security group for the worker node group to communicate with the cluster.
-         * 
-         * This security group requires specific inbound and outbound rules.
-         * 
-         * See for more details:
-         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
-         * 
-         * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
-            return nodeSecurityGroup(Output.of(nodeSecurityGroup));
         }
 
         /**
@@ -1253,19 +1164,9 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder taints(@Nullable Output<Map<String,TaintArgs>> taints) {
+        public Builder taints(@Nullable Map<String,TaintArgs> taints) {
             $.taints = taints;
             return this;
-        }
-
-        /**
-         * @param taints Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
-         * 
-         * @return builder
-         * 
-         */
-        public Builder taints(Map<String,TaintArgs> taints) {
-            return taints(Output.of(taints));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -107,13 +107,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="bootstrapExtraArgs")
-    private @Nullable Output<String> bootstrapExtraArgs;
+    private @Nullable String bootstrapExtraArgs;
 
     /**
      * @return Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
      * 
      */
-    public Optional<Output<String>> bootstrapExtraArgs() {
+    public Optional<String> bootstrapExtraArgs() {
         return Optional.ofNullable(this.bootstrapExtraArgs);
     }
 
@@ -156,13 +156,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="clusterIngressRule")
-    private @Nullable Output<SecurityGroupRule> clusterIngressRule;
+    private @Nullable SecurityGroupRule clusterIngressRule;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<Output<SecurityGroupRule>> clusterIngressRule() {
+    public Optional<SecurityGroupRule> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
     }
 
@@ -203,7 +203,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="extraNodeSecurityGroups")
-    private @Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups;
+    private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
 
     /**
      * @return Extra security groups to attach on all nodes in this worker node group.
@@ -211,7 +211,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * This additional set of security groups captures any user application rules that will be needed for the nodes.
      * 
      */
-    public Optional<Output<List<SecurityGroup>>> extraNodeSecurityGroups() {
+    public Optional<List<SecurityGroup>> extraNodeSecurityGroups() {
         return Optional.ofNullable(this.extraNodeSecurityGroups);
     }
 
@@ -251,13 +251,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="instanceProfile")
-    private @Nullable Output<InstanceProfile> instanceProfile;
+    private @Nullable InstanceProfile instanceProfile;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<Output<InstanceProfile>> instanceProfile() {
+    public Optional<InstanceProfile> instanceProfile() {
         return Optional.ofNullable(this.instanceProfile);
     }
 
@@ -296,13 +296,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="kubeletExtraArgs")
-    private @Nullable Output<String> kubeletExtraArgs;
+    private @Nullable String kubeletExtraArgs;
 
     /**
      * @return Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
      * 
      */
-    public Optional<Output<String>> kubeletExtraArgs() {
+    public Optional<String> kubeletExtraArgs() {
         return Optional.ofNullable(this.kubeletExtraArgs);
     }
 
@@ -311,13 +311,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="labels")
-    private @Nullable Output<Map<String,String>> labels;
+    private @Nullable Map<String,String> labels;
 
     /**
      * @return Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
      * 
      */
-    public Optional<Output<Map<String,String>>> labels() {
+    public Optional<Map<String,String>> labels() {
         return Optional.ofNullable(this.labels);
     }
 
@@ -386,13 +386,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeAssociatePublicIpAddress")
-    private @Nullable Output<Boolean> nodeAssociatePublicIpAddress;
+    private @Nullable Boolean nodeAssociatePublicIpAddress;
 
     /**
      * @return Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
      * 
      */
-    public Optional<Output<Boolean>> nodeAssociatePublicIpAddress() {
+    public Optional<Boolean> nodeAssociatePublicIpAddress() {
         return Optional.ofNullable(this.nodeAssociatePublicIpAddress);
     }
 
@@ -442,7 +442,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeSecurityGroup")
-    private @Nullable Output<SecurityGroup> nodeSecurityGroup;
+    private @Nullable SecurityGroup nodeSecurityGroup;
 
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -455,7 +455,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      * 
      */
-    public Optional<Output<SecurityGroup>> nodeSecurityGroup() {
+    public Optional<SecurityGroup> nodeSecurityGroup() {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
 
@@ -532,13 +532,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="taints")
-    private @Nullable Output<Map<String,TaintArgs>> taints;
+    private @Nullable Map<String,TaintArgs> taints;
 
     /**
      * @return Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
      * 
      */
-    public Optional<Output<Map<String,TaintArgs>>> taints() {
+    public Optional<Map<String,TaintArgs>> taints() {
         return Optional.ofNullable(this.taints);
     }
 
@@ -709,19 +709,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder bootstrapExtraArgs(@Nullable Output<String> bootstrapExtraArgs) {
+        public Builder bootstrapExtraArgs(@Nullable String bootstrapExtraArgs) {
             $.bootstrapExtraArgs = bootstrapExtraArgs;
             return this;
-        }
-
-        /**
-         * @param bootstrapExtraArgs Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder bootstrapExtraArgs(String bootstrapExtraArgs) {
-            return bootstrapExtraArgs(Output.of(bootstrapExtraArgs));
         }
 
         /**
@@ -796,19 +786,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder clusterIngressRule(@Nullable Output<SecurityGroupRule> clusterIngressRule) {
+        public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
             $.clusterIngressRule = clusterIngressRule;
             return this;
-        }
-
-        /**
-         * @param clusterIngressRule The ingress rule that gives node group access.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
-            return clusterIngressRule(Output.of(clusterIngressRule));
         }
 
         /**
@@ -861,21 +841,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder extraNodeSecurityGroups(@Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups) {
+        public Builder extraNodeSecurityGroups(@Nullable List<SecurityGroup> extraNodeSecurityGroups) {
             $.extraNodeSecurityGroups = extraNodeSecurityGroups;
             return this;
-        }
-
-        /**
-         * @param extraNodeSecurityGroups Extra security groups to attach on all nodes in this worker node group.
-         * 
-         * This additional set of security groups captures any user application rules that will be needed for the nodes.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraNodeSecurityGroups(List<SecurityGroup> extraNodeSecurityGroups) {
-            return extraNodeSecurityGroups(Output.of(extraNodeSecurityGroups));
         }
 
         /**
@@ -933,19 +901,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder instanceProfile(@Nullable Output<InstanceProfile> instanceProfile) {
+        public Builder instanceProfile(@Nullable InstanceProfile instanceProfile) {
             $.instanceProfile = instanceProfile;
             return this;
-        }
-
-        /**
-         * @param instanceProfile The ingress rule that gives node group access.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder instanceProfile(InstanceProfile instanceProfile) {
-            return instanceProfile(Output.of(instanceProfile));
         }
 
         /**
@@ -996,40 +954,20 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder kubeletExtraArgs(@Nullable Output<String> kubeletExtraArgs) {
+        public Builder kubeletExtraArgs(@Nullable String kubeletExtraArgs) {
             $.kubeletExtraArgs = kubeletExtraArgs;
             return this;
         }
 
         /**
-         * @param kubeletExtraArgs Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder kubeletExtraArgs(String kubeletExtraArgs) {
-            return kubeletExtraArgs(Output.of(kubeletExtraArgs));
-        }
-
-        /**
          * @param labels Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
          * 
          * @return builder
          * 
          */
-        public Builder labels(@Nullable Output<Map<String,String>> labels) {
+        public Builder labels(@Nullable Map<String,String> labels) {
             $.labels = labels;
             return this;
-        }
-
-        /**
-         * @param labels Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder labels(Map<String,String> labels) {
-            return labels(Output.of(labels));
         }
 
         /**
@@ -1132,19 +1070,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeAssociatePublicIpAddress(@Nullable Output<Boolean> nodeAssociatePublicIpAddress) {
+        public Builder nodeAssociatePublicIpAddress(@Nullable Boolean nodeAssociatePublicIpAddress) {
             $.nodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             return this;
-        }
-
-        /**
-         * @param nodeAssociatePublicIpAddress Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeAssociatePublicIpAddress(Boolean nodeAssociatePublicIpAddress) {
-            return nodeAssociatePublicIpAddress(Output.of(nodeAssociatePublicIpAddress));
         }
 
         /**
@@ -1206,26 +1134,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeSecurityGroup(@Nullable Output<SecurityGroup> nodeSecurityGroup) {
+        public Builder nodeSecurityGroup(@Nullable SecurityGroup nodeSecurityGroup) {
             $.nodeSecurityGroup = nodeSecurityGroup;
             return this;
-        }
-
-        /**
-         * @param nodeSecurityGroup The security group for the worker node group to communicate with the cluster.
-         * 
-         * This security group requires specific inbound and outbound rules.
-         * 
-         * See for more details:
-         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
-         * 
-         * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
-            return nodeSecurityGroup(Output.of(nodeSecurityGroup));
         }
 
         /**
@@ -1338,19 +1249,9 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder taints(@Nullable Output<Map<String,TaintArgs>> taints) {
+        public Builder taints(@Nullable Map<String,TaintArgs> taints) {
             $.taints = taints;
             return this;
-        }
-
-        /**
-         * @param taints Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
-         * 
-         * @return builder
-         * 
-         */
-        public Builder taints(Map<String,TaintArgs> taints) {
-            return taints(Output.of(taints));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -107,13 +107,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="bootstrapExtraArgs")
-    private @Nullable Output<String> bootstrapExtraArgs;
+    private @Nullable String bootstrapExtraArgs;
 
     /**
      * @return Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
      * 
      */
-    public Optional<Output<String>> bootstrapExtraArgs() {
+    public Optional<String> bootstrapExtraArgs() {
         return Optional.ofNullable(this.bootstrapExtraArgs);
     }
 
@@ -141,13 +141,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="clusterIngressRule")
-    private @Nullable Output<SecurityGroupRule> clusterIngressRule;
+    private @Nullable SecurityGroupRule clusterIngressRule;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<Output<SecurityGroupRule>> clusterIngressRule() {
+    public Optional<SecurityGroupRule> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
     }
 
@@ -188,7 +188,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="extraNodeSecurityGroups")
-    private @Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups;
+    private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
 
     /**
      * @return Extra security groups to attach on all nodes in this worker node group.
@@ -196,7 +196,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * This additional set of security groups captures any user application rules that will be needed for the nodes.
      * 
      */
-    public Optional<Output<List<SecurityGroup>>> extraNodeSecurityGroups() {
+    public Optional<List<SecurityGroup>> extraNodeSecurityGroups() {
         return Optional.ofNullable(this.extraNodeSecurityGroups);
     }
 
@@ -236,13 +236,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="instanceProfile")
-    private @Nullable Output<InstanceProfile> instanceProfile;
+    private @Nullable InstanceProfile instanceProfile;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<Output<InstanceProfile>> instanceProfile() {
+    public Optional<InstanceProfile> instanceProfile() {
         return Optional.ofNullable(this.instanceProfile);
     }
 
@@ -281,13 +281,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="kubeletExtraArgs")
-    private @Nullable Output<String> kubeletExtraArgs;
+    private @Nullable String kubeletExtraArgs;
 
     /**
      * @return Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
      * 
      */
-    public Optional<Output<String>> kubeletExtraArgs() {
+    public Optional<String> kubeletExtraArgs() {
         return Optional.ofNullable(this.kubeletExtraArgs);
     }
 
@@ -296,13 +296,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="labels")
-    private @Nullable Output<Map<String,String>> labels;
+    private @Nullable Map<String,String> labels;
 
     /**
      * @return Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
      * 
      */
-    public Optional<Output<Map<String,String>>> labels() {
+    public Optional<Map<String,String>> labels() {
         return Optional.ofNullable(this.labels);
     }
 
@@ -341,13 +341,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="nodeAssociatePublicIpAddress")
-    private @Nullable Output<Boolean> nodeAssociatePublicIpAddress;
+    private @Nullable Boolean nodeAssociatePublicIpAddress;
 
     /**
      * @return Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
      * 
      */
-    public Optional<Output<Boolean>> nodeAssociatePublicIpAddress() {
+    public Optional<Boolean> nodeAssociatePublicIpAddress() {
         return Optional.ofNullable(this.nodeAssociatePublicIpAddress);
     }
 
@@ -397,7 +397,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="nodeSecurityGroup")
-    private @Nullable Output<SecurityGroup> nodeSecurityGroup;
+    private @Nullable SecurityGroup nodeSecurityGroup;
 
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -410,7 +410,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      * 
      */
-    public Optional<Output<SecurityGroup>> nodeSecurityGroup() {
+    public Optional<SecurityGroup> nodeSecurityGroup() {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
 
@@ -487,13 +487,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="taints")
-    private @Nullable Output<Map<String,TaintArgs>> taints;
+    private @Nullable Map<String,TaintArgs> taints;
 
     /**
      * @return Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
      * 
      */
-    public Optional<Output<Map<String,TaintArgs>>> taints() {
+    public Optional<Map<String,TaintArgs>> taints() {
         return Optional.ofNullable(this.taints);
     }
 
@@ -661,19 +661,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder bootstrapExtraArgs(@Nullable Output<String> bootstrapExtraArgs) {
+        public Builder bootstrapExtraArgs(@Nullable String bootstrapExtraArgs) {
             $.bootstrapExtraArgs = bootstrapExtraArgs;
             return this;
-        }
-
-        /**
-         * @param bootstrapExtraArgs Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder bootstrapExtraArgs(String bootstrapExtraArgs) {
-            return bootstrapExtraArgs(Output.of(bootstrapExtraArgs));
         }
 
         /**
@@ -707,19 +697,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder clusterIngressRule(@Nullable Output<SecurityGroupRule> clusterIngressRule) {
+        public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
             $.clusterIngressRule = clusterIngressRule;
             return this;
-        }
-
-        /**
-         * @param clusterIngressRule The ingress rule that gives node group access.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
-            return clusterIngressRule(Output.of(clusterIngressRule));
         }
 
         /**
@@ -772,21 +752,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder extraNodeSecurityGroups(@Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups) {
+        public Builder extraNodeSecurityGroups(@Nullable List<SecurityGroup> extraNodeSecurityGroups) {
             $.extraNodeSecurityGroups = extraNodeSecurityGroups;
             return this;
-        }
-
-        /**
-         * @param extraNodeSecurityGroups Extra security groups to attach on all nodes in this worker node group.
-         * 
-         * This additional set of security groups captures any user application rules that will be needed for the nodes.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraNodeSecurityGroups(List<SecurityGroup> extraNodeSecurityGroups) {
-            return extraNodeSecurityGroups(Output.of(extraNodeSecurityGroups));
         }
 
         /**
@@ -844,19 +812,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder instanceProfile(@Nullable Output<InstanceProfile> instanceProfile) {
+        public Builder instanceProfile(@Nullable InstanceProfile instanceProfile) {
             $.instanceProfile = instanceProfile;
             return this;
-        }
-
-        /**
-         * @param instanceProfile The ingress rule that gives node group access.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder instanceProfile(InstanceProfile instanceProfile) {
-            return instanceProfile(Output.of(instanceProfile));
         }
 
         /**
@@ -907,40 +865,20 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder kubeletExtraArgs(@Nullable Output<String> kubeletExtraArgs) {
+        public Builder kubeletExtraArgs(@Nullable String kubeletExtraArgs) {
             $.kubeletExtraArgs = kubeletExtraArgs;
             return this;
         }
 
         /**
-         * @param kubeletExtraArgs Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder kubeletExtraArgs(String kubeletExtraArgs) {
-            return kubeletExtraArgs(Output.of(kubeletExtraArgs));
-        }
-
-        /**
          * @param labels Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
          * 
          * @return builder
          * 
          */
-        public Builder labels(@Nullable Output<Map<String,String>> labels) {
+        public Builder labels(@Nullable Map<String,String> labels) {
             $.labels = labels;
             return this;
-        }
-
-        /**
-         * @param labels Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder labels(Map<String,String> labels) {
-            return labels(Output.of(labels));
         }
 
         /**
@@ -991,19 +929,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder nodeAssociatePublicIpAddress(@Nullable Output<Boolean> nodeAssociatePublicIpAddress) {
+        public Builder nodeAssociatePublicIpAddress(@Nullable Boolean nodeAssociatePublicIpAddress) {
             $.nodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             return this;
-        }
-
-        /**
-         * @param nodeAssociatePublicIpAddress Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeAssociatePublicIpAddress(Boolean nodeAssociatePublicIpAddress) {
-            return nodeAssociatePublicIpAddress(Output.of(nodeAssociatePublicIpAddress));
         }
 
         /**
@@ -1065,26 +993,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder nodeSecurityGroup(@Nullable Output<SecurityGroup> nodeSecurityGroup) {
+        public Builder nodeSecurityGroup(@Nullable SecurityGroup nodeSecurityGroup) {
             $.nodeSecurityGroup = nodeSecurityGroup;
             return this;
-        }
-
-        /**
-         * @param nodeSecurityGroup The security group for the worker node group to communicate with the cluster.
-         * 
-         * This security group requires specific inbound and outbound rules.
-         * 
-         * See for more details:
-         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
-         * 
-         * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
-            return nodeSecurityGroup(Output.of(nodeSecurityGroup));
         }
 
         /**
@@ -1197,19 +1108,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder taints(@Nullable Output<Map<String,TaintArgs>> taints) {
+        public Builder taints(@Nullable Map<String,TaintArgs> taints) {
             $.taints = taints;
             return this;
-        }
-
-        /**
-         * @param taints Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
-         * 
-         * @return builder
-         * 
-         */
-        public Builder taints(Map<String,TaintArgs> taints) {
-            return taints(Output.of(taints));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/CreationRoleProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/CreationRoleProviderArgs.java
@@ -5,7 +5,6 @@ package com.pulumi.eks.inputs;
 
 import com.pulumi.aws.Provider;
 import com.pulumi.aws.iam.Role;
-import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.util.Objects;
 
@@ -19,16 +18,16 @@ public final class CreationRoleProviderArgs extends com.pulumi.resources.Resourc
     public static final CreationRoleProviderArgs Empty = new CreationRoleProviderArgs();
 
     @Import(name="provider", required=true)
-    private Output<Provider> provider;
+    private Provider provider;
 
-    public Output<Provider> provider() {
+    public Provider provider() {
         return this.provider;
     }
 
     @Import(name="role", required=true)
-    private Output<Role> role;
+    private Role role;
 
-    public Output<Role> role() {
+    public Role role() {
         return this.role;
     }
 
@@ -57,22 +56,14 @@ public final class CreationRoleProviderArgs extends com.pulumi.resources.Resourc
             $ = new CreationRoleProviderArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder provider(Output<Provider> provider) {
+        public Builder provider(Provider provider) {
             $.provider = provider;
             return this;
         }
 
-        public Builder provider(Provider provider) {
-            return provider(Output.of(provider));
-        }
-
-        public Builder role(Output<Role> role) {
+        public Builder role(Role role) {
             $.role = role;
             return this;
-        }
-
-        public Builder role(Role role) {
-            return role(Output.of(role));
         }
 
         public CreationRoleProviderArgs build() {

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/TaintArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/TaintArgs.java
@@ -3,7 +3,6 @@
 
 package com.pulumi.eks.inputs;
 
-import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import java.lang.String;
 import java.util.Objects;
@@ -22,13 +21,13 @@ public final class TaintArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="effect", required=true)
-    private Output<String> effect;
+    private String effect;
 
     /**
      * @return The effect of the taint.
      * 
      */
-    public Output<String> effect() {
+    public String effect() {
         return this.effect;
     }
 
@@ -37,13 +36,13 @@ public final class TaintArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="value", required=true)
-    private Output<String> value;
+    private String value;
 
     /**
      * @return The value of the taint.
      * 
      */
-    public Output<String> value() {
+    public String value() {
         return this.value;
     }
 
@@ -78,29 +77,8 @@ public final class TaintArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder effect(Output<String> effect) {
-            $.effect = effect;
-            return this;
-        }
-
-        /**
-         * @param effect The effect of the taint.
-         * 
-         * @return builder
-         * 
-         */
         public Builder effect(String effect) {
-            return effect(Output.of(effect));
-        }
-
-        /**
-         * @param value The value of the taint.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder value(Output<String> value) {
-            $.value = value;
+            $.effect = effect;
             return this;
         }
 
@@ -111,7 +89,8 @@ public final class TaintArgs extends com.pulumi.resources.ResourceArgs {
          * 
          */
         public Builder value(String value) {
-            return value(Output.of(value));
+            $.value = value;
+            return this;
         }
 
         public TaintArgs build() {

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -30,29 +30,29 @@ class ClusterNodeGroupOptionsArgs:
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]] = None,
+                 taints: Optional[Mapping[str, 'TaintArgs']] = None,
                  version: Optional[pulumi.Input[str]] = None):
         """
         Describes the configuration options accepted by a cluster to create its own node groups.
@@ -74,14 +74,14 @@ class ClusterNodeGroupOptionsArgs:
                Per AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input[str] bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -93,19 +93,19 @@ class ClusterNodeGroupOptionsArgs:
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
-        :param pulumi.Input['pulumi_aws.iam.InstanceProfile'] instance_profile: The ingress rule that gives node group access.
+        :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
         :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
-        :param pulumi.Input[str] kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+        :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         :param pulumi.Input[int] max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
         :param pulumi.Input[int] min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -121,7 +121,7 @@ class ClusterNodeGroupOptionsArgs:
                
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html
         :param pulumi.Input[str] spot_price: Bidding price for spot instance. If set, only spot instances will be added as worker node.
-        :param pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
+        :param Mapping[str, 'TaintArgs'] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
         """
         if ami_id is not None:
@@ -232,14 +232,14 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="bootstrapExtraArgs")
-    def bootstrap_extra_args(self) -> Optional[pulumi.Input[str]]:
+    def bootstrap_extra_args(self) -> Optional[str]:
         """
         Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         """
         return pulumi.get(self, "bootstrap_extra_args")
 
     @bootstrap_extra_args.setter
-    def bootstrap_extra_args(self, value: Optional[pulumi.Input[str]]):
+    def bootstrap_extra_args(self, value: Optional[str]):
         pulumi.set(self, "bootstrap_extra_args", value)
 
     @property
@@ -258,14 +258,14 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="clusterIngressRule")
-    def cluster_ingress_rule(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]:
+    def cluster_ingress_rule(self) -> Optional['pulumi_aws.ec2.SecurityGroupRule']:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
 
     @cluster_ingress_rule.setter
-    def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
+    def cluster_ingress_rule(self, value: Optional['pulumi_aws.ec2.SecurityGroupRule']):
         pulumi.set(self, "cluster_ingress_rule", value)
 
     @property
@@ -294,7 +294,7 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]:
+    def extra_node_security_groups(self) -> Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -303,7 +303,7 @@ class ClusterNodeGroupOptionsArgs:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]):
+    def extra_node_security_groups(self, value: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -328,14 +328,14 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="instanceProfile")
-    def instance_profile(self) -> Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']]:
+    def instance_profile(self) -> Optional['pulumi_aws.iam.InstanceProfile']:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "instance_profile")
 
     @instance_profile.setter
-    def instance_profile(self, value: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']]):
+    def instance_profile(self, value: Optional['pulumi_aws.iam.InstanceProfile']):
         pulumi.set(self, "instance_profile", value)
 
     @property
@@ -364,26 +364,26 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="kubeletExtraArgs")
-    def kubelet_extra_args(self) -> Optional[pulumi.Input[str]]:
+    def kubelet_extra_args(self) -> Optional[str]:
         """
         Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         """
         return pulumi.get(self, "kubelet_extra_args")
 
     @kubelet_extra_args.setter
-    def kubelet_extra_args(self, value: Optional[pulumi.Input[str]]):
+    def kubelet_extra_args(self, value: Optional[str]):
         pulumi.set(self, "kubelet_extra_args", value)
 
     @property
     @pulumi.getter
-    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def labels(self) -> Optional[Mapping[str, str]]:
         """
         Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         """
         return pulumi.get(self, "labels")
 
     @labels.setter
-    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def labels(self, value: Optional[Mapping[str, str]]):
         pulumi.set(self, "labels", value)
 
     @property
@@ -412,14 +412,14 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="nodeAssociatePublicIpAddress")
-    def node_associate_public_ip_address(self) -> Optional[pulumi.Input[bool]]:
+    def node_associate_public_ip_address(self) -> Optional[bool]:
         """
         Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         """
         return pulumi.get(self, "node_associate_public_ip_address")
 
     @node_associate_public_ip_address.setter
-    def node_associate_public_ip_address(self, value: Optional[pulumi.Input[bool]]):
+    def node_associate_public_ip_address(self, value: Optional[bool]):
         pulumi.set(self, "node_associate_public_ip_address", value)
 
     @property
@@ -450,7 +450,7 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
+    def node_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
         """
         The security group for the worker node group to communicate with the cluster.
 
@@ -464,7 +464,7 @@ class ClusterNodeGroupOptionsArgs:
         return pulumi.get(self, "node_security_group")
 
     @node_security_group.setter
-    def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
+    def node_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
         pulumi.set(self, "node_security_group", value)
 
     @property
@@ -521,14 +521,14 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter
-    def taints(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]]:
+    def taints(self) -> Optional[Mapping[str, 'TaintArgs']]:
         """
         Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         """
         return pulumi.get(self, "taints")
 
     @taints.setter
-    def taints(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]]):
+    def taints(self, value: Optional[Mapping[str, 'TaintArgs']]):
         pulumi.set(self, "taints", value)
 
     @property
@@ -802,8 +802,8 @@ class CoreDataArgs:
 @pulumi.input_type
 class CreationRoleProviderArgs:
     def __init__(__self__, *,
-                 provider: pulumi.Input['pulumi_aws.Provider'],
-                 role: pulumi.Input['pulumi_aws.iam.Role']):
+                 provider: 'pulumi_aws.Provider',
+                 role: 'pulumi_aws.iam.Role'):
         """
         Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         """
@@ -812,20 +812,20 @@ class CreationRoleProviderArgs:
 
     @property
     @pulumi.getter
-    def provider(self) -> pulumi.Input['pulumi_aws.Provider']:
+    def provider(self) -> 'pulumi_aws.Provider':
         return pulumi.get(self, "provider")
 
     @provider.setter
-    def provider(self, value: pulumi.Input['pulumi_aws.Provider']):
+    def provider(self, value: 'pulumi_aws.Provider'):
         pulumi.set(self, "provider", value)
 
     @property
     @pulumi.getter
-    def role(self) -> pulumi.Input['pulumi_aws.iam.Role']:
+    def role(self) -> 'pulumi_aws.iam.Role':
         return pulumi.get(self, "role")
 
     @role.setter
-    def role(self, value: pulumi.Input['pulumi_aws.iam.Role']):
+    def role(self, value: 'pulumi_aws.iam.Role'):
         pulumi.set(self, "role", value)
 
 
@@ -1195,38 +1195,38 @@ class StorageClassArgs:
 @pulumi.input_type
 class TaintArgs:
     def __init__(__self__, *,
-                 effect: pulumi.Input[str],
-                 value: pulumi.Input[str]):
+                 effect: str,
+                 value: str):
         """
         Represents a Kubernetes `taint` to apply to all Nodes in a NodeGroup. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
-        :param pulumi.Input[str] effect: The effect of the taint.
-        :param pulumi.Input[str] value: The value of the taint.
+        :param str effect: The effect of the taint.
+        :param str value: The value of the taint.
         """
         pulumi.set(__self__, "effect", effect)
         pulumi.set(__self__, "value", value)
 
     @property
     @pulumi.getter
-    def effect(self) -> pulumi.Input[str]:
+    def effect(self) -> str:
         """
         The effect of the taint.
         """
         return pulumi.get(self, "effect")
 
     @effect.setter
-    def effect(self, value: pulumi.Input[str]):
+    def effect(self, value: str):
         pulumi.set(self, "effect", value)
 
     @property
     @pulumi.getter
-    def value(self) -> pulumi.Input[str]:
+    def value(self) -> str:
         """
         The value of the taint.
         """
         return pulumi.get(self, "value")
 
     @value.setter
-    def value(self, value: pulumi.Input[str]):
+    def value(self, value: str):
         pulumi.set(self, "value", value)
 
 

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -18,11 +18,11 @@ __all__ = ['ClusterArgs', 'Cluster']
 @pulumi.input_type
 class ClusterArgs:
     def __init__(__self__, *,
-                 cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 cluster_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
-                 creation_role_provider: Optional[pulumi.Input['CreationRoleProviderArgs']] = None,
+                 creation_role_provider: Optional['CreationRoleProviderArgs'] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -41,8 +41,8 @@ class ClusterArgs:
                  min_size: Optional[pulumi.Input[int]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  node_ami_id: Optional[pulumi.Input[str]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
-                 node_group_options: Optional[pulumi.Input['ClusterNodeGroupOptionsArgs']] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
+                 node_group_options: Optional['ClusterNodeGroupOptionsArgs'] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
                  node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
@@ -55,23 +55,23 @@ class ClusterArgs:
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  private_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  provider_credential_opts: Optional[pulumi.Input['KubeconfigOptionsArgs']] = None,
-                 proxy: Optional[pulumi.Input[str]] = None,
+                 proxy: Optional[str] = None,
                  public_access_cidrs: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  public_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  role_mappings: Optional[pulumi.Input[Sequence[pulumi.Input['RoleMappingArgs']]]] = None,
                  service_role: Optional[pulumi.Input['pulumi_aws.iam.Role']] = None,
-                 skip_default_node_group: Optional[pulumi.Input[bool]] = None,
-                 storage_classes: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]]] = None,
+                 skip_default_node_group: Optional[bool] = None,
+                 storage_classes: Optional[Union[str, Mapping[str, 'StorageClassArgs']]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 use_default_vpc_cni: Optional[pulumi.Input[bool]] = None,
+                 use_default_vpc_cni: Optional[bool] = None,
                  user_mappings: Optional[pulumi.Input[Sequence[pulumi.Input['UserMappingArgs']]]] = None,
                  version: Optional[pulumi.Input[str]] = None,
-                 vpc_cni_options: Optional[pulumi.Input['VpcCniOptionsArgs']] = None,
+                 vpc_cni_options: Optional['VpcCniOptionsArgs'] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Cluster resource.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
+        :param 'pulumi_aws.ec2.SecurityGroup' cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
@@ -83,7 +83,7 @@ class ClusterArgs:
                 - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
                 - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
                 - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
-        :param pulumi.Input['CreationRoleProviderArgs'] creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+        :param 'CreationRoleProviderArgs' creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] default_addons_to_remove: List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: ["api", "audit", "authenticator", "controllerManager", "scheduler"]. By default it is off.
@@ -138,8 +138,8 @@ class ClusterArgs:
                
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-        :param pulumi.Input['ClusterNodeGroupOptionsArgs'] node_group_options: The common configuration settings for NodeGroups.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param 'ClusterNodeGroupOptionsArgs' node_group_options: The common configuration settings for NodeGroups.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
@@ -182,7 +182,7 @@ class ClusterArgs:
                - https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/
                - https://www.pulumi.com/docs/intro/cloud-providers/aws/#configuration
                - https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
-        :param pulumi.Input[str] proxy: The HTTP(S) proxy to use within a proxied environment.
+        :param str proxy: The HTTP(S) proxy to use within a proxied environment.
                
                 The proxy is used during cluster creation, and OIDC configuration.
                
@@ -213,8 +213,8 @@ class ClusterArgs:
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.Note: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged.
         :param pulumi.Input[Sequence[pulumi.Input['RoleMappingArgs']]] role_mappings: Optional mappings from AWS IAM roles to Kubernetes users and groups.
         :param pulumi.Input['pulumi_aws.iam.Role'] service_role: IAM Service Role for EKS to use to manage the cluster.
-        :param pulumi.Input[bool] skip_default_node_group: If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
-        :param pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
+        :param bool skip_default_node_group: If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
+        :param Union[str, Mapping[str, 'StorageClassArgs']] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
                
                Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The set of all subnets, public and private, to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.
@@ -227,10 +227,10 @@ class ClusterArgs:
                
                Note: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of tags that are automatically applied to all AWS resources directly under management with this cluster, which support tagging.
-        :param pulumi.Input[bool] use_default_vpc_cni: Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
+        :param bool use_default_vpc_cni: Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
         :param pulumi.Input[Sequence[pulumi.Input['UserMappingArgs']]] user_mappings: Optional mappings from AWS IAM users to Kubernetes users and groups.
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
-        :param pulumi.Input['VpcCniOptionsArgs'] vpc_cni_options: The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
+        :param 'VpcCniOptionsArgs' vpc_cni_options: The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
         :param pulumi.Input[str] vpc_id: The VPC in which to create the cluster and its worker nodes. If unset, the cluster will be created in the default VPC.
         """
         if cluster_security_group is not None:
@@ -338,14 +338,14 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="clusterSecurityGroup")
-    def cluster_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
+    def cluster_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
         """
         The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         """
         return pulumi.get(self, "cluster_security_group")
 
     @cluster_security_group.setter
-    def cluster_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
+    def cluster_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
         pulumi.set(self, "cluster_security_group", value)
 
     @property
@@ -394,14 +394,14 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="creationRoleProvider")
-    def creation_role_provider(self) -> Optional[pulumi.Input['CreationRoleProviderArgs']]:
+    def creation_role_provider(self) -> Optional['CreationRoleProviderArgs']:
         """
         The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         """
         return pulumi.get(self, "creation_role_provider")
 
     @creation_role_provider.setter
-    def creation_role_provider(self, value: Optional[pulumi.Input['CreationRoleProviderArgs']]):
+    def creation_role_provider(self, value: Optional['CreationRoleProviderArgs']):
         pulumi.set(self, "creation_role_provider", value)
 
     @property
@@ -658,26 +658,26 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="nodeAssociatePublicIpAddress")
-    def node_associate_public_ip_address(self) -> Optional[pulumi.Input[bool]]:
+    def node_associate_public_ip_address(self) -> Optional[bool]:
         """
         Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         """
         return pulumi.get(self, "node_associate_public_ip_address")
 
     @node_associate_public_ip_address.setter
-    def node_associate_public_ip_address(self, value: Optional[pulumi.Input[bool]]):
+    def node_associate_public_ip_address(self, value: Optional[bool]):
         pulumi.set(self, "node_associate_public_ip_address", value)
 
     @property
     @pulumi.getter(name="nodeGroupOptions")
-    def node_group_options(self) -> Optional[pulumi.Input['ClusterNodeGroupOptionsArgs']]:
+    def node_group_options(self) -> Optional['ClusterNodeGroupOptionsArgs']:
         """
         The common configuration settings for NodeGroups.
         """
         return pulumi.get(self, "node_group_options")
 
     @node_group_options.setter
-    def node_group_options(self, value: Optional[pulumi.Input['ClusterNodeGroupOptionsArgs']]):
+    def node_group_options(self, value: Optional['ClusterNodeGroupOptionsArgs']):
         pulumi.set(self, "node_group_options", value)
 
     @property
@@ -856,7 +856,7 @@ class ClusterArgs:
 
     @property
     @pulumi.getter
-    def proxy(self) -> Optional[pulumi.Input[str]]:
+    def proxy(self) -> Optional[str]:
         """
         The HTTP(S) proxy to use within a proxied environment.
 
@@ -877,7 +877,7 @@ class ClusterArgs:
         return pulumi.get(self, "proxy")
 
     @proxy.setter
-    def proxy(self, value: Optional[pulumi.Input[str]]):
+    def proxy(self, value: Optional[str]):
         pulumi.set(self, "proxy", value)
 
     @property
@@ -942,19 +942,19 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="skipDefaultNodeGroup")
-    def skip_default_node_group(self) -> Optional[pulumi.Input[bool]]:
+    def skip_default_node_group(self) -> Optional[bool]:
         """
         If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
         """
         return pulumi.get(self, "skip_default_node_group")
 
     @skip_default_node_group.setter
-    def skip_default_node_group(self, value: Optional[pulumi.Input[bool]]):
+    def skip_default_node_group(self, value: Optional[bool]):
         pulumi.set(self, "skip_default_node_group", value)
 
     @property
     @pulumi.getter(name="storageClasses")
-    def storage_classes(self) -> Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]]]:
+    def storage_classes(self) -> Optional[Union[str, Mapping[str, 'StorageClassArgs']]]:
         """
         An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
 
@@ -963,7 +963,7 @@ class ClusterArgs:
         return pulumi.get(self, "storage_classes")
 
     @storage_classes.setter
-    def storage_classes(self, value: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input['StorageClassArgs']]]]]):
+    def storage_classes(self, value: Optional[Union[str, Mapping[str, 'StorageClassArgs']]]):
         pulumi.set(self, "storage_classes", value)
 
     @property
@@ -1000,14 +1000,14 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="useDefaultVpcCni")
-    def use_default_vpc_cni(self) -> Optional[pulumi.Input[bool]]:
+    def use_default_vpc_cni(self) -> Optional[bool]:
         """
         Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
         """
         return pulumi.get(self, "use_default_vpc_cni")
 
     @use_default_vpc_cni.setter
-    def use_default_vpc_cni(self, value: Optional[pulumi.Input[bool]]):
+    def use_default_vpc_cni(self, value: Optional[bool]):
         pulumi.set(self, "use_default_vpc_cni", value)
 
     @property
@@ -1036,14 +1036,14 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="vpcCniOptions")
-    def vpc_cni_options(self) -> Optional[pulumi.Input['VpcCniOptionsArgs']]:
+    def vpc_cni_options(self) -> Optional['VpcCniOptionsArgs']:
         """
         The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
         """
         return pulumi.get(self, "vpc_cni_options")
 
     @vpc_cni_options.setter
-    def vpc_cni_options(self, value: Optional[pulumi.Input['VpcCniOptionsArgs']]):
+    def vpc_cni_options(self, value: Optional['VpcCniOptionsArgs']):
         pulumi.set(self, "vpc_cni_options", value)
 
     @property
@@ -1064,11 +1064,11 @@ class Cluster(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 cluster_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
-                 creation_role_provider: Optional[pulumi.Input[pulumi.InputType['CreationRoleProviderArgs']]] = None,
+                 creation_role_provider: Optional[pulumi.InputType['CreationRoleProviderArgs']] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -1087,8 +1087,8 @@ class Cluster(pulumi.ComponentResource):
                  min_size: Optional[pulumi.Input[int]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  node_ami_id: Optional[pulumi.Input[str]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
-                 node_group_options: Optional[pulumi.Input[pulumi.InputType['ClusterNodeGroupOptionsArgs']]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
+                 node_group_options: Optional[pulumi.InputType['ClusterNodeGroupOptionsArgs']] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
                  node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
@@ -1101,19 +1101,19 @@ class Cluster(pulumi.ComponentResource):
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  private_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  provider_credential_opts: Optional[pulumi.Input[pulumi.InputType['KubeconfigOptionsArgs']]] = None,
-                 proxy: Optional[pulumi.Input[str]] = None,
+                 proxy: Optional[str] = None,
                  public_access_cidrs: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  public_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  role_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleMappingArgs']]]]] = None,
                  service_role: Optional[pulumi.Input['pulumi_aws.iam.Role']] = None,
-                 skip_default_node_group: Optional[pulumi.Input[bool]] = None,
-                 storage_classes: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input[pulumi.InputType['StorageClassArgs']]]]]] = None,
+                 skip_default_node_group: Optional[bool] = None,
+                 storage_classes: Optional[Union[str, Mapping[str, pulumi.InputType['StorageClassArgs']]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 use_default_vpc_cni: Optional[pulumi.Input[bool]] = None,
+                 use_default_vpc_cni: Optional[bool] = None,
                  user_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['UserMappingArgs']]]]] = None,
                  version: Optional[pulumi.Input[str]] = None,
-                 vpc_cni_options: Optional[pulumi.Input[pulumi.InputType['VpcCniOptionsArgs']]] = None,
+                 vpc_cni_options: Optional[pulumi.InputType['VpcCniOptionsArgs']] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -1121,7 +1121,7 @@ class Cluster(pulumi.ComponentResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
+        :param 'pulumi_aws.ec2.SecurityGroup' cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
@@ -1133,7 +1133,7 @@ class Cluster(pulumi.ComponentResource):
                 - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
                 - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
                 - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
-        :param pulumi.Input[pulumi.InputType['CreationRoleProviderArgs']] creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+        :param pulumi.InputType['CreationRoleProviderArgs'] creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] default_addons_to_remove: List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: ["api", "audit", "authenticator", "controllerManager", "scheduler"]. By default it is off.
@@ -1188,8 +1188,8 @@ class Cluster(pulumi.ComponentResource):
                
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
-        :param pulumi.Input[pulumi.InputType['ClusterNodeGroupOptionsArgs']] node_group_options: The common configuration settings for NodeGroups.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign the EKS worker nodes public IP addresses. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param pulumi.InputType['ClusterNodeGroupOptionsArgs'] node_group_options: The common configuration settings for NodeGroups.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
@@ -1232,7 +1232,7 @@ class Cluster(pulumi.ComponentResource):
                - https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/
                - https://www.pulumi.com/docs/intro/cloud-providers/aws/#configuration
                - https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
-        :param pulumi.Input[str] proxy: The HTTP(S) proxy to use within a proxied environment.
+        :param str proxy: The HTTP(S) proxy to use within a proxied environment.
                
                 The proxy is used during cluster creation, and OIDC configuration.
                
@@ -1263,8 +1263,8 @@ class Cluster(pulumi.ComponentResource):
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html.Note: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleMappingArgs']]]] role_mappings: Optional mappings from AWS IAM roles to Kubernetes users and groups.
         :param pulumi.Input['pulumi_aws.iam.Role'] service_role: IAM Service Role for EKS to use to manage the cluster.
-        :param pulumi.Input[bool] skip_default_node_group: If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
-        :param pulumi.Input[Union[str, Mapping[str, pulumi.Input[pulumi.InputType['StorageClassArgs']]]]] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
+        :param bool skip_default_node_group: If this toggle is set to true, the EKS cluster will be created without node group attached. Defaults to false, unless `fargate` input is provided.
+        :param Union[str, Mapping[str, pulumi.InputType['StorageClassArgs']]] storage_classes: An optional set of StorageClasses to enable for the cluster. If this is a single volume type rather than a map, a single StorageClass will be created for that volume type.
                
                Note: As of Kubernetes v1.11+ on EKS, a default `gp2` storage class will always be created automatically for the cluster by the EKS service. See https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: The set of all subnets, public and private, to use for the worker node groups on the EKS cluster. These subnets are automatically tagged by EKS for Kubernetes purposes.
@@ -1277,10 +1277,10 @@ class Cluster(pulumi.ComponentResource):
                
                Note: The use of `subnetIds`, along with `publicSubnetIds` and/or `privateSubnetIds` is mutually exclusive. The use of `publicSubnetIds` and `privateSubnetIds` is encouraged.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of tags that are automatically applied to all AWS resources directly under management with this cluster, which support tagging.
-        :param pulumi.Input[bool] use_default_vpc_cni: Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
+        :param bool use_default_vpc_cni: Use the default VPC CNI instead of creating a custom one. Should not be used in conjunction with `vpcCniOptions`.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['UserMappingArgs']]]] user_mappings: Optional mappings from AWS IAM users to Kubernetes users and groups.
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
-        :param pulumi.Input[pulumi.InputType['VpcCniOptionsArgs']] vpc_cni_options: The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
+        :param pulumi.InputType['VpcCniOptionsArgs'] vpc_cni_options: The configuration of the Amazon VPC CNI plugin for this instance. Defaults are described in the documentation for the VpcCniOptions type.
         :param pulumi.Input[str] vpc_id: The VPC in which to create the cluster and its worker nodes. If unset, the cluster will be created in the default VPC.
         """
         ...
@@ -1307,11 +1307,11 @@ class Cluster(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 cluster_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
-                 creation_role_provider: Optional[pulumi.Input[pulumi.InputType['CreationRoleProviderArgs']]] = None,
+                 creation_role_provider: Optional[pulumi.InputType['CreationRoleProviderArgs']] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -1330,8 +1330,8 @@ class Cluster(pulumi.ComponentResource):
                  min_size: Optional[pulumi.Input[int]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  node_ami_id: Optional[pulumi.Input[str]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
-                 node_group_options: Optional[pulumi.Input[pulumi.InputType['ClusterNodeGroupOptionsArgs']]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
+                 node_group_options: Optional[pulumi.InputType['ClusterNodeGroupOptionsArgs']] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
                  node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
@@ -1344,19 +1344,19 @@ class Cluster(pulumi.ComponentResource):
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  private_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  provider_credential_opts: Optional[pulumi.Input[pulumi.InputType['KubeconfigOptionsArgs']]] = None,
-                 proxy: Optional[pulumi.Input[str]] = None,
+                 proxy: Optional[str] = None,
                  public_access_cidrs: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  public_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  role_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleMappingArgs']]]]] = None,
                  service_role: Optional[pulumi.Input['pulumi_aws.iam.Role']] = None,
-                 skip_default_node_group: Optional[pulumi.Input[bool]] = None,
-                 storage_classes: Optional[pulumi.Input[Union[str, Mapping[str, pulumi.Input[pulumi.InputType['StorageClassArgs']]]]]] = None,
+                 skip_default_node_group: Optional[bool] = None,
+                 storage_classes: Optional[Union[str, Mapping[str, pulumi.InputType['StorageClassArgs']]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 use_default_vpc_cni: Optional[pulumi.Input[bool]] = None,
+                 use_default_vpc_cni: Optional[bool] = None,
                  user_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['UserMappingArgs']]]]] = None,
                  version: Optional[pulumi.Input[str]] = None,
-                 vpc_cni_options: Optional[pulumi.Input[pulumi.InputType['VpcCniOptionsArgs']]] = None,
+                 vpc_cni_options: Optional[pulumi.InputType['VpcCniOptionsArgs']] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -22,29 +22,29 @@ class NodeGroupArgs:
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]] = None,
+                 taints: Optional[Mapping[str, 'TaintArgs']] = None,
                  version: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a NodeGroup resource.
@@ -67,14 +67,14 @@ class NodeGroupArgs:
                Per AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input[str] bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -86,19 +86,19 @@ class NodeGroupArgs:
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
-        :param pulumi.Input['pulumi_aws.iam.InstanceProfile'] instance_profile: The ingress rule that gives node group access.
+        :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
         :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
-        :param pulumi.Input[str] kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+        :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         :param pulumi.Input[int] max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
         :param pulumi.Input[int] min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -114,7 +114,7 @@ class NodeGroupArgs:
                
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html
         :param pulumi.Input[str] spot_price: Bidding price for spot instance. If set, only spot instances will be added as worker node.
-        :param pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
+        :param Mapping[str, 'TaintArgs'] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
         """
         pulumi.set(__self__, "cluster", cluster)
@@ -238,14 +238,14 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="bootstrapExtraArgs")
-    def bootstrap_extra_args(self) -> Optional[pulumi.Input[str]]:
+    def bootstrap_extra_args(self) -> Optional[str]:
         """
         Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         """
         return pulumi.get(self, "bootstrap_extra_args")
 
     @bootstrap_extra_args.setter
-    def bootstrap_extra_args(self, value: Optional[pulumi.Input[str]]):
+    def bootstrap_extra_args(self, value: Optional[str]):
         pulumi.set(self, "bootstrap_extra_args", value)
 
     @property
@@ -264,14 +264,14 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="clusterIngressRule")
-    def cluster_ingress_rule(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]:
+    def cluster_ingress_rule(self) -> Optional['pulumi_aws.ec2.SecurityGroupRule']:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
 
     @cluster_ingress_rule.setter
-    def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
+    def cluster_ingress_rule(self, value: Optional['pulumi_aws.ec2.SecurityGroupRule']):
         pulumi.set(self, "cluster_ingress_rule", value)
 
     @property
@@ -300,7 +300,7 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]:
+    def extra_node_security_groups(self) -> Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -309,7 +309,7 @@ class NodeGroupArgs:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]):
+    def extra_node_security_groups(self, value: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -334,14 +334,14 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="instanceProfile")
-    def instance_profile(self) -> Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']]:
+    def instance_profile(self) -> Optional['pulumi_aws.iam.InstanceProfile']:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "instance_profile")
 
     @instance_profile.setter
-    def instance_profile(self, value: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']]):
+    def instance_profile(self, value: Optional['pulumi_aws.iam.InstanceProfile']):
         pulumi.set(self, "instance_profile", value)
 
     @property
@@ -370,26 +370,26 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="kubeletExtraArgs")
-    def kubelet_extra_args(self) -> Optional[pulumi.Input[str]]:
+    def kubelet_extra_args(self) -> Optional[str]:
         """
         Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         """
         return pulumi.get(self, "kubelet_extra_args")
 
     @kubelet_extra_args.setter
-    def kubelet_extra_args(self, value: Optional[pulumi.Input[str]]):
+    def kubelet_extra_args(self, value: Optional[str]):
         pulumi.set(self, "kubelet_extra_args", value)
 
     @property
     @pulumi.getter
-    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def labels(self) -> Optional[Mapping[str, str]]:
         """
         Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         """
         return pulumi.get(self, "labels")
 
     @labels.setter
-    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def labels(self, value: Optional[Mapping[str, str]]):
         pulumi.set(self, "labels", value)
 
     @property
@@ -418,14 +418,14 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="nodeAssociatePublicIpAddress")
-    def node_associate_public_ip_address(self) -> Optional[pulumi.Input[bool]]:
+    def node_associate_public_ip_address(self) -> Optional[bool]:
         """
         Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         """
         return pulumi.get(self, "node_associate_public_ip_address")
 
     @node_associate_public_ip_address.setter
-    def node_associate_public_ip_address(self, value: Optional[pulumi.Input[bool]]):
+    def node_associate_public_ip_address(self, value: Optional[bool]):
         pulumi.set(self, "node_associate_public_ip_address", value)
 
     @property
@@ -456,7 +456,7 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
+    def node_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
         """
         The security group for the worker node group to communicate with the cluster.
 
@@ -470,7 +470,7 @@ class NodeGroupArgs:
         return pulumi.get(self, "node_security_group")
 
     @node_security_group.setter
-    def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
+    def node_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
         pulumi.set(self, "node_security_group", value)
 
     @property
@@ -527,14 +527,14 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter
-    def taints(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]]:
+    def taints(self) -> Optional[Mapping[str, 'TaintArgs']]:
         """
         Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         """
         return pulumi.get(self, "taints")
 
     @taints.setter
-    def taints(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]]):
+    def taints(self, value: Optional[Mapping[str, 'TaintArgs']]):
         pulumi.set(self, "taints", value)
 
     @property
@@ -558,30 +558,30 @@ class NodeGroup(pulumi.ComponentResource):
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['TaintArgs']]]]] = None,
+                 taints: Optional[Mapping[str, pulumi.InputType['TaintArgs']]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -607,15 +607,15 @@ class NodeGroup(pulumi.ComponentResource):
                Per AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input[str] bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -627,19 +627,19 @@ class NodeGroup(pulumi.ComponentResource):
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
-        :param pulumi.Input['pulumi_aws.iam.InstanceProfile'] instance_profile: The ingress rule that gives node group access.
+        :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
         :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
-        :param pulumi.Input[str] kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+        :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         :param pulumi.Input[int] max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
         :param pulumi.Input[int] min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -655,7 +655,7 @@ class NodeGroup(pulumi.ComponentResource):
                
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html
         :param pulumi.Input[str] spot_price: Bidding price for spot instance. If set, only spot instances will be added as worker node.
-        :param pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['TaintArgs']]]] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
+        :param Mapping[str, pulumi.InputType['TaintArgs']] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
         """
         ...
@@ -685,30 +685,30 @@ class NodeGroup(pulumi.ComponentResource):
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['TaintArgs']]]]] = None,
+                 taints: Optional[Mapping[str, pulumi.InputType['TaintArgs']]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -22,31 +22,31 @@ class NodeGroupV2Args:
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  launch_template_tag_specifications: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_refresh_percentage: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]] = None,
+                 taints: Optional[Mapping[str, 'TaintArgs']] = None,
                  version: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a NodeGroupV2 resource.
@@ -69,14 +69,14 @@ class NodeGroupV2Args:
                Per AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input[str] bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -88,21 +88,21 @@ class NodeGroupV2Args:
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
-        :param pulumi.Input['pulumi_aws.iam.InstanceProfile'] instance_profile: The ingress rule that gives node group access.
+        :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
         :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
-        :param pulumi.Input[str] kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+        :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]] launch_template_tag_specifications: The tag specifications to apply to the launch template.
         :param pulumi.Input[int] max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
         :param pulumi.Input[int] min_refresh_percentage: The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
         :param pulumi.Input[int] min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -118,7 +118,7 @@ class NodeGroupV2Args:
                
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html
         :param pulumi.Input[str] spot_price: Bidding price for spot instance. If set, only spot instances will be added as worker node.
-        :param pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
+        :param Mapping[str, 'TaintArgs'] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
         """
         pulumi.set(__self__, "cluster", cluster)
@@ -246,14 +246,14 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="bootstrapExtraArgs")
-    def bootstrap_extra_args(self) -> Optional[pulumi.Input[str]]:
+    def bootstrap_extra_args(self) -> Optional[str]:
         """
         Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         """
         return pulumi.get(self, "bootstrap_extra_args")
 
     @bootstrap_extra_args.setter
-    def bootstrap_extra_args(self, value: Optional[pulumi.Input[str]]):
+    def bootstrap_extra_args(self, value: Optional[str]):
         pulumi.set(self, "bootstrap_extra_args", value)
 
     @property
@@ -272,14 +272,14 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="clusterIngressRule")
-    def cluster_ingress_rule(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]:
+    def cluster_ingress_rule(self) -> Optional['pulumi_aws.ec2.SecurityGroupRule']:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
 
     @cluster_ingress_rule.setter
-    def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
+    def cluster_ingress_rule(self, value: Optional['pulumi_aws.ec2.SecurityGroupRule']):
         pulumi.set(self, "cluster_ingress_rule", value)
 
     @property
@@ -308,7 +308,7 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]:
+    def extra_node_security_groups(self) -> Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -317,7 +317,7 @@ class NodeGroupV2Args:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]):
+    def extra_node_security_groups(self, value: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -342,14 +342,14 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="instanceProfile")
-    def instance_profile(self) -> Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']]:
+    def instance_profile(self) -> Optional['pulumi_aws.iam.InstanceProfile']:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "instance_profile")
 
     @instance_profile.setter
-    def instance_profile(self, value: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']]):
+    def instance_profile(self, value: Optional['pulumi_aws.iam.InstanceProfile']):
         pulumi.set(self, "instance_profile", value)
 
     @property
@@ -378,26 +378,26 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="kubeletExtraArgs")
-    def kubelet_extra_args(self) -> Optional[pulumi.Input[str]]:
+    def kubelet_extra_args(self) -> Optional[str]:
         """
         Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         """
         return pulumi.get(self, "kubelet_extra_args")
 
     @kubelet_extra_args.setter
-    def kubelet_extra_args(self, value: Optional[pulumi.Input[str]]):
+    def kubelet_extra_args(self, value: Optional[str]):
         pulumi.set(self, "kubelet_extra_args", value)
 
     @property
     @pulumi.getter
-    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+    def labels(self) -> Optional[Mapping[str, str]]:
         """
         Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         """
         return pulumi.get(self, "labels")
 
     @labels.setter
-    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
+    def labels(self, value: Optional[Mapping[str, str]]):
         pulumi.set(self, "labels", value)
 
     @property
@@ -450,14 +450,14 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="nodeAssociatePublicIpAddress")
-    def node_associate_public_ip_address(self) -> Optional[pulumi.Input[bool]]:
+    def node_associate_public_ip_address(self) -> Optional[bool]:
         """
         Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         """
         return pulumi.get(self, "node_associate_public_ip_address")
 
     @node_associate_public_ip_address.setter
-    def node_associate_public_ip_address(self, value: Optional[pulumi.Input[bool]]):
+    def node_associate_public_ip_address(self, value: Optional[bool]):
         pulumi.set(self, "node_associate_public_ip_address", value)
 
     @property
@@ -488,7 +488,7 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
+    def node_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
         """
         The security group for the worker node group to communicate with the cluster.
 
@@ -502,7 +502,7 @@ class NodeGroupV2Args:
         return pulumi.get(self, "node_security_group")
 
     @node_security_group.setter
-    def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
+    def node_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
         pulumi.set(self, "node_security_group", value)
 
     @property
@@ -559,14 +559,14 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter
-    def taints(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]]:
+    def taints(self) -> Optional[Mapping[str, 'TaintArgs']]:
         """
         Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         """
         return pulumi.get(self, "taints")
 
     @taints.setter
-    def taints(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['TaintArgs']]]]):
+    def taints(self, value: Optional[Mapping[str, 'TaintArgs']]):
         pulumi.set(self, "taints", value)
 
     @property
@@ -590,32 +590,32 @@ class NodeGroupV2(pulumi.ComponentResource):
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  launch_template_tag_specifications: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_refresh_percentage: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['TaintArgs']]]]] = None,
+                 taints: Optional[Mapping[str, pulumi.InputType['TaintArgs']]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -641,15 +641,15 @@ class NodeGroupV2(pulumi.ComponentResource):
                Per AWS, all stack-level tags, including automatically created tags, and the `cloudFormationTags` option are propagated to resources that AWS CloudFormation supports, including the AutoScalingGroup. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param pulumi.Input[str] bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -661,21 +661,21 @@ class NodeGroupV2(pulumi.ComponentResource):
                See for more details:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
-        :param pulumi.Input['pulumi_aws.iam.InstanceProfile'] instance_profile: The ingress rule that gives node group access.
+        :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
         :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
-        :param pulumi.Input[str] kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+        :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]] launch_template_tag_specifications: The tag specifications to apply to the launch template.
         :param pulumi.Input[int] max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
         :param pulumi.Input[int] min_refresh_percentage: The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
         :param pulumi.Input[int] min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
-        :param pulumi.Input[bool] node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
+        :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -691,7 +691,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                
                See for more details: https://docs.aws.amazon.com/eks/latest/userguide/worker.html
         :param pulumi.Input[str] spot_price: Bidding price for spot instance. If set, only spot instances will be added as worker node.
-        :param pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['TaintArgs']]]] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
+        :param Mapping[str, pulumi.InputType['TaintArgs']] taints: Custom k8s node taints to be attached to each worker node. Adds the given taints to the `--register-with-taints` kubelet argument
         :param pulumi.Input[str] version: Desired Kubernetes master / control plane version. If you do not specify a value, the latest available version is used.
         """
         ...
@@ -721,32 +721,32 @@ class NodeGroupV2(pulumi.ComponentResource):
                  ami_id: Optional[pulumi.Input[str]] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 bootstrap_extra_args: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
+                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
-                 instance_profile: Optional[pulumi.Input['pulumi_aws.iam.InstanceProfile']] = None,
+                 instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
                  key_name: Optional[pulumi.Input[str]] = None,
-                 kubelet_extra_args: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
+                 labels: Optional[Mapping[str, str]] = None,
                  launch_template_tag_specifications: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
                  min_refresh_percentage: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
-                 node_associate_public_ip_address: Optional[pulumi.Input[bool]] = None,
+                 node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
                  spot_price: Optional[pulumi.Input[str]] = None,
-                 taints: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['TaintArgs']]]]] = None,
+                 taints: Optional[Mapping[str, pulumi.InputType['TaintArgs']]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:


### PR DESCRIPTION
There are cases where inputs to some components in the TS implementation are plain, but the schema doesn’t indicate they are plain (EKS was originally schematized before plain values were supported in the schema), so it’s possible someone could pass an `Output<T>` for these from multi-lang, which may result in problems in the implementation if it isn't expecting an `Output<T>` value.

Fixes #817