### PR TITLE
Deprecate CHANGELOG.md

### DIFF
--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -1,3 +1,9 @@
+## Notice (2022-12-14)
+
+As of this notice, using CHANGELOG.md is DEPRECATED. We will be using [GitHub Releases](https://github.com/pulumi/pulumi-eks/releases) for this repository
+
+---
+
 ## 1.0.0 (Released Nov 23, 2022)
 - [Remove input properties on Cluster that are not implemented #821](https://github.com/pulumi/pulumi-eks/pull/821)
 - [Add support for non-default AWS partitions #788](https://github.com/pulumi/pulumi-eks/pull/788)


### PR DESCRIPTION
We now use the GitHub release notes for changelogs, rather than manually writing them; reflect this at the top of the changelog.