### PR TITLE
Defaulted aws-auth ConfigMap creation to upsert, added optional ConfigMap update in place property to cluster

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -713,6 +713,7 @@ export function createCore(
         `${name}-eks-k8s`,
         {
             kubeconfig: kubeconfig.apply(JSON.stringify),
+            enableConfigMapMutable: args.enableConfigMapMutable,
         },
         { parent: parent },
     );
@@ -874,9 +875,13 @@ export function createCore(
         `${name}-nodeAccess`,
         {
             apiVersion: "v1",
+            immutable: false,
             metadata: {
                 name: `aws-auth`,
                 namespace: "kube-system",
+                annotations: {
+                    "pulumi.com/patchForce": "true",
+                },
             },
             data: nodeAccessData,
         },
@@ -1508,6 +1513,13 @@ export interface ClusterOptions {
      * - https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
      */
     providerCredentialOpts?: pulumi.Input<KubeconfigOptions>;
+
+    /**
+     * Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+     * Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+     * https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+     */
+    enableConfigMapMutable?: pulumi.Input<boolean>;
 
     /**
      * KMS Key ARN to use with the encryption configuration for the cluster.

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -584,6 +584,12 @@ func generateSchema() schema.PackageSpec {
 							"- https://www.pulumi.com/docs/intro/cloud-providers/aws/#configuration\n" +
 							"- https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html",
 					},
+					"enableConfigMapMutable": {
+						TypeSpec: schema.TypeSpec{Type: "boolean"},
+						Description: "Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.\n\n" +
+							"Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.\n" +
+							"https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs",
+					},
 					"encryptionConfigKeyArn": {
 						TypeSpec: schema.TypeSpec{Type: "string"},
 						Description: "KMS Key ARN to use with the encryption configuration for the cluster.\n\n" +

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -696,6 +696,10 @@
                     "type": "integer",
                     "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
                 },
+                "enableConfigMapMutable": {
+                    "type": "boolean",
+                    "description": "Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.\n\nApplies updates to the aws-auth ConfigMap in place over a replace operation if set to true.\nhttps://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs"
+                },
                 "enabledClusterLogTypes": {
                     "type": "array",
                     "items": {

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -184,6 +184,15 @@ namespace Pulumi.Eks
         [Input("desiredCapacity")]
         public Input<int>? DesiredCapacity { get; set; }
 
+        /// <summary>
+        /// Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+        /// 
+        /// Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+        /// https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+        /// </summary>
+        [Input("enableConfigMapMutable")]
+        public Input<bool>? EnableConfigMapMutable { get; set; }
+
         [Input("enabledClusterLogTypes")]
         private InputList<string>? _enabledClusterLogTypes;
 

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -80,6 +80,11 @@ type clusterArgs struct {
 	DefaultAddonsToRemove []string `pulumi:"defaultAddonsToRemove"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
+	// Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+	//
+	// Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+	// https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+	EnableConfigMapMutable *bool `pulumi:"enableConfigMapMutable"`
 	// Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: ["api", "audit", "authenticator", "controllerManager", "scheduler"]. By default it is off.
 	EnabledClusterLogTypes []string `pulumi:"enabledClusterLogTypes"`
 	// KMS Key ARN to use with the encryption configuration for the cluster.
@@ -286,6 +291,11 @@ type ClusterArgs struct {
 	DefaultAddonsToRemove pulumi.StringArrayInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
+	// Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+	//
+	// Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+	// https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+	EnableConfigMapMutable pulumi.BoolPtrInput
 	// Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: ["api", "audit", "authenticator", "controllerManager", "scheduler"]. By default it is off.
 	EnabledClusterLogTypes pulumi.StringArrayInput
 	// KMS Key ARN to use with the encryption configuration for the cluster.

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -152,6 +152,27 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Sets the &#39;enableConfigMapMutable&#39; option on the cluster kubernetes provider.
+     * 
+     * Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+     * https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+     * 
+     */
+    @Import(name="enableConfigMapMutable")
+    private @Nullable Output<Boolean> enableConfigMapMutable;
+
+    /**
+     * @return Sets the &#39;enableConfigMapMutable&#39; option on the cluster kubernetes provider.
+     * 
+     * Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+     * https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+     * 
+     */
+    public Optional<Output<Boolean>> enableConfigMapMutable() {
+        return Optional.ofNullable(this.enableConfigMapMutable);
+    }
+
+    /**
      * Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: [&#34;api&#34;, &#34;audit&#34;, &#34;authenticator&#34;, &#34;controllerManager&#34;, &#34;scheduler&#34;]. By default it is off.
      * 
      */
@@ -950,6 +971,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         this.creationRoleProvider = $.creationRoleProvider;
         this.defaultAddonsToRemove = $.defaultAddonsToRemove;
         this.desiredCapacity = $.desiredCapacity;
+        this.enableConfigMapMutable = $.enableConfigMapMutable;
         this.enabledClusterLogTypes = $.enabledClusterLogTypes;
         this.encryptionConfigKeyArn = $.encryptionConfigKeyArn;
         this.endpointPrivateAccess = $.endpointPrivateAccess;
@@ -1170,6 +1192,33 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder desiredCapacity(Integer desiredCapacity) {
             return desiredCapacity(Output.of(desiredCapacity));
+        }
+
+        /**
+         * @param enableConfigMapMutable Sets the &#39;enableConfigMapMutable&#39; option on the cluster kubernetes provider.
+         * 
+         * Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+         * https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableConfigMapMutable(@Nullable Output<Boolean> enableConfigMapMutable) {
+            $.enableConfigMapMutable = enableConfigMapMutable;
+            return this;
+        }
+
+        /**
+         * @param enableConfigMapMutable Sets the &#39;enableConfigMapMutable&#39; option on the cluster kubernetes provider.
+         * 
+         * Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+         * https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableConfigMapMutable(Boolean enableConfigMapMutable) {
+            return enableConfigMapMutable(Output.of(enableConfigMapMutable));
         }
 
         /**

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -26,6 +26,7 @@ class ClusterArgs:
                  creation_role_provider: Optional['CreationRoleProviderArgs'] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  encryption_config_key_arn: Optional[pulumi.Input[str]] = None,
                  endpoint_private_access: Optional[pulumi.Input[bool]] = None,
@@ -82,6 +83,10 @@ class ClusterArgs:
         :param 'CreationRoleProviderArgs' creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] default_addons_to_remove: List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_config_map_mutable: Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+               
+               Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+               https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: ["api", "audit", "authenticator", "controllerManager", "scheduler"]. By default it is off.
         :param pulumi.Input[str] encryption_config_key_arn: KMS Key ARN to use with the encryption configuration for the cluster.
                
@@ -238,6 +243,8 @@ class ClusterArgs:
             pulumi.set(__self__, "default_addons_to_remove", default_addons_to_remove)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
+        if enable_config_map_mutable is not None:
+            pulumi.set(__self__, "enable_config_map_mutable", enable_config_map_mutable)
         if enabled_cluster_log_types is not None:
             pulumi.set(__self__, "enabled_cluster_log_types", enabled_cluster_log_types)
         if encryption_config_key_arn is not None:
@@ -408,6 +415,21 @@ class ClusterArgs:
     @desired_capacity.setter
     def desired_capacity(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "desired_capacity", value)
+
+    @property
+    @pulumi.getter(name="enableConfigMapMutable")
+    def enable_config_map_mutable(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+
+        Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+        https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
+        """
+        return pulumi.get(self, "enable_config_map_mutable")
+
+    @enable_config_map_mutable.setter
+    def enable_config_map_mutable(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_config_map_mutable", value)
 
     @property
     @pulumi.getter(name="enabledClusterLogTypes")
@@ -992,6 +1014,7 @@ class Cluster(pulumi.ComponentResource):
                  creation_role_provider: Optional[pulumi.InputType['CreationRoleProviderArgs']] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  encryption_config_key_arn: Optional[pulumi.Input[str]] = None,
                  endpoint_private_access: Optional[pulumi.Input[bool]] = None,
@@ -1052,6 +1075,10 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.InputType['CreationRoleProviderArgs'] creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
         :param pulumi.Input[Sequence[pulumi.Input[str]]] default_addons_to_remove: List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_config_map_mutable: Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
+               
+               Applies updates to the aws-auth ConfigMap in place over a replace operation if set to true.
+               https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs
         :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_cluster_log_types: Enable EKS control plane logging. This sends logs to cloudwatch. Possible list of values are: ["api", "audit", "authenticator", "controllerManager", "scheduler"]. By default it is off.
         :param pulumi.Input[str] encryption_config_key_arn: KMS Key ARN to use with the encryption configuration for the cluster.
                
@@ -1225,6 +1252,7 @@ class Cluster(pulumi.ComponentResource):
                  creation_role_provider: Optional[pulumi.InputType['CreationRoleProviderArgs']] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enabled_cluster_log_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  encryption_config_key_arn: Optional[pulumi.Input[str]] = None,
                  endpoint_private_access: Optional[pulumi.Input[bool]] = None,
@@ -1282,6 +1310,7 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["creation_role_provider"] = creation_role_provider
             __props__.__dict__["default_addons_to_remove"] = default_addons_to_remove
             __props__.__dict__["desired_capacity"] = desired_capacity
+            __props__.__dict__["enable_config_map_mutable"] = enable_config_map_mutable
             __props__.__dict__["enabled_cluster_log_types"] = enabled_cluster_log_types
             __props__.__dict__["encryption_config_key_arn"] = encryption_config_key_arn
             __props__.__dict__["endpoint_private_access"] = endpoint_private_access


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR does two things:

Defaults `aws-auth` ConfigMap management to an [upsert operation](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/managing-resources-with-server-side-apply/#upsert-a-resource). This ensures pulumi takes full control of the ConfigMap regardless of whether it exists already or not eliminating any possible race conditions that could occur and error popping up stating the `aws-auth` ConfigMap already exists.

Adds an optional [`enableConfigMapMutable`](https://www.pulumi.com/registry/packages/kubernetes/api-docs/provider/#enableconfigmapmutable_nodejs) property to pass to the cluster's pulumi k8s provider that will allow for updating the `aws-auth` ConfigMap in place over the default replace operation. A replace operation for this particular ConfigMap can be especially dangerous if some failure blocks recreation after a delete as default M2M auth entries would get wiped as we have seen already intermittently in cluster provisioning workflows: `error: resource kube-system/aws-auth was not successfully created by the Kubernetes API server : configmaps "aws-auth" already exists`

The `enableConfigMapMutable` property is optional because docs denote it is still in preview and if consumers of this library re-use the exposed cluster k8s provider downstream it could have unintended effects on their k8s deployment workflows. AWS documentation like https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html always advises updating/applying/patching this ConfigMap in place.

### Related issues (optional)

Fixes: https://github.com/pulumi/pulumi-eks/issues/918
Fixes: https://github.com/pulumi/pulumi-eks/issues/883
