### PR TITLE
Pin gradle version to 7.6

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -138,6 +138,10 @@ jobs:
           cache: gradle
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: "7.6"
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -138,6 +138,10 @@ jobs:
           cache: gradle
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: "7.6"
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,10 @@ jobs:
           cache: gradle
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: "7.6"
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -177,6 +177,10 @@ jobs:
           cache: gradle
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: "7.6"
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Update PATH for Yarn


### PR DESCRIPTION
The Java build assumes Gradle v7, and there are breaking changes in Gradle 8; so, pin the Gradle version used, wherever Java is installed in the CI workflows. This is effectively a port of https://github.com/pulumi/ci-mgmt/pull/352 to this repo (which is not under control of ci-mgmt).
