### PR TITLE
fix OIDC provider dns suffix issue for AWS partitions

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -963,7 +963,7 @@ export function createCore(
     if (args.createOidcProvider) {
         // Retrieve the OIDC provider URL's intermediate root CA fingerprint.
         const awsRegionName = pulumi.output(aws.getRegion({}, { parent, async: true })).name;
-        const eksOidcProviderUrl = pulumi.interpolate`https://oidc.eks.${awsRegionName}.amazonaws.com`;
+        const eksOidcProviderUrl = pulumi.interpolate`https://oidc.eks.${awsRegionName}.${dnsSuffix}`;
         const agent = createHttpAgent(args.proxy);
         const fingerprint = getIssuerCAThumbprint(eksOidcProviderUrl, agent);
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
This pull request will help fix the EKS cluster creation with OIDC enabled create failed with other than AWS global partition such as GOV/CN...
### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Fixes #534 