### PR TITLE
Upgrade .Net to 6.x from 3.1

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,6 +19,11 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   PULUMI_ENABLE_RESOURCE_REFERENCES: 1
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  GOVERSION: "1.19.x"
+  DOTNETVERSION: "6.x"
+  PYTHONVERSION: "3.8"
+  NODEVERSION: "18.x"
+  JAVAVERSION: "11"
 jobs:
   lint:
     name: lint
@@ -35,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -73,7 +78,8 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin/ pulumi-resource-${{ env.PROVIDER }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -106,7 +112,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -116,22 +122,22 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: ${{matrix.javaversion}}
+          java-version: ${{ env.JAVAVERSION }}
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn
@@ -163,21 +169,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dotnetversion:
-          - 3.1
-        goversion:
-          - 1.19.x
         language:
           - nodejs
           - python
           - dotnet
           - java
-        javaversion:
-          - 11
-        nodeversion:
-          - 18.x
-        pythonversion:
-          - 3.8
   test-nodejs:
     name: Run NodeJS Tests
     needs: build_sdk
@@ -195,11 +191,11 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -213,7 +209,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Download provider binary
         uses: actions/download-artifact@v2
@@ -221,22 +217,24 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
       - name: Download SDK
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.language }}-sdk.tar.gz
+          name: nodejs-sdk.tar.gz
           path: ${{ github.workspace}}
       - name: Uncompress SDK folder
-        run: tar -zxf ${{ github.workspace}}/${{ matrix.language }}.tar.gz -C ${{github.workspace}}/${{ matrix.language }}
+        run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
+        run: make install_nodejs_sdk
       - name: Install gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
         with:
@@ -262,16 +260,10 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=${{ matrix.language }}
+        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=nodejs
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        language:
-          - nodejs
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfile
           - Cluster
@@ -311,7 +303,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -319,7 +311,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -329,12 +321,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install Python deps
         run: |-
           pip3 install virtualenv==20.0.23
@@ -345,10 +337,12 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -399,12 +393,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        pythonversion:
-          - 3.8
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfilePy
           - AwsProfileRolePy
@@ -429,11 +417,11 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install python
         uses: actions/setup-python@v2
         with:
-            python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -447,22 +435,24 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Download provider binary
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -514,16 +504,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        dotnetversion:
-          - 3.1
-        nodeversion:
-          - 18.x
         test-name:
           - ClusterCs
 name: cron
 "on":
   schedule:
     # Run every day at 06:00AM UTC
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -192,10 +192,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -308,10 +308,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
           repo: pulumi/pulumictl
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -323,10 +323,6 @@ jobs:
         with:
           node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
       - name: Install Python deps
         run: |-
           pip3 install virtualenv==20.0.23
@@ -418,10 +414,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,6 +19,11 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   PULUMI_ENABLE_RESOURCE_REFERENCES: 1
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  GOVERSION: "1.19.x"
+  DOTNETVERSION: "6.x"
+  PYTHONVERSION: "3.8"
+  NODEVERSION: "18.x"
+  JAVAVERSION: "11"
 jobs:
   lint:
     name: lint
@@ -35,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -73,7 +78,8 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin/ pulumi-resource-${{ env.PROVIDER }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -106,7 +112,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -116,22 +122,22 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: ${{matrix.javaversion}}
+          java-version: ${{ env.JAVAVERSION }}
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn
@@ -163,21 +169,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dotnetversion:
-          - 3.1
-        goversion:
-          - 1.19.x
         language:
           - nodejs
           - python
           - dotnet
           - java
-        javaversion:
-          - 11
-        nodeversion:
-          - 18.x
-        pythonversion:
-          - 3.8
   publish:
     name: publish
     needs: [test-nodejs, test-python, test-dotnet]
@@ -247,7 +243,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        run:
+          echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
           $GITHUB_ENV
       - name: Download NodeJS SDK
         uses: actions/download-artifact@v2
@@ -314,7 +311,8 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        run:
+          echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
           $GITHUB_ENV
       - name: Download Java SDK
         uses: actions/download-artifact@v2
@@ -346,11 +344,11 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -364,7 +362,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Download provider binary
         uses: actions/download-artifact@v2
@@ -372,22 +370,24 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
       - name: Download SDK
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.language }}-sdk.tar.gz
+          name: nodejs-sdk.tar.gz
           path: ${{ github.workspace}}
       - name: Uncompress SDK folder
