### PR TITLE
Remove unusable `provider` output from `ClusterCreationRoleProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Remove default for NodeRootVolumeSize that conflicted with NodeGroupOptions #813](https://github.com/pulumi/pulumi-eks/pull/813)
 - [Add support for passing Cluster to NodeGroup/NodeGroupV2/ManagedNodeGroup in all languages #815](https://github.com/pulumi/pulumi-eks/pull/815)
 - [Add kubeconfigJson output property to Cluster #815](https://github.com/pulumi/pulumi-eks/pull/815)
+- [Remove unusable `provider` output from `ClusterCreationRoleProvider` #823](https://github.com/pulumi/pulumi-eks/pull/823)
 
 ## 0.42.2 (Released Oct 12, 2022)
 - Fix internal registration of NodeGroupV2 resource.

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -606,13 +606,15 @@ func generateSchema() schema.PackageSpec {
 						"role": {
 							TypeSpec: schema.TypeSpec{Ref: awsRef("#/resources/aws:iam%2Frole:Role")},
 						},
-						"provider": {
-							TypeSpec: schema.TypeSpec{Ref: awsRef("#/provider")},
-						},
+						// Temporarily excluding the provider output since `Output<ProviderResource>`` is currently
+						// unusable from multi-lang because `ResourceOptions` requires a plain `ProviderResource`.
+						// "provider": {
+						// 	TypeSpec: schema.TypeSpec{Ref: awsRef("#/provider")},
+						// },
 					},
 					Required: []string{
 						"role",
-						"provider",
+						// "provider",
 					},
 				},
 				InputProperties: map[string]schema.PropertySpec{

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -883,16 +883,12 @@
         "eks:index:ClusterCreationRoleProvider": {
             "description": "ClusterCreationRoleProvider is a component that wraps creating a role provider that can be passed to the `Cluster`'s `creationRoleProvider`. This can be used to provide a specific role to use for the creation of the EKS cluster different from the role being used to run the Pulumi deployment.",
             "properties": {
-                "provider": {
-                    "$ref": "/aws/v5.4.0/schema.json#/provider"
-                },
                 "role": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:iam%2Frole:Role"
                 }
             },
             "required": [
-                "role",
-                "provider"
+                "role"
             ],
             "inputProperties": {
                 "profile": {

--- a/sdk/dotnet/ClusterCreationRoleProvider.cs
+++ b/sdk/dotnet/ClusterCreationRoleProvider.cs
@@ -15,9 +15,6 @@ namespace Pulumi.Eks
     [EksResourceType("eks:index:ClusterCreationRoleProvider")]
     public partial class ClusterCreationRoleProvider : Pulumi.ComponentResource
     {
-        [Output("provider")]
-        public Output<Pulumi.Aws.Provider> Provider { get; private set; } = null!;
-
         [Output("role")]
         public Output<Pulumi.Aws.Iam.Role> Role { get; private set; } = null!;
 

--- a/sdk/go/eks/clusterCreationRoleProvider.go
+++ b/sdk/go/eks/clusterCreationRoleProvider.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -16,8 +15,7 @@ import (
 type ClusterCreationRoleProvider struct {
 	pulumi.ResourceState
 
-	Provider aws.ProviderOutput `pulumi:"provider"`
-	Role     iam.RoleOutput     `pulumi:"role"`
+	Role iam.RoleOutput `pulumi:"role"`
 }
 
 // NewClusterCreationRoleProvider registers a new resource with the given unique name, arguments, and options.
@@ -131,10 +129,6 @@ func (o ClusterCreationRoleProviderOutput) ToClusterCreationRoleProviderOutput()
 
 func (o ClusterCreationRoleProviderOutput) ToClusterCreationRoleProviderOutputWithContext(ctx context.Context) ClusterCreationRoleProviderOutput {
 	return o
-}
-
-func (o ClusterCreationRoleProviderOutput) Provider() aws.ProviderOutput {
-	return o.ApplyT(func(v *ClusterCreationRoleProvider) aws.ProviderOutput { return v.Provider }).(aws.ProviderOutput)
 }
 
 func (o ClusterCreationRoleProviderOutput) Role() iam.RoleOutput {

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterCreationRoleProvider.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterCreationRoleProvider.java
@@ -3,7 +3,6 @@
 
 package com.pulumi.eks;
 
-import com.pulumi.aws.Provider;
 import com.pulumi.aws.iam.Role;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Export;
@@ -19,12 +18,6 @@ import javax.annotation.Nullable;
  */
 @ResourceType(type="eks:index:ClusterCreationRoleProvider")
 public class ClusterCreationRoleProvider extends com.pulumi.resources.ComponentResource {
-    @Export(name="provider", type=Provider.class, parameters={})
-    private Output<Provider> provider;
-
-    public Output<Provider> provider() {
-        return this.provider;
-    }
     @Export(name="role", type=Role.class, parameters={})
     private Output<Role> role;
 

--- a/sdk/python/pulumi_eks/cluster_creation_role_provider.py
+++ b/sdk/python/pulumi_eks/cluster_creation_role_provider.py
@@ -99,7 +99,6 @@ class ClusterCreationRoleProvider(pulumi.ComponentResource):
 
             __props__.__dict__["profile"] = profile
             __props__.__dict__["region"] = region
-            __props__.__dict__["provider"] = None
             __props__.__dict__["role"] = None
         super(ClusterCreationRoleProvider, __self__).__init__(
             'eks:index:ClusterCreationRoleProvider',
@@ -107,11 +106,6 @@ class ClusterCreationRoleProvider(pulumi.ComponentResource):
             __props__,
             opts,
             remote=True)
-
-    @property
-    @pulumi.getter
-    def provider(self) -> pulumi.Output['pulumi_aws.Provider']:
-        return pulumi.get(self, "provider")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
`Output<ProviderResource>` isn't usable, so let's not expose it. The workaround is to create your own `aws.Provider`, passing in the `ClusterCreationRoleProvider.role`'s `arn` for the provider's `roleArn`.

Fixes #822