### PR TITLE
Fix nodegroup test failure

### DIFF
--- a/examples/nodegroup/index.ts
+++ b/examples/nodegroup/index.ts
@@ -64,7 +64,6 @@ const spot = new eks.NodeGroup("example-ng-simple-spot", {
             effect: "NoSchedule",
         },
     },
-    kubeletExtraArgs: "--alsologtostderr",
     bootstrapExtraArgs: "--aws-api-retry-attempts 10",
     instanceProfile: instanceProfile0,
 }, {

--- a/examples/utils/utils.go
+++ b/examples/utils/utils.go
@@ -20,8 +20,8 @@ import (
 )
 
 // Each resource request will be fetched from the Kubernetes API Server at a
-// max of 20 retries, with 15 seconds in between each attempt.
-// This creates a max wait time of up to 5 minutes that a resource request
+// max of 40 retries, with 15 seconds in between each attempt.
+// This creates a max wait time of up to 10 minutes that a resource request
 // must successfully return within, before moving on.
 
 // MaxRetries is the maximum number of retries that a resource will be


### PR DESCRIPTION
Providing extra kubelet flags/args seem to cause the NodeGroup to not attach to the cluster. Remove this line to unblock CI.