### PR TITLE
Changing all the SecurityGroup  inputs to not use "Plain" to support …

### DIFF
--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1423,7 +1423,6 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				Items: &schema.TypeSpec{
 					Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
 				},
-				Plain: true,
 			},
 			Description: "Extra security groups to attach on all nodes in this worker node group.\n\n" +
 				"This additional set of security groups captures any user application rules that will be " +

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1412,8 +1412,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		},
 		"clusterIngressRule": {
 			TypeSpec: schema.TypeSpec{
-				Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule"),
-				Plain: true,
+				Ref: awsRef("#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule"),
 			},
 			Description: "The ingress rule that gives node group access.",
 		},

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -390,8 +390,7 @@ func generateSchema() schema.PackageSpec {
 					},
 					"clusterSecurityGroup": {
 						TypeSpec: schema.TypeSpec{
-							Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
-							Plain: true,
+							Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
 						},
 						Description: "The security group to use for the cluster API endpoint. If not provided, a new " +
 							"security group will be created with full internet egress and ingress from node groups.",
@@ -1402,8 +1401,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		},
 		"nodeSecurityGroup": {
 			TypeSpec: schema.TypeSpec{
-				Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
-				Plain: true,
+				Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
 			},
 			Description: "The security group for the worker node group to communicate with the cluster.\n\n" +
 				"This security group requires specific inbound and outbound rules.\n\n" +
@@ -1423,8 +1421,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 			TypeSpec: schema.TypeSpec{
 				Type: "array",
 				Items: &schema.TypeSpec{
-					Ref:   awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
-					Plain: true,
+					Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"),
 				},
 				Plain: true,
 			},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -43,7 +43,6 @@
                 },
                 "clusterIngressRule": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
-                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
@@ -1093,7 +1092,6 @@
                 },
                 "clusterIngressRule": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
-                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
@@ -1314,7 +1312,6 @@
                 },
                 "clusterIngressRule": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
-                    "plain": true,
                     "description": "The ingress rule that gives node group access."
                 },
                 "desiredCapacity": {

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -59,7 +59,6 @@
                     "items": {
                         "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
-                    "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
                 "gpu": {
@@ -1110,7 +1109,6 @@
                     "items": {
                         "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
-                    "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
                 "gpu": {
@@ -1332,7 +1330,6 @@
                     "items": {
                         "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
-                    "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
                 "gpu": {

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -57,8 +57,7 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                        "plain": true
+                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
@@ -117,7 +116,6 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "plain": true,
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
@@ -629,7 +627,6 @@
             "inputProperties": {
                 "clusterSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "plain": true,
                     "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups."
                 },
                 "clusterSecurityGroupTags": {
@@ -1111,8 +1108,7 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                        "plain": true
+                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
@@ -1171,7 +1167,6 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "plain": true,
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
@@ -1335,8 +1330,7 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                        "plain": true
+                        "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "plain": true,
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
@@ -1406,7 +1400,6 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v5.4.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "plain": true,
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -120,7 +120,7 @@ namespace Pulumi.Eks
         /// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         /// </summary>
         [Input("clusterSecurityGroup")]
-        public Pulumi.Aws.Ec2.SecurityGroup? ClusterSecurityGroup { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroup>? ClusterSecurityGroup { get; set; }
 
         [Input("clusterSecurityGroupTags")]
         private InputMap<string>? _clusterSecurityGroupTags;

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -93,16 +93,16 @@ namespace Pulumi.Eks.Inputs
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private List<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
+        private List<Input<Pulumi.Aws.Ec2.SecurityGroup>>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public List<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
+        public List<Input<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Pulumi.Aws.Ec2.SecurityGroup>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Input<Pulumi.Aws.Ec2.SecurityGroup>>());
             set => _extraNodeSecurityGroups = value;
         }
 
@@ -199,7 +199,7 @@ namespace Pulumi.Eks.Inputs
         /// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         /// </summary>
         [Input("nodeSecurityGroup")]
-        public Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -78,7 +78,7 @@ namespace Pulumi.Eks.Inputs
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("clusterIngressRule")]
-        public Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -93,16 +93,16 @@ namespace Pulumi.Eks.Inputs
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private List<Input<Pulumi.Aws.Ec2.SecurityGroup>>? _extraNodeSecurityGroups;
+        private InputList<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public List<Input<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups
+        public InputList<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Input<Pulumi.Aws.Ec2.SecurityGroup>>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new InputList<Pulumi.Aws.Ec2.SecurityGroup>());
             set => _extraNodeSecurityGroups = value;
         }
 

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -136,7 +136,7 @@ namespace Pulumi.Eks
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("clusterIngressRule")]
-        public Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -151,16 +151,16 @@ namespace Pulumi.Eks
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private List<Input<Pulumi.Aws.Ec2.SecurityGroup>>? _extraNodeSecurityGroups;
+        private InputList<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public List<Input<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups
+        public InputList<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Input<Pulumi.Aws.Ec2.SecurityGroup>>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new InputList<Pulumi.Aws.Ec2.SecurityGroup>());
             set => _extraNodeSecurityGroups = value;
         }
 

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -151,16 +151,16 @@ namespace Pulumi.Eks
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private List<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
+        private List<Input<Pulumi.Aws.Ec2.SecurityGroup>>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public List<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
+        public List<Input<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Pulumi.Aws.Ec2.SecurityGroup>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Input<Pulumi.Aws.Ec2.SecurityGroup>>());
             set => _extraNodeSecurityGroups = value;
         }
 
