### PR TITLE
Re-enable and enhance tests

### DIFF
--- a/examples/aws-profile-role-py/__main__.py
+++ b/examples/aws-profile-role-py/__main__.py
@@ -68,7 +68,7 @@ role_kubeconfig = cluster.get_kubeconfig(
 pulumi.export("roleKubeconfig", role_kubeconfig)
 role_provider = k8s.Provider("provider",
     kubeconfig=role_kubeconfig,
-    opts=pulumi.ResourceOptions(depends_on=[cluster.provider])
+    opts=pulumi.ResourceOptions(depends_on=[cluster])
 )
 
 # Create a pod with the role-based kubeconfig.

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -116,14 +116,12 @@ func TestAccFargate(t *testing.T) {
 				// (specifically us-west-2).
 				"aws:region": "us-east-2",
 			},
-			// TODO[pulumi/pulumi-eks#286] Disabled until we address CNI daemonset issues which
-			// cause those daemonset pods not to get scheduled.
-			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			// 	utils.RunEKSSmokeTest(t,
-			// 		info.Deployment.Resources,
-			// 		info.Outputs["kubeconfig"],
-			// 	)
-			// },
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -19,7 +19,6 @@ package example
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -558,7 +557,7 @@ func TestAccMigrateNodeGroups(t *testing.T) {
 
 						// Write kubeconfig to temp file & export it for use
 						// with kubectl.
-						kubeconfigFile, err := ioutil.TempFile(os.TempDir(), "kubeconfig-*.json")
+						kubeconfigFile, err := os.CreateTemp(os.TempDir(), "kubeconfig-*.json")
 						assert.NoError(t, err, "expected tempfile to be created: %v", err)
 						defer os.Remove(kubeconfigFile.Name())
 						_, err = kubeconfigFile.Write(kubeconfig)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -264,28 +264,8 @@ func TestAccScopedKubeconfig(t *testing.T) {
 }
 
 func TestAccAwsProfile(t *testing.T) {
-	// EKS token retrieval using the AWS_PROFILE seems to prefer the
-	// the following variables over AWS_PROFILE so you end up with
-	// authentication failures in the tests. So drop these environment
-	// variables if set and reapply them after the test.
-	oldEnvVars := map[string]string{}
-	if val := os.Getenv("AWS_SECRET_ACCESS_KEY"); val != "" {
-		oldEnvVars["AWS_SECRET_ACCESS_KEY"] = val
-		assert.NoError(t, os.Unsetenv("AWS_SECRET_ACCESS_KEY"))
-	}
-	if val := os.Getenv("AWS_ACCESS_KEY_ID"); val != "" {
-		oldEnvVars["AWS_ACCESS_KEY_ID"] = val
-		assert.NoError(t, os.Unsetenv("AWS_ACCESS_KEY_ID"))
-	}
-	if val := os.Getenv("AWS_SESSION_TOKEN"); val != "" {
-		oldEnvVars["AWS_SESSION_TOKEN"] = val
-		assert.NoError(t, os.Unsetenv("AWS_SESSION_TOKEN"))
-	}
-	defer func() {
-		for k, v := range oldEnvVars {
-			assert.NoError(t, os.Setenv(k, v))
-		}
-	}()
+	unsetAWSProfileEnv(t)
+
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "aws-profile"),

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -20,38 +20,35 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pulumi/pulumi-eks/examples/utils"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
 func TestAccAwsProfilePy(t *testing.T) {
-	t.Skip("Temp Skip")
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "aws-profile-py"),
-			// TODO: Temporarily skip the extra runtime validation due to test failure.
-			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			// 	utils.RunEKSSmokeTest(t,
-			// 		info.Deployment.Resources,
-			// 		info.Outputs["kubeconfig"],
-			// 	)
-			// },
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
 		})
 
 	integration.ProgramTest(t, &test)
 }
 
 func TestAccAwsProfileRolePy(t *testing.T) {
-	t.Skip("Temp Skip")
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "aws-profile-role-py"),
-			// TODO: [pulumi/pulumi-eks#629] Temporarily skip the extra runtime validation due to test failure.
-			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			// 	utils.RunEKSSmokeTest(t,
-			// 		info.Deployment.Resources,
-			// 		info.Outputs["kubeconfig"],
-			// 	)
-			// },
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -61,15 +58,14 @@ func TestAccClusterPy(t *testing.T) {
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "cluster-py"),
-			// TODO: Temporarily skip the extra runtime validation due to test failure.
-			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			// 	utils.RunEKSSmokeTest(t,
-			// 		info.Deployment.Resources,
-			// 		info.Outputs["kubeconfig1"],
-			// 		info.Outputs["kubeconfig2"],
-			//		info.Outputs["kubeconfig3"],
-			// 	)
-			// },
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig1"],
+					info.Outputs["kubeconfig2"],
+					info.Outputs["kubeconfig3"],
+				)
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -84,14 +80,12 @@ func TestAccFargatePy(t *testing.T) {
 				// (specifically us-west-2).
 				"aws:region": "us-east-2",
 			},
-			// TODO[pulumi/pulumi-eks#286] Disabled until we address CNI daemonset issues which
-			// cause those daemonset pods not to get scheduled.
-			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			// 	utils.RunEKSSmokeTest(t,
-			// 		info.Deployment.Resources,
-			// 		info.Outputs["kubeconfig"],
-			// 	)
-			// },
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
 		})
 
 	integration.ProgramTest(t, &test)
@@ -112,13 +106,12 @@ func TestAccManagedNodeGroupPy(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			// RunUpdateTest: true,
 			Dir: filepath.Join(getCwd(t), "managed-nodegroups-py"),
-			// TODO: Temporarily skip the extra runtime validation due to test failure.
-			// ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			// 	utils.RunEKSSmokeTest(t,
-			// 		info.Deployment.Resources,
-			// 		info.Outputs["kubeconfig"],
-			// 	)
-			// },
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -25,9 +25,12 @@ import (
 )
 
 func TestAccAwsProfilePy(t *testing.T) {
+	unsetAWSProfileEnv(t)
+
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "aws-profile-py"),
+			NoParallel: true,
+			Dir:        filepath.Join(getCwd(t), "aws-profile-py"),
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,
@@ -75,11 +78,6 @@ func TestAccFargatePy(t *testing.T) {
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "fargate-py"),
-			Config: map[string]string{
-				// Hard code to us-east-2 since Fargate support is not yet available in all regions
-				// (specifically us-west-2).
-				"aws:region": "us-east-2",
-			},
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/assert"
 )
 
 func getEnvRegion(t *testing.T) string {
@@ -73,4 +74,20 @@ func providerPluginPathEnv() (string, error) {
 		pathSeparator = ";"
 	}
 	return "PATH=" + os.Getenv("PATH") + pathSeparator + absPluginDir + pathSeparator + absTestPluginDir, nil
+}
+
+var envToUnset = [...]string{"AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "AWS_SESSION_TOKEN"}
+
+// unsetAWSProfileEnv unsets the AWS_PROFILE and associated environment variables.
+// EKS token retrieval using the AWS_PROFILE seems to prefer the
+// the following variables over AWS_PROFILE so you end up with
+// authentication failures in the tests. So drop these environment
+// variables if set and reapply them after the test.
+func unsetAWSProfileEnv(t *testing.T) {
+	t.Helper()
+
+	for _, envVar := range envToUnset {
+		t.Setenv(envVar, "")
+		assert.NoError(t, os.Unsetenv(envVar)) // Explicitly unset the environment variable, as well.
+	}
 }

--- a/examples/utils/utils.go
+++ b/examples/utils/utils.go
@@ -369,7 +369,7 @@ func ValidateDaemonSet(t *testing.T, kubeconfig interface{}, namespace, name str
 	}
 
 	if !ready {
-		fmt.Errorf("daemonset wasn't ready in time")
+		return fmt.Errorf("daemonset wasn't ready in time")
 	}
 
 	validateFn(ds)

--- a/examples/utils/utils.go
+++ b/examples/utils/utils.go
@@ -155,7 +155,7 @@ func AssertAllNodesReady(t *testing.T, clientset *kubernetes.Clientset, desiredN
 	}
 
 	// Require that the readyCount matches the desiredNodeCount / total Nodes.
-	require.Equal(t, readyCount, len(nodes.Items),
+	require.Equal(t, len(nodes.Items), readyCount,
 		"%d out of %d Nodes are ready", readyCount, len(nodes.Items))
 
 	// Output the overall ready status.
@@ -230,8 +230,8 @@ func AssertKindListIsReady(t *testing.T, clientset *kubernetes.Clientset, list i
 
 		// Validate that the readyCount is not 0, and matches the total Deployments
 		// returned.
-		require.NotEqual(t, readyCount, 0, "No Deployments are ready")
-		require.Equal(t, readyCount, listLength,
+		require.NotEqual(t, 0, readyCount, "No Deployments are ready")
+		require.Equal(t, listLength, readyCount,
 			"%d out of %d Deployments are ready", readyCount, listLength)
 
 		PrintAndLog(fmt.Sprintf("%d out of %d Deployments are ready\n", readyCount, listLength), t)
@@ -255,8 +255,8 @@ func AssertKindListIsReady(t *testing.T, clientset *kubernetes.Clientset, list i
 
 		// Validate that the readyCount is not 0, and matches the total ReplicaSets
 		// returned.
-		require.NotEqual(t, readyCount, 0, "No ReplicaSets are ready")
-		require.Equal(t, readyCount, listLength,
+		require.NotEqual(t, 0, readyCount, "No ReplicaSets are ready")
+		require.Equal(t, listLength, readyCount,
 			"%d out of %d ReplicaSets are ready", readyCount, listLength)
 
 		PrintAndLog(fmt.Sprintf("%d out of %d ReplicaSets are ready\n", readyCount, listLength), t)
@@ -280,8 +280,8 @@ func AssertKindListIsReady(t *testing.T, clientset *kubernetes.Clientset, list i
 
 		// Validate that the readyCount is not 0, and matches the total Deployments
 		// returned.
-		require.NotEqual(t, readyCount, 0, "No Pods are ready")
-		require.Equal(t, readyCount, listLength,
+		require.NotEqual(t, 0, readyCount, "No Pods are ready")
+		require.Equal(t, listLength, readyCount,
 			"%d out of %d Pods are ready", readyCount, listLength)
 
 		PrintAndLog(fmt.Sprintf("%d out of %d Pods are ready\n", readyCount, listLength), t)


### PR DESCRIPTION
### Proposed changes

This PR encompasses several enhancements related to tests. In summary, tests have been refactored to run faster, Python tests have been re-enabled, and various regressions/bugs have been addressed during test development.

#### Changes made:

- Re-enabled EKS validation for NodeJS Fargate tests
- Re-enabled all Python tests (#629)
- Resolved a bug causing unscheduled CoreDNS pods for Fargate-only clusters (#1030)
- Improved efficiency by running smoke tests concurrently, resulting in a reduction of test times from 45 minutes to 20 minutes in worst-case scenarios
- Improved test outputs by correcting swapped test assertions for expected and actual values
- Expanded the existing NodeJS cluster test to validate ARM64 node creation
- Fixed bitrotten AWS Profile python test

These changes are segregated into individual commits for easier review. Additionally, they are intended to be rebased and merged independently to ensure their autonomy upon merging into the mainline branch.

### Related issues (optional)

Fixes: #1030 
Fixes: #629
