### PR TITLE
Create fargate profile with the given private subnets when provided

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -918,7 +918,7 @@ export function createCore(
                         selectors: selectors,
                         subnetIds: pulumi
                             .output(clusterSubnetIds)
-                            .apply((subnets) => computeWorkerSubnets(parent, subnets)),
+                            .apply((subnets) => computeWorkerSubnets(parent, fargate.subnetIds ?? subnets)),
                     },
                     { parent, dependsOn: [eksNodeAccess], provider },
                 );


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

When deploying an EKS cluster with Fargate profile, the configured subnets in FargateProfile were being ignored. 
I am unable to run integration tests on my side due to lack of permissions in my AWS account, I need someone validate that this tiny change didn't break anything.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