@@ -257,7 +257,7 @@ namespace Pulumi.Eks
         /// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         /// </summary>
         [Input("nodeSecurityGroup")]
-        public Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -130,7 +130,7 @@ namespace Pulumi.Eks
         /// The ingress rule that gives node group access.
         /// </summary>
         [Input("clusterIngressRule")]
-        public Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -145,16 +145,16 @@ namespace Pulumi.Eks
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private List<Input<Pulumi.Aws.Ec2.SecurityGroup>>? _extraNodeSecurityGroups;
+        private InputList<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public List<Input<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups
+        public InputList<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Input<Pulumi.Aws.Ec2.SecurityGroup>>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new InputList<Pulumi.Aws.Ec2.SecurityGroup>());
             set => _extraNodeSecurityGroups = value;
         }
 

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -145,16 +145,16 @@ namespace Pulumi.Eks
         public Input<bool>? EncryptRootBlockDevice { get; set; }
 
         [Input("extraNodeSecurityGroups")]
-        private List<Pulumi.Aws.Ec2.SecurityGroup>? _extraNodeSecurityGroups;
+        private List<Input<Pulumi.Aws.Ec2.SecurityGroup>>? _extraNodeSecurityGroups;
 
         /// <summary>
         /// Extra security groups to attach on all nodes in this worker node group.
         /// 
         /// This additional set of security groups captures any user application rules that will be needed for the nodes.
         /// </summary>
-        public List<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups
+        public List<Input<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups
         {
-            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Pulumi.Aws.Ec2.SecurityGroup>());
+            get => _extraNodeSecurityGroups ?? (_extraNodeSecurityGroups = new List<Input<Pulumi.Aws.Ec2.SecurityGroup>>());
             set => _extraNodeSecurityGroups = value;
         }
 
@@ -269,7 +269,7 @@ namespace Pulumi.Eks
         /// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         /// </summary>
         [Input("nodeSecurityGroup")]
-        public Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup { get; set; }
+        public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -263,7 +263,7 @@ type clusterArgs struct {
 // The set of arguments for constructing a Cluster resource.
 type ClusterArgs struct {
 	// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
-	ClusterSecurityGroup *ec2.SecurityGroup
+	ClusterSecurityGroup ec2.SecurityGroupInput
 	// The tags to apply to the cluster security group.
 	ClusterSecurityGroupTags pulumi.StringMapInput
 	// The tags to apply to the EKS cluster.

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -177,7 +177,7 @@ type NodeGroupArgs struct {
 	// The target EKS cluster.
 	Cluster pulumi.Input
 	// The ingress rule that gives node group access.
-	ClusterIngressRule *ec2.SecurityGroupRule
+	ClusterIngressRule ec2.SecurityGroupRuleInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
 	// Encrypt the root block device of the nodes in the node group.

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -185,7 +185,7 @@ type NodeGroupArgs struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups []*ec2.SecurityGroup
+	ExtraNodeSecurityGroups []ec2.SecurityGroupInput
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.
@@ -226,7 +226,7 @@ type NodeGroupArgs struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-	NodeSecurityGroup *ec2.SecurityGroup
+	NodeSecurityGroup ec2.SecurityGroupInput
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -185,7 +185,7 @@ type NodeGroupArgs struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups []ec2.SecurityGroupInput
+	ExtraNodeSecurityGroups ec2.SecurityGroupArrayInput
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -187,7 +187,7 @@ type NodeGroupV2Args struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups []ec2.SecurityGroupInput
+	ExtraNodeSecurityGroups ec2.SecurityGroupArrayInput
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -179,7 +179,7 @@ type NodeGroupV2Args struct {
 	// The target EKS cluster.
 	Cluster pulumi.Input
 	// The ingress rule that gives node group access.
-	ClusterIngressRule *ec2.SecurityGroupRule
+	ClusterIngressRule ec2.SecurityGroupRuleInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
 	// Encrypt the root block device of the nodes in the node group.

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -187,7 +187,7 @@ type NodeGroupV2Args struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups []*ec2.SecurityGroup
+	ExtraNodeSecurityGroups []ec2.SecurityGroupInput
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.
@@ -232,7 +232,7 @@ type NodeGroupV2Args struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-	NodeSecurityGroup *ec2.SecurityGroup
+	NodeSecurityGroup ec2.SecurityGroupInput
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -158,7 +158,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
 	CloudFormationTags pulumi.StringMapInput `pulumi:"cloudFormationTags"`
 	// The ingress rule that gives node group access.
-	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
+	ClusterIngressRule ec2.SecurityGroupRuleInput `pulumi:"clusterIngressRule"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput `pulumi:"desiredCapacity"`
 	// Encrypt the root block device of the nodes in the node group.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -166,7 +166,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups []*ec2.SecurityGroup `pulumi:"extraNodeSecurityGroups"`
+	ExtraNodeSecurityGroups []ec2.SecurityGroupInput `pulumi:"extraNodeSecurityGroups"`
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.
@@ -207,7 +207,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
+	NodeSecurityGroup ec2.SecurityGroupInput `pulumi:"nodeSecurityGroup"`
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -166,7 +166,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	// Extra security groups to attach on all nodes in this worker node group.
 	//
 	// This additional set of security groups captures any user application rules that will be needed for the nodes.
-	ExtraNodeSecurityGroups []ec2.SecurityGroupInput `pulumi:"extraNodeSecurityGroups"`
+	ExtraNodeSecurityGroups ec2.SecurityGroupArrayInput `pulumi:"extraNodeSecurityGroups"`
 	// Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
 	//
 	// Defaults to false.

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -35,13 +35,13 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="clusterSecurityGroup")
-    private @Nullable SecurityGroup clusterSecurityGroup;
+    private @Nullable Output<SecurityGroup> clusterSecurityGroup;
 
     /**
      * @return The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
      * 
      */
-    public Optional<SecurityGroup> clusterSecurityGroup() {
+    public Optional<Output<SecurityGroup>> clusterSecurityGroup() {
         return Optional.ofNullable(this.clusterSecurityGroup);
     }
 
@@ -1015,9 +1015,19 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder clusterSecurityGroup(@Nullable SecurityGroup clusterSecurityGroup) {
+        public Builder clusterSecurityGroup(@Nullable Output<SecurityGroup> clusterSecurityGroup) {
             $.clusterSecurityGroup = clusterSecurityGroup;
             return this;
+        }
+
+        /**
+         * @param clusterSecurityGroup The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterSecurityGroup(SecurityGroup clusterSecurityGroup) {
+            return clusterSecurityGroup(Output.of(clusterSecurityGroup));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -411,7 +411,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeSecurityGroup")
-    private @Nullable SecurityGroup nodeSecurityGroup;
+    private @Nullable Output<SecurityGroup> nodeSecurityGroup;
 
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -424,7 +424,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      * 
      */
-    public Optional<SecurityGroup> nodeSecurityGroup() {
+    public Optional<Output<SecurityGroup>> nodeSecurityGroup() {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
 
@@ -1049,9 +1049,26 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeSecurityGroup(@Nullable SecurityGroup nodeSecurityGroup) {
+        public Builder nodeSecurityGroup(@Nullable Output<SecurityGroup> nodeSecurityGroup) {
             $.nodeSecurityGroup = nodeSecurityGroup;
             return this;
+        }
+
+        /**
+         * @param nodeSecurityGroup The security group for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
+            return nodeSecurityGroup(Output.of(nodeSecurityGroup));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -155,13 +155,13 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="clusterIngressRule")
-    private @Nullable SecurityGroupRule clusterIngressRule;
+    private @Nullable Output<SecurityGroupRule> clusterIngressRule;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<SecurityGroupRule> clusterIngressRule() {
+    public Optional<Output<SecurityGroupRule>> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
     }
 
@@ -753,9 +753,19 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
+        public Builder clusterIngressRule(@Nullable Output<SecurityGroupRule> clusterIngressRule) {
             $.clusterIngressRule = clusterIngressRule;
             return this;
+        }
+
+        /**
+         * @param clusterIngressRule The ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
+            return clusterIngressRule(Output.of(clusterIngressRule));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -202,7 +202,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="extraNodeSecurityGroups")
-    private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
+    private @Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups;
 
     /**
      * @return Extra security groups to attach on all nodes in this worker node group.
@@ -210,7 +210,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      * This additional set of security groups captures any user application rules that will be needed for the nodes.
      * 
      */
-    public Optional<List<SecurityGroup>> extraNodeSecurityGroups() {
+    public Optional<Output<List<SecurityGroup>>> extraNodeSecurityGroups() {
         return Optional.ofNullable(this.extraNodeSecurityGroups);
     }
 
@@ -808,9 +808,21 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder extraNodeSecurityGroups(@Nullable List<SecurityGroup> extraNodeSecurityGroups) {
+        public Builder extraNodeSecurityGroups(@Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups) {
             $.extraNodeSecurityGroups = extraNodeSecurityGroups;
             return this;
+        }
+
+        /**
+         * @param extraNodeSecurityGroups Extra security groups to attach on all nodes in this worker node group.
+         * 
+         * This additional set of security groups captures any user application rules that will be needed for the nodes.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder extraNodeSecurityGroups(List<SecurityGroup> extraNodeSecurityGroups) {
+            return extraNodeSecurityGroups(Output.of(extraNodeSecurityGroups));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -156,13 +156,13 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="clusterIngressRule")
-    private @Nullable SecurityGroupRule clusterIngressRule;
+    private @Nullable Output<SecurityGroupRule> clusterIngressRule;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<SecurityGroupRule> clusterIngressRule() {
+    public Optional<Output<SecurityGroupRule>> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
     }
 
@@ -786,9 +786,19 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
+        public Builder clusterIngressRule(@Nullable Output<SecurityGroupRule> clusterIngressRule) {
             $.clusterIngressRule = clusterIngressRule;
             return this;
+        }
+
+        /**
+         * @param clusterIngressRule The ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
+            return clusterIngressRule(Output.of(clusterIngressRule));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -442,7 +442,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="nodeSecurityGroup")
-    private @Nullable SecurityGroup nodeSecurityGroup;
+    private @Nullable Output<SecurityGroup> nodeSecurityGroup;
 
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -455,7 +455,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      * 
      */
-    public Optional<SecurityGroup> nodeSecurityGroup() {
+    public Optional<Output<SecurityGroup>> nodeSecurityGroup() {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
 
@@ -1134,9 +1134,26 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder nodeSecurityGroup(@Nullable SecurityGroup nodeSecurityGroup) {
+        public Builder nodeSecurityGroup(@Nullable Output<SecurityGroup> nodeSecurityGroup) {
             $.nodeSecurityGroup = nodeSecurityGroup;
             return this;
+        }
+
+        /**
+         * @param nodeSecurityGroup The security group for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
+            return nodeSecurityGroup(Output.of(nodeSecurityGroup));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -203,7 +203,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="extraNodeSecurityGroups")
-    private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
+    private @Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups;
 
     /**
      * @return Extra security groups to attach on all nodes in this worker node group.
@@ -211,7 +211,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      * This additional set of security groups captures any user application rules that will be needed for the nodes.
      * 
      */
-    public Optional<List<SecurityGroup>> extraNodeSecurityGroups() {
+    public Optional<Output<List<SecurityGroup>>> extraNodeSecurityGroups() {
         return Optional.ofNullable(this.extraNodeSecurityGroups);
     }
 
@@ -841,9 +841,21 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder extraNodeSecurityGroups(@Nullable List<SecurityGroup> extraNodeSecurityGroups) {
+        public Builder extraNodeSecurityGroups(@Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups) {
             $.extraNodeSecurityGroups = extraNodeSecurityGroups;
             return this;
+        }
+
+        /**
+         * @param extraNodeSecurityGroups Extra security groups to attach on all nodes in this worker node group.
+         * 
+         * This additional set of security groups captures any user application rules that will be needed for the nodes.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder extraNodeSecurityGroups(List<SecurityGroup> extraNodeSecurityGroups) {
+            return extraNodeSecurityGroups(Output.of(extraNodeSecurityGroups));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -397,7 +397,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="nodeSecurityGroup")
-    private @Nullable SecurityGroup nodeSecurityGroup;
+    private @Nullable Output<SecurityGroup> nodeSecurityGroup;
 
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -410,7 +410,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      * 
      */
-    public Optional<SecurityGroup> nodeSecurityGroup() {
+    public Optional<Output<SecurityGroup>> nodeSecurityGroup() {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
 
@@ -993,9 +993,26 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder nodeSecurityGroup(@Nullable SecurityGroup nodeSecurityGroup) {
+        public Builder nodeSecurityGroup(@Nullable Output<SecurityGroup> nodeSecurityGroup) {
             $.nodeSecurityGroup = nodeSecurityGroup;
             return this;
+        }
+
+        /**
+         * @param nodeSecurityGroup The security group for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
+            return nodeSecurityGroup(Output.of(nodeSecurityGroup));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -141,13 +141,13 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="clusterIngressRule")
-    private @Nullable SecurityGroupRule clusterIngressRule;
+    private @Nullable Output<SecurityGroupRule> clusterIngressRule;
 
     /**
      * @return The ingress rule that gives node group access.
      * 
      */
-    public Optional<SecurityGroupRule> clusterIngressRule() {
+    public Optional<Output<SecurityGroupRule>> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
     }
 
@@ -697,9 +697,19 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
+        public Builder clusterIngressRule(@Nullable Output<SecurityGroupRule> clusterIngressRule) {
             $.clusterIngressRule = clusterIngressRule;
             return this;
+        }
+
+        /**
+         * @param clusterIngressRule The ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
+            return clusterIngressRule(Output.of(clusterIngressRule));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -188,7 +188,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="extraNodeSecurityGroups")
-    private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
+    private @Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups;
 
     /**
      * @return Extra security groups to attach on all nodes in this worker node group.
@@ -196,7 +196,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      * This additional set of security groups captures any user application rules that will be needed for the nodes.
      * 
      */
-    public Optional<List<SecurityGroup>> extraNodeSecurityGroups() {
+    public Optional<Output<List<SecurityGroup>>> extraNodeSecurityGroups() {
         return Optional.ofNullable(this.extraNodeSecurityGroups);
     }
 
@@ -752,9 +752,21 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder extraNodeSecurityGroups(@Nullable List<SecurityGroup> extraNodeSecurityGroups) {
+        public Builder extraNodeSecurityGroups(@Nullable Output<List<SecurityGroup>> extraNodeSecurityGroups) {
             $.extraNodeSecurityGroups = extraNodeSecurityGroups;
             return this;
+        }
+
+        /**
+         * @param extraNodeSecurityGroups Extra security groups to attach on all nodes in this worker node group.
+         * 
+         * This additional set of security groups captures any user application rules that will be needed for the nodes.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder extraNodeSecurityGroups(List<SecurityGroup> extraNodeSecurityGroups) {
+            return extraNodeSecurityGroups(Output.of(extraNodeSecurityGroups));
         }
 
         /**

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -35,7 +35,7 @@ class ClusterNodeGroupOptionsArgs:
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -81,7 +81,7 @@ class ClusterNodeGroupOptionsArgs:
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -294,7 +294,7 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]:
+    def extra_node_security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -303,7 +303,7 @@ class ClusterNodeGroupOptionsArgs:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]):
+    def extra_node_security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -35,7 +35,7 @@ class ClusterNodeGroupOptionsArgs:
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -47,7 +47,7 @@ class ClusterNodeGroupOptionsArgs:
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -81,7 +81,7 @@ class ClusterNodeGroupOptionsArgs:
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -105,7 +105,7 @@ class ClusterNodeGroupOptionsArgs:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -294,7 +294,7 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]:
+    def extra_node_security_groups(self) -> Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -303,7 +303,7 @@ class ClusterNodeGroupOptionsArgs:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]):
+    def extra_node_security_groups(self, value: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -450,7 +450,7 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
+    def node_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
         """
         The security group for the worker node group to communicate with the cluster.
 
@@ -464,7 +464,7 @@ class ClusterNodeGroupOptionsArgs:
         return pulumi.get(self, "node_security_group")
 
     @node_security_group.setter
-    def node_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
+    def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "node_security_group", value)
 
     @property

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -32,7 +32,7 @@ class ClusterNodeGroupOptionsArgs:
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
@@ -78,7 +78,7 @@ class ClusterNodeGroupOptionsArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
@@ -258,14 +258,14 @@ class ClusterNodeGroupOptionsArgs:
 
     @property
     @pulumi.getter(name="clusterIngressRule")
-    def cluster_ingress_rule(self) -> Optional['pulumi_aws.ec2.SecurityGroupRule']:
+    def cluster_ingress_rule(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
 
     @cluster_ingress_rule.setter
-    def cluster_ingress_rule(self, value: Optional['pulumi_aws.ec2.SecurityGroupRule']):
+    def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
         pulumi.set(self, "cluster_ingress_rule", value)
 
     @property

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -18,7 +18,7 @@ __all__ = ['ClusterArgs', 'Cluster']
 @pulumi.input_type
 class ClusterArgs:
     def __init__(__self__, *,
-                 cluster_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
@@ -66,7 +66,7 @@ class ClusterArgs:
                  vpc_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Cluster resource.
-        :param 'pulumi_aws.ec2.SecurityGroup' cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
@@ -318,14 +318,14 @@ class ClusterArgs:
 
     @property
     @pulumi.getter(name="clusterSecurityGroup")
-    def cluster_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
+    def cluster_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
         """
         The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         """
         return pulumi.get(self, "cluster_security_group")
 
     @cluster_security_group.setter
-    def cluster_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
+    def cluster_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "cluster_security_group", value)
 
     @property
@@ -984,7 +984,7 @@ class Cluster(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cluster_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
@@ -1036,7 +1036,7 @@ class Cluster(pulumi.ComponentResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param 'pulumi_aws.ec2.SecurityGroup' cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
@@ -1217,7 +1217,7 @@ class Cluster(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cluster_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -27,7 +27,7 @@ class NodeGroupArgs:
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -39,7 +39,7 @@ class NodeGroupArgs:
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -74,7 +74,7 @@ class NodeGroupArgs:
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -98,7 +98,7 @@ class NodeGroupArgs:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -300,7 +300,7 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]:
+    def extra_node_security_groups(self) -> Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -309,7 +309,7 @@ class NodeGroupArgs:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]):
+    def extra_node_security_groups(self, value: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -456,7 +456,7 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
+    def node_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
         """
         The security group for the worker node group to communicate with the cluster.
 
@@ -470,7 +470,7 @@ class NodeGroupArgs:
         return pulumi.get(self, "node_security_group")
 
     @node_security_group.setter
-    def node_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
+    def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "node_security_group", value)
 
     @property
@@ -564,7 +564,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -576,7 +576,7 @@ class NodeGroup(pulumi.ComponentResource):
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -615,7 +615,7 @@ class NodeGroup(pulumi.ComponentResource):
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -639,7 +639,7 @@ class NodeGroup(pulumi.ComponentResource):
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -691,7 +691,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -703,7 +703,7 @@ class NodeGroup(pulumi.ComponentResource):
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -27,7 +27,7 @@ class NodeGroupArgs:
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -74,7 +74,7 @@ class NodeGroupArgs:
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -300,7 +300,7 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]:
+    def extra_node_security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -309,7 +309,7 @@ class NodeGroupArgs:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]):
+    def extra_node_security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -564,7 +564,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -615,7 +615,7 @@ class NodeGroup(pulumi.ComponentResource):
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -691,7 +691,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -24,7 +24,7 @@ class NodeGroupArgs:
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
@@ -71,7 +71,7 @@ class NodeGroupArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
@@ -264,14 +264,14 @@ class NodeGroupArgs:
 
     @property
     @pulumi.getter(name="clusterIngressRule")
-    def cluster_ingress_rule(self) -> Optional['pulumi_aws.ec2.SecurityGroupRule']:
+    def cluster_ingress_rule(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
 
     @cluster_ingress_rule.setter
-    def cluster_ingress_rule(self, value: Optional['pulumi_aws.ec2.SecurityGroupRule']):
+    def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
         pulumi.set(self, "cluster_ingress_rule", value)
 
     @property
@@ -561,7 +561,7 @@ class NodeGroup(pulumi.ComponentResource):
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
@@ -612,7 +612,7 @@ class NodeGroup(pulumi.ComponentResource):
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
-        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
@@ -688,7 +688,7 @@ class NodeGroup(pulumi.ComponentResource):
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -27,7 +27,7 @@ class NodeGroupV2Args:
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -76,7 +76,7 @@ class NodeGroupV2Args:
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -308,7 +308,7 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]:
+    def extra_node_security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -317,7 +317,7 @@ class NodeGroupV2Args:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]):
+    def extra_node_security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -596,7 +596,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -649,7 +649,7 @@ class NodeGroupV2(pulumi.ComponentResource):
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -727,7 +727,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
+                 extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -27,7 +27,7 @@ class NodeGroupV2Args:
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -41,7 +41,7 @@ class NodeGroupV2Args:
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -76,7 +76,7 @@ class NodeGroupV2Args:
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -102,7 +102,7 @@ class NodeGroupV2Args:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -308,7 +308,7 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")
-    def extra_node_security_groups(self) -> Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]:
+    def extra_node_security_groups(self) -> Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]:
         """
         Extra security groups to attach on all nodes in this worker node group.
 
@@ -317,7 +317,7 @@ class NodeGroupV2Args:
         return pulumi.get(self, "extra_node_security_groups")
 
     @extra_node_security_groups.setter
-    def extra_node_security_groups(self, value: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']]):
+    def extra_node_security_groups(self, value: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]):
         pulumi.set(self, "extra_node_security_groups", value)
 
     @property
@@ -488,7 +488,7 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> Optional['pulumi_aws.ec2.SecurityGroup']:
+    def node_security_group(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]:
         """
         The security group for the worker node group to communicate with the cluster.
 
@@ -502,7 +502,7 @@ class NodeGroupV2Args:
         return pulumi.get(self, "node_security_group")
 
     @node_security_group.setter
-    def node_security_group(self, value: Optional['pulumi_aws.ec2.SecurityGroup']):
+    def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "node_security_group", value)
 
     @property
@@ -596,7 +596,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -610,7 +610,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -649,7 +649,7 @@ class NodeGroupV2(pulumi.ComponentResource):
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
-        :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
+        :param Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
                This additional set of security groups captures any user application rules that will be needed for the nodes.
         :param pulumi.Input[bool] gpu: Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.
@@ -675,7 +675,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
-        :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -727,7 +727,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
-                 extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
+                 extra_node_security_groups: Optional[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
                  instance_profile: Optional['pulumi_aws.iam.InstanceProfile'] = None,
                  instance_type: Optional[pulumi.Input[str]] = None,
@@ -741,7 +741,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
-                 node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -24,7 +24,7 @@ class NodeGroupV2Args:
                  auto_scaling_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
@@ -73,7 +73,7 @@ class NodeGroupV2Args:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cloud_formation_tags: The tags to apply to the CloudFormation Stack of the Worker NodeGroup.
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
-        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
@@ -272,14 +272,14 @@ class NodeGroupV2Args:
 
     @property
     @pulumi.getter(name="clusterIngressRule")
-    def cluster_ingress_rule(self) -> Optional['pulumi_aws.ec2.SecurityGroupRule']:
+    def cluster_ingress_rule(self) -> Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]:
         """
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
 
     @cluster_ingress_rule.setter
-    def cluster_ingress_rule(self, value: Optional['pulumi_aws.ec2.SecurityGroupRule']):
+    def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
         pulumi.set(self, "cluster_ingress_rule", value)
 
     @property
@@ -593,7 +593,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
@@ -646,7 +646,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
-        :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
@@ -724,7 +724,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  bootstrap_extra_args: Optional[str] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
-                 cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,


### PR DESCRIPTION
…outputs being used

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
Change the SecurityGroups back to allowing outputs to be passed.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #829
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