-        run: tar -zxf ${{ github.workspace}}/${{ matrix.language }}.tar.gz -C ${{github.workspace}}/${{ matrix.language }}
+        run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
+        run: make install_nodejs_sdk
       - name: Install gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
         with:
@@ -413,16 +413,10 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=${{ matrix.language }}
+        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=nodejs
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        language:
-          - nodejs
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfile
           - Cluster
@@ -462,7 +456,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -470,7 +464,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -480,12 +474,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install Python deps
         run: |-
           pip3 install virtualenv==20.0.23
@@ -496,10 +490,12 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -550,12 +546,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        pythonversion:
-          - 3.8
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfilePy
           - AwsProfileRolePy
@@ -580,11 +570,11 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install python
         uses: actions/setup-python@v2
         with:
-            python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -598,22 +588,24 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Download provider binary
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -665,12 +657,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        dotnetversion:
-          - 3.1
-        nodeversion:
-          - 18.x
         test-name:
           - ClusterCs
 name: master
@@ -684,5 +670,5 @@ name: master
     tags-ignore:
       - v*
       - sdk/*
-      - '**'
+      - "**"
   workflow_dispatch: {}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -228,7 +228,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -239,9 +239,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           always-auth: true
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
@@ -290,7 +293,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -301,15 +304,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           always-auth: true
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: 11
+          java-version: ${{ env.JAVAVERSION }}
       - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
@@ -345,10 +351,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -461,10 +467,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
           repo: pulumi/pulumictl
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -476,10 +482,6 @@ jobs:
         with:
           node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
       - name: Install Python deps
         run: |-
           pip3 install virtualenv==20.0.23
@@ -571,10 +573,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   PULUMI_ENABLE_RESOURCE_REFERENCES: 1
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  GOVERSION: "1.19.x"
+  DOTNETVERSION: "6.x"
+  PYTHONVERSION: "3.8"
+  NODEVERSION: "18.x"
+  JAVAVERSION: "11"
 jobs:
   lint:
     name: lint
@@ -35,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -62,7 +67,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -72,22 +77,22 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: ${{matrix.javaversion}}
+          java-version: ${{ env.JAVAVERSION }}
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn
@@ -119,21 +124,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dotnetversion:
-          - 3.1
-        goversion:
-          - 1.19.x
         language:
           - nodejs
           - python
           - dotnet
           - java
-        javaversion:
-          - 11
-        nodeversion:
-          - 18.x
-        pythonversion:
-          - 3.8
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -162,7 +157,8 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin/ pulumi-resource-${{ env.PROVIDER }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -245,7 +241,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        run:
+          echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
           $GITHUB_ENV
       - name: Download NodeJS SDK
         uses: actions/download-artifact@v2
@@ -313,7 +310,8 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        run:
+          echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
           $GITHUB_ENV
       - name: Download Java SDK
         uses: actions/download-artifact@v2
@@ -358,7 +356,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -366,7 +364,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -376,7 +374,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Download provider binary
         uses: actions/download-artifact@v2
@@ -384,22 +382,24 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
       - name: Download SDK
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.language }}-sdk.tar.gz
+          name: nodejs-sdk.tar.gz
           path: ${{ github.workspace}}
       - name: Uncompress SDK folder
-        run: tar -zxf ${{ github.workspace}}/${{ matrix.language }}.tar.gz -C ${{github.workspace}}/${{ matrix.language}}
+        run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
+        run: make install_nodejs_sdk
       - name: Install gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
         with:
@@ -425,16 +425,10 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=${{ matrix.language }}
+        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=nodejs
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        language:
-          - nodejs
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfile
           - Cluster
@@ -474,7 +468,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -484,16 +478,16 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -508,10 +502,12 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -562,12 +558,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        pythonversion:
-          - 3.8
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfilePy
           - AwsProfileRolePy
@@ -592,7 +582,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -602,7 +592,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -610,22 +600,24 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Download provider binary
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -677,12 +669,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        dotnetversion:
-          - 3.1
-        nodeversion:
-          - 18.x
         test-name:
           - ClusterCs
   tag_sdk:
@@ -697,7 +683,8 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Add SDK version tag
-        run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
+        run:
+          git tag sdk/v$(pulumictl get version --language generic) && git push origin
           sdk/v$(pulumictl get version --language generic)
 name: release
 "on":

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -226,7 +226,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -237,9 +237,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           always-auth: true
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
@@ -289,7 +292,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -300,15 +303,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           always-auth: true
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: 11
+          java-version: ${{ env.JAVAVERSION }}
       - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
@@ -361,10 +367,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
           repo: pulumi/pulumictl
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -484,10 +490,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHONVERSION }}
-      - name: Install python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -589,10 +591,10 @@ jobs:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -28,6 +28,11 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   PULUMI_ENABLE_RESOURCE_REFERENCES: 1
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  GOVERSION: "1.19.x"
+  DOTNETVERSION: "6.x"
+  PYTHONVERSION: "3.8"
+  NODEVERSION: "18.x"
+  JAVAVERSION: "11"
 jobs:
   comment-notification:
     if: github.event_name == 'repository_dispatch'
@@ -59,7 +64,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -116,7 +121,8 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin/ pulumi-resource-${{ env.PROVIDER }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -145,7 +151,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -155,22 +161,22 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: ${{matrix.javaversion}}
+          java-version: ${{ env.JAVAVERSION }}
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn
@@ -202,22 +208,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dotnetversion:
-          - 3.1
-        goversion:
-          - 1.19.x
         language:
           - nodejs
           - python
           - dotnet
           - go
           - java
-        javaversion:
-          - 11
-        nodeversion:
-          - 18.x
-        pythonversion:
-          - 3.8
   test-nodejs:
     name: Run NodeJS Tests
     needs: build_sdk
@@ -238,7 +234,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install Kubectl
         run: |
           curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
@@ -247,7 +243,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -261,7 +257,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Download provider binary
         uses: actions/download-artifact@v2
@@ -269,22 +265,24 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
       - name: Download SDK
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.language }}-sdk.tar.gz
+          name: nodejs-sdk.tar.gz
           path: ${{ github.workspace}}
       - name: Uncompress SDK folder
-        run: tar -zxf ${{ github.workspace}}/${{ matrix.language }}.tar.gz -C ${{github.workspace}}/${{ matrix.language}}
+        run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
+        run: make install_nodejs_sdk
       - name: Install gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
         with:
@@ -310,16 +308,10 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=${{ matrix.language }}
+        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=nodejs
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        language:
-          - nodejs
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfile
           - Cluster
@@ -360,7 +352,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -370,12 +362,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -390,10 +382,12 @@ jobs:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -444,12 +438,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        pythonversion:
-          - 3.8
-        nodeversion:
-          - 18.x
         test-name:
           - AwsProfilePy
           - AwsProfileRolePy
@@ -475,7 +463,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -485,7 +473,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -493,22 +481,24 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Download provider binary
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -560,12 +550,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        dotnetversion:
-          - 3.1
-        nodeversion:
-          - 18.x
         test-name:
           - ClusterCs
   test-go:
@@ -586,7 +570,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -596,12 +580,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
       - name: Install python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.7"
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -609,17 +593,19 @@ jobs:
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ env.DOTNETVERSION }}
       - name: Download provider binary
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.PROVIDER }}-provider.tar.gz
           path: ${{ github.workspace }}/bin
       - name: Untar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
           }}/bin
       - name: Restore binary perms
-        run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -668,11 +654,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion:
-          - 1.19.x
-        pythonversion:
-          - 3.8
-        nodeversion:
-          - 18.x
         test-name:
           - ClusterGo

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: ${{ env.GOVERSION }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
@@ -240,10 +240,10 @@ jobs:
           curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv kubectl /usr/local/bin
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -470,10 +470,10 @@ jobs:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip
@@ -582,10 +582,10 @@ jobs:
         with:
           node-version: ${{ env.NODEVERSION }}
           registry-url: https://registry.npmjs.org
-      - name: Install python
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Install awscli
         run: |
           python -m pip install --upgrade pip

--- a/examples/cluster-cs/Cluster.csproj
+++ b/examples/cluster-cs/Cluster.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Pulumi.Aws" Version="5.*" />
-    <PackageReference Include="Pulumi.Awsx" Version="1.0.0-beta.*" />
+    <PackageReference Include="Pulumi.Awsx" Version="1.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Specify version via env not matrix.
- Remove language from nodejs specific test jobs.
- Upgrade example to use dotnet 6 and AWSx 1.*