### PR TITLE
Guard against cluster certificate authority being undefined

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -199,7 +199,7 @@ interface ExecEnvVar {
 export function generateKubeconfig(
     clusterName: pulumi.Input<string>,
     clusterEndpoint: pulumi.Input<string>,
-    certData: pulumi.Input<string>,
+    certData?: pulumi.Input<string>,
     opts?: KubeconfigOptions,
 ) {
     let args = ["eks", "get-token", "--cluster-name", clusterName];
@@ -627,7 +627,7 @@ export function createCore(
                             timeout: reqTimeoutMilliseconds,
                         };
                         const req = https.request(options, (res) => {
-                            res.statusCode === 200 ? resolve() : reject(); // Verify healthz returns 200
+                            res.statusCode === 200 ? resolve(undefined) : reject(); // Verify healthz returns 200
                         });
                         req.on("timeout", reject);
                         req.on("error", reject);
@@ -675,7 +675,7 @@ export function createCore(
                         return generateKubeconfig(
                             clusterName,
                             clusterEndpoint,
-                            clusterCertificateAuthority.data,
+                            clusterCertificateAuthority?.data,
                             opts,
                         );
                     });
@@ -683,14 +683,14 @@ export function createCore(
                     config = generateKubeconfig(
                         clusterName,
                         clusterEndpoint,
-                        clusterCertificateAuthority.data,
+                        clusterCertificateAuthority?.data,
                         providerCredentialOpts,
                     );
                 } else {
                     config = generateKubeconfig(
                         clusterName,
                         clusterEndpoint,
-                        clusterCertificateAuthority.data,
+                        clusterCertificateAuthority?.data,
                     );
                 }
                 return config;
@@ -918,7 +918,9 @@ export function createCore(
                         selectors: selectors,
                         subnetIds: pulumi
                             .output(clusterSubnetIds)
-                            .apply((subnets) => computeWorkerSubnets(parent, fargate.subnetIds ?? subnets)),
+                            .apply((subnets) =>
+                                computeWorkerSubnets(parent, fargate.subnetIds ?? subnets),
+                            ),
                     },
                     { parent, dependsOn: [eksNodeAccess], provider },
                 );
@@ -1673,7 +1675,7 @@ export class Cluster extends pulumi.ComponentResource {
         const kc = generateKubeconfig(
             this.eksCluster.name,
             this.eksCluster.endpoint,
-            this.eksCluster.certificateAuthority.data,
+            this.eksCluster.certificateAuthority?.data,
             args,
         );
         return pulumi.output(kc).apply(JSON.stringify);
@@ -1876,7 +1878,7 @@ export class ClusterInternal extends pulumi.ComponentResource {
         const kc = generateKubeconfig(
             this.eksCluster.name,
             this.eksCluster.endpoint,
-            this.eksCluster.certificateAuthority.data,
+            this.eksCluster.certificateAuthority?.data,
             args,
         );
         return pulumi.output(kc).apply(JSON.stringify);


### PR DESCRIPTION
Hopefully addresses #676

Although the types don't describe the certificate authority as being possibly undefined, the error reported would indicate it can be (these are the only reference of accessing `.data` in the cluster code). Therefore we'll add some extra guards just in case.

If the cluster certificate authority is undefined, then we'll pass the certData to generateKubeConfig as undefined. This will then not set the property within the kubeconfig, but at least it won't throw a hard error causing the whole deployment to fail.

Aside: Fix resolve() call which requires a value to be passed.
