### PR TITLE
Fix dynamic lookup of amiId for NodeGroup and NodeGroupV2

### DIFF
--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -747,7 +747,7 @@ ${customUserData}
     // https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
     let amiId: pulumi.Input<string> | undefined = args.amiId;
     if (!amiId) {
-        const amiType = args.amiType ?? args.gpu ? "amazon-linux-2-gpu" : "amazon-linux-2";
+        const amiType = args.amiType ?? (args.gpu ? "amazon-linux-2-gpu" : "amazon-linux-2");
         amiId = version.apply((v) => {
             const parameterName = `/aws/service/eks/optimized-ami/${v}/${amiType}/recommended/image_id`;
             return pulumi.output(
@@ -1146,7 +1146,7 @@ ${customUserData}
     // https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
     let amiId: pulumi.Input<string> | undefined = args.amiId;
     if (!amiId) {
-        const amiType = args.amiType ?? args.gpu ? "amazon-linux-2-gpu" : "amazon-linux-2";
+        const amiType = args.amiType ?? (args.gpu ? "amazon-linux-2-gpu" : "amazon-linux-2");
         amiId = version.apply((v) => {
             const parameterName = `/aws/service/eks/optimized-ami/${v}/${amiType}/recommended/image_id`;
             return pulumi.output(


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

When `amiId` is not specified the `amiType` is incorrectly decided upon due to missing brackets after the null coalescing operator.

The `amiType` will always equal `amazon-linux-2-gpu`, confirmed in a REPL:
```
"test" ?? false ? "amazon-linux-2-gpu" : "amazon-linux-2"
> 'amazon-linux-2-gpu'
"test" ?? true ? "amazon-linux-2-gpu" : "amazon-linux-2"
> 'amazon-linux-2-gpu'
undefined ?? true ? "amazon-linux-2-gpu" : "amazon-linux-2"
> 'amazon-linux-2-gpu'
```

The fix is to use brackets:
```
"test" ?? (false ? "amazon-linux-2-gpu" : "amazon-linux-2")
> 'test'
"test" ?? (true ? "amazon-linux-2-gpu" : "amazon-linux-2")
> 'test'
undefined ?? (true ? "amazon-linux-2-gpu" : "amazon-linux-2")
> 'amazon-linux-2-gpu'
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
