### PR TITLE
Pin Pulumi CLI used in CI to v3.89.0

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -72,7 +72,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Build provider binary + schema
         run: make schema provider
       - name: Check worktree clean
@@ -118,7 +120,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -209,7 +213,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -321,7 +327,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install awscli --upgrade
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -431,7 +439,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -72,7 +72,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Build provider binary + schema
         run: make schema provider
       - name: Check worktree clean
@@ -118,7 +120,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -210,7 +214,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Create Provider Binaries
         run: make dist
       - name: Upload Provider Binaries
@@ -238,7 +244,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -303,7 +311,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -368,7 +378,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -480,7 +492,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install awscli --upgrade
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -590,7 +604,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -155,7 +157,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Build provider binary + schema
         run: make schema provider
       - name: Check worktree clean
@@ -201,7 +205,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Create Provider Binaries
         run: make dist
       - name: Upload Provider Binaries
@@ -236,7 +242,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -302,7 +310,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -380,7 +390,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install awscli --upgrade
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -484,7 +496,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -594,7 +608,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -101,7 +101,9 @@ jobs:
         with:
           repo: mikhailshilkov/schema-tools
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Build provider binary + schema
         run: make schema provider
       - name: Check Schema is Valid
@@ -157,7 +159,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -257,7 +261,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -362,7 +368,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -473,7 +481,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -580,7 +590,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/actions@v4
+        with:
+          pulumi-version: v3.89.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
### Proposed changes

This is required to avoid a bug in upstream v3.90.0 which causes the ` error: expected property name after '.'` error we see.

Note: the workflow files in pulumi-eks do not appear to be managed by ci-mgmt.

### Related issues (optional)

Fixes: https://github.com/pulumi/pulumi-eks/issues/931