### PR TITLE
Get VPC ID with VpcId instead of Id

### DIFF
--- a/examples/utils/testvpc/index.ts
+++ b/examples/utils/testvpc/index.ts
@@ -14,7 +14,7 @@ class Provider implements pulumi.provider.Provider {
         return Promise.resolve({
             urn: vpc.urn,
             state: {
-                vpcId: vpc.id,
+                vpcId: vpc.vpcId,
                 publicSubnetIds: vpc.publicSubnetIds,
                 privateSubnetIds: vpc.privateSubnetIds
             },

--- a/examples/utils/testvpc/package.json
+++ b/examples/utils/testvpc/package.json
@@ -3,11 +3,11 @@
     "main": "index.js",
     "devDependencies": {
         "typescript": "^3.0.0",
-        "@types/node": "latest"
+        "@types/node": "18.11.9"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/aws": "latest",
-        "@pulumi/awsx": "latest"
+        "@pulumi/pulumi": "^3.48.0",
+        "@pulumi/aws": "^5.21.1",
+        "@pulumi/awsx": "^1.0.0"
     }
 }


### PR DESCRIPTION
This should fix the currently failing tests (all of them).

We currently use AWSX within the examples (test) folder in testvpc, which has very lenient package locks (mostly latest). This has meant it's automatically moved from 0.40.0 to 1.0 in CI, which changed the way of getting a VPC ID from vpc.Id to vpc.VpcId.

In future, we should probably remove this code, likely when (if) we redesign our testing strategy. 
