### PR TITLE
support setting value 0 for warmEniTarget in VpcCni module

### DIFF
--- a/nodejs/eks/cmd/provider/cni.ts
+++ b/nodejs/eks/cmd/provider/cni.ts
@@ -70,14 +70,7 @@ function computeVpcCniYaml(cniYamlText: string, args: VpcCniInputs): string {
             value: args.customNetworkConfig ? "true" : "false",
         });
     }
-    if (args.warmEniTarget) {
-        env.push({
-            name: "WARM_ENI_TARGET",
-            value: args.warmEniTarget.toString(),
-        });
-    } else {
-        env.push({ name: "WARM_ENI_TARGET", value: "1" });
-    }
+    env.push({ name: "WARM_ENI_TARGET", value: `${args.warmEniTarget ?? 1}` });
     if (args.warmIpTarget) {
         env.push({
             name: "WARM_IP_TARGET",


### PR DESCRIPTION
### Proposed changes
Allow setting a value of `0` for `WARM_ENI_TARGET` in `aws-node` configuration through `VpcCni` module

### Related issues (optional)
Fixes #878
