### PR TITLE
Allow setting custom nodeagent container images

### DIFF
--- a/nodejs/eks/cmd/provider/cni.test.ts
+++ b/nodejs/eks/cmd/provider/cni.test.ts
@@ -1,0 +1,639 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getBaseVpcCniYaml, updateImage } from "./cni";
+import * as jsyaml from "js-yaml";
+import * as fs from "fs";
+
+describe("updateImage", () => {
+    let daemonSet: any;
+    let cniManifest: string;
+    let cniYaml: any[];
+    beforeEach(() => {
+        cniManifest = getBaseVpcCniYaml();
+        cniYaml = jsyaml.loadAll(cniManifest);
+        daemonSet = cniYaml.filter((o) => o.kind === "DaemonSet")[0];
+    });
+
+    it("should update the aws-node and aws-eks-nodeagent images", () => {
+        let testCode = () => {
+            updateImage(daemonSet, "aws-node", "amazon/amazon-k8s-cni:fake");
+            updateImage(daemonSet, "aws-eks-nodeagent", "amazon/aws-network-policy-agent:fake");
+            return cniYaml.map((o) => `---\n${jsyaml.dump(o)}`).join("");
+        };
+
+        expect(testCode).not.toThrow();
+        expect(testCode()).toBe(updatedManifest)
+    });
+});
+
+const updatedManifest = `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: amazon-network-policy-controller-k8s
+  name: policyendpoints.networking.k8s.aws
+spec:
+  group: networking.k8s.aws
+  names:
+    kind: PolicyEndpoint
+    listKind: PolicyEndpointList
+    plural: policyendpoints
+    singular: policyendpoint
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: PolicyEndpoint is the Schema for the policyendpoints API
+          properties:
+            apiVersion:
+              description: >-
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More
+                info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: >-
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase.
+                More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PolicyEndpointSpec defines the desired state of PolicyEndpoint
+              properties:
+                egress:
+                  description: >-
+                    Egress is the list of egress rules containing resolved
+                    network addresses
+                  items:
+                    description: >-
+                      EndpointInfo defines the network endpoint information for
+                      the policy ingress/egress
+                    properties:
+                      cidr:
+                        description: CIDR is the network address(s) of the endpoint
+                        type: string
+                      except:
+                        description: >-
+                          Except is the exceptions to the CIDR ranges mentioned
+                          above.
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: Ports is the list of ports
+                        items:
+                          description: >-
+                            Port contains information about the transport
+                            port/protocol
+                          properties:
+                            endPort:
+                              description: >-
+                                Endport specifies the port range port to endPort
+                                port must be defined and an integer, endPort >
+                                port
+                              format: int32
+                              type: integer
+                            port:
+                              description: >-
+                                Port specifies the numerical port for the
+                                protocol. If empty applies to all ports
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: >-
+                                Protocol specifies the transport protocol,
+                                default TCP
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                      - cidr
+                    type: object
+                  type: array
+                ingress:
+                  description: >-
+                    Ingress is the list of ingress rules containing resolved
+                    network addresses
+                  items:
+                    description: >-
+                      EndpointInfo defines the network endpoint information for
+                      the policy ingress/egress
+                    properties:
+                      cidr:
+                        description: CIDR is the network address(s) of the endpoint
+                        type: string
+                      except:
+                        description: >-
+                          Except is the exceptions to the CIDR ranges mentioned
+                          above.
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: Ports is the list of ports
+                        items:
+                          description: >-
+                            Port contains information about the transport
+                            port/protocol
+                          properties:
+                            endPort:
+                              description: >-
+                                Endport specifies the port range port to endPort
+                                port must be defined and an integer, endPort >
+                                port
+                              format: int32
+                              type: integer
+                            port:
+                              description: >-
+                                Port specifies the numerical port for the
+                                protocol. If empty applies to all ports
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: >-
+                                Protocol specifies the transport protocol,
+                                default TCP
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                      - cidr
+                    type: object
+                  type: array
+                podIsolation:
+                  description: >-
+                    PodIsolation specifies whether the pod needs to be isolated
+                    for a particular traffic direction Ingress or Egress, or
+                    both. If default isolation is not specified, and there are
+                    no ingress/egress rules, then the pod is not isolated from
+                    the point of view of this policy. This follows the
+                    NetworkPolicy spec.PolicyTypes.
+                  items:
+                    description: >-
+                      PolicyType string describes the NetworkPolicy type This
+                      type is beta-level in 1.8
+                    type: string
+                  type: array
+                podSelector:
+                  description: PodSelector is the podSelector from the policy resource
+                  properties:
+                    matchExpressions:
+                      description: >-
+                        matchExpressions is a list of label selector
+                        requirements. The requirements are ANDed.
+                      items:
+                        description: >-
+                          A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates
+                          the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: >-
+                              operator represents a key's relationship to a set
+                              of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: >-
+                              values is an array of string values. If the
+                              operator is In or NotIn, the values array must be
+                              non-empty. If the operator is Exists or
+                              DoesNotExist, the values array must be empty. This
+                              array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: >-
+                        matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an
+                        element of matchExpressions, whose key field is "key",
+                        the operator is "In", and the values array contains only
+                        "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                podSelectorEndpoints:
+                  description: >-
+                    PodSelectorEndpoints contains information about the pods
+                    matching the podSelector
+                  items:
+                    description: PodEndpoint defines the summary information for the pods
+                    properties:
+                      hostIP:
+                        description: >-
+                          HostIP is the IP address of the host the pod is
+                          currently running on
+                        type: string
+                      name:
+                        description: Name is the pod name
+                        type: string
+                      namespace:
+                        description: Namespace is the pod namespace
+                        type: string
+                      podIP:
+                        description: PodIP is the IP address of the pod
+                        type: string
+                    required:
+                      - hostIP
+                      - name
+                      - namespace
+                      - podIP
+                    type: object
+                  type: array
+                policyRef:
+                  description: >-
+                    PolicyRef is a reference to the Kubernetes NetworkPolicy
+                    resource.
+                  properties:
+                    name:
+                      description: Name is the name of the Policy
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Policy
+                      type: string
+                  required:
+                    - name
+                    - namespace
+                  type: object
+              required:
+                - policyRef
+              type: object
+            status:
+              description: >-
+                PolicyEndpointStatus defines the observed state of
+                PolicyEndpoint
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: v1.16.0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: v1.16.0
+data:
+  enable-windows-ipam: 'false'
+  enable-network-policy-controller: 'false'
+  enable-windows-prefix-delegation: 'false'
+  warm-prefix-target: '0'
+  warm-ip-target: '1'
+  minimum-ip-target: '3'
+  branch-eni-cooldown: '60'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-node
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: v1.16.0
+rules:
+  - apiGroups:
+      - crd.k8s.amazonaws.com
+    resources:
+      - eniconfigs
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - ''
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - list
+  - apiGroups:
+      - networking.k8s.aws
+    resources:
+      - policyendpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.aws
+    resources:
+      - policyendpoints/status
+    verbs:
+      - get
+  - apiGroups:
+      - vpcresources.k8s.aws
+    resources:
+      - cninodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: v1.16.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: v1.16.0
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-node
+        app.kubernetes.io/instance: aws-vpc-cni
+        k8s-app: aws-node
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: aws-node
+      hostNetwork: true
+      initContainers:
+        - name: aws-vpc-cni-init
+          image: >-
+            602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.16.0
+          env: []
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 25m
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      securityContext: {}
+      containers:
+        - name: aws-node
+          image: amazon/amazon-k8s-cni:fake
+          ports:
+            - containerPort: 61678
+              name: metrics
+          livenessProbe:
+            exec:
+              command:
+                - /app/grpc-health-probe
+                - '-addr=:50051'
+                - '-connect-timeout=5s'
+                - '-rpc-timeout=5s'
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /app/grpc-health-probe
+                - '-addr=:50051'
+                - '-connect-timeout=5s'
+                - '-rpc-timeout=5s'
+            initialDelaySeconds: 1
+            timeoutSeconds: 10
+          env:
+            - name: ADDITIONAL_ENI_TAGS
+              value: '{}'
+            - name: AWS_VPC_K8S_CNI_RANDOMIZESNAT
+              value: prng
+            - name: DISABLE_INTROSPECTION
+              value: 'false'
+            - name: DISABLE_METRICS
+              value: 'false'
+            - name: DISABLE_NETWORK_RESOURCE_PROVISIONING
+              value: 'false'
+            - name: ENABLE_IPv4
+              value: 'true'
+            - name: VPC_CNI_VERSION
+              value: v1.16.0
+            - name: WARM_PREFIX_TARGET
+              value: '1'
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            requests:
+              cpu: 25m
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /host/var/log/aws-routed-eni
+              name: log-dir
+            - mountPath: /var/run/aws-node
+              name: run-dir
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+        - name: aws-eks-nodeagent
+          image: amazon/aws-network-policy-agent:fake
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          args:
+            - '--enable-ipv6=false'
+            - '--enable-network-policy=false'
+            - '--enable-cloudwatch-logs=false'
+            - '--enable-policy-event-logs=false'
+            - '--metrics-bind-addr=:8162'
+            - '--health-probe-bind-addr=:8163'
+            - '--conntrack-cache-cleanup-period=300'
+          resources:
+            requests:
+              cpu: 25m
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /sys/fs/bpf
+              name: bpf-pin-path
+            - mountPath: /var/log/aws-routed-eni
+              name: log-dir
+            - mountPath: /var/run/aws-node
+              name: run-dir
+      volumes:
+        - name: bpf-pin-path
+          hostPath:
+            path: /sys/fs/bpf
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: log-dir
+          hostPath:
+            path: /var/log/aws-routed-eni
+            type: DirectoryOrCreate
+        - name: run-dir
+          hostPath:
+            path: /var/run/aws-node
+            type: DirectoryOrCreate
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
+`;

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -93,11 +93,18 @@ export interface VpcCniOptions {
     logFile?: pulumi.Input<string>;
 
     /**
-     * Specifies the container image to use in the AWS CNI cluster DaemonSet.
+     * Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
      *
      * Defaults to the official AWS CNI image in ECR.
      */
     image?: pulumi.Input<string>;
+
+    /**
+     * Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+     *
+     * Defaults to the official AWS CNI image in ECR.
+     */
+    nodeAgentImage?: pulumi.Input<string>;
 
     /**
      * Specifies the init container image to use in the AWS CNI cluster DaemonSet.
@@ -244,6 +251,7 @@ export class VpcCni extends pulumi.CustomResource {
                 logLevel: args?.logLevel,
                 logFile: args?.logFile,
                 image: args?.image,
+                nodeAgentImage: args?.nodeAgentImage,
                 initImage: args?.initImage,
                 eniConfigLabelDef: args?.eniConfigLabelDef,
                 pluginLogLevel: args?.pluginLogLevel,

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1688,8 +1688,13 @@ func vpcCniProperties(kubeconfig bool) map[string]schema.PropertySpec {
 		},
 		"image": {
 			TypeSpec: schema.TypeSpec{Type: "string"},
-			Description: "Specifies the container image to use in the AWS CNI cluster DaemonSet.\n\n" +
+			Description: "Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.\n\n" +
 				"Defaults to the official AWS CNI image in ECR.",
+		},
+		"nodeAgentImage": {
+			TypeSpec: schema.TypeSpec{Type: "string"},
+			Description: "Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.\n\n" +
+				"Defaults to the official AWS CNI nodeagent image in ECR.",
 		},
 		"initImage": {
 			TypeSpec: schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -555,7 +555,7 @@
                 },
                 "image": {
                     "type": "string",
-                    "description": "Specifies the container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI image in ECR."
+                    "description": "Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI image in ECR."
                 },
                 "initImage": {
                     "type": "string",
@@ -568,6 +568,10 @@
                 "logLevel": {
                     "type": "string",
                     "description": "Specifies the log level used for logs.\n\nDefaults to \"DEBUG\"\nValid values: \"DEBUG\", \"INFO\", \"WARN\", \"ERROR\", or \"FATAL\"."
+                },
+                "nodeAgentImage": {
+                    "type": "string",
+                    "description": "Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI nodeagent image in ECR."
                 },
                 "nodePortSupport": {
                     "type": "boolean",
@@ -1522,7 +1526,7 @@
                 },
                 "image": {
                     "type": "string",
-                    "description": "Specifies the container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI image in ECR."
+                    "description": "Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI image in ECR."
                 },
                 "initImage": {
                     "type": "string",
@@ -1539,6 +1543,10 @@
                 "logLevel": {
                     "type": "string",
                     "description": "Specifies the log level used for logs.\n\nDefaults to \"DEBUG\"\nValid values: \"DEBUG\", \"INFO\", \"WARN\", \"ERROR\", or \"FATAL\"."
+                },
+                "nodeAgentImage": {
+                    "type": "string",
+                    "description": "Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.\n\nDefaults to the official AWS CNI nodeagent image in ECR."
                 },
                 "nodePortSupport": {
                     "type": "boolean",

--- a/sdk/dotnet/Inputs/VpcCniOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/VpcCniOptionsArgs.cs
@@ -91,7 +91,7 @@ namespace Pulumi.Eks.Inputs
         public Input<bool>? ExternalSnat { get; set; }
 
         /// <summary>
-        /// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        /// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
         /// 
         /// Defaults to the official AWS CNI image in ECR.
         /// </summary>
@@ -122,6 +122,14 @@ namespace Pulumi.Eks.Inputs
         /// </summary>
         [Input("logLevel")]
         public Input<string>? LogLevel { get; set; }
+
+        /// <summary>
+        /// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+        /// 
+        /// Defaults to the official AWS CNI nodeagent image in ECR.
+        /// </summary>
+        [Input("nodeAgentImage")]
+        public Input<string>? NodeAgentImage { get; set; }
 
         /// <summary>
         /// Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.

--- a/sdk/dotnet/VpcCni.cs
+++ b/sdk/dotnet/VpcCni.cs
@@ -135,7 +135,7 @@ namespace Pulumi.Eks
         public Input<bool>? ExternalSnat { get; set; }
 
         /// <summary>
-        /// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        /// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
         /// 
         /// Defaults to the official AWS CNI image in ECR.
         /// </summary>
@@ -172,6 +172,14 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("logLevel")]
         public Input<string>? LogLevel { get; set; }
+
+        /// <summary>
+        /// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+        /// 
+        /// Defaults to the official AWS CNI nodeagent image in ECR.
+        /// </summary>
+        [Input("nodeAgentImage")]
+        public Input<string>? NodeAgentImage { get; set; }
 
         /// <summary>
         /// Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -2231,7 +2231,7 @@ type VpcCniOptions struct {
 	//
 	// Defaults to false.
 	ExternalSnat *bool `pulumi:"externalSnat"`
-	// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+	// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 	//
 	// Defaults to the official AWS CNI image in ECR.
 	Image *string `pulumi:"image"`
@@ -2248,6 +2248,10 @@ type VpcCniOptions struct {
 	// Defaults to "DEBUG"
 	// Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
 	LogLevel *string `pulumi:"logLevel"`
+	// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+	//
+	// Defaults to the official AWS CNI nodeagent image in ECR.
+	NodeAgentImage *string `pulumi:"nodeAgentImage"`
 	// Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
 	//
 	// Defaults to true.
@@ -2314,7 +2318,7 @@ type VpcCniOptionsArgs struct {
 	//
 	// Defaults to false.
 	ExternalSnat pulumi.BoolPtrInput `pulumi:"externalSnat"`
-	// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+	// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 	//
 	// Defaults to the official AWS CNI image in ECR.
 	Image pulumi.StringPtrInput `pulumi:"image"`
@@ -2331,6 +2335,10 @@ type VpcCniOptionsArgs struct {
 	// Defaults to "DEBUG"
 	// Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
 	LogLevel pulumi.StringPtrInput `pulumi:"logLevel"`
+	// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+	//
+	// Defaults to the official AWS CNI nodeagent image in ECR.
+	NodeAgentImage pulumi.StringPtrInput `pulumi:"nodeAgentImage"`
 	// Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
 	//
 	// Defaults to true.
@@ -2495,7 +2503,7 @@ func (o VpcCniOptionsOutput) ExternalSnat() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v VpcCniOptions) *bool { return v.ExternalSnat }).(pulumi.BoolPtrOutput)
 }
 
-// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 //
 // Defaults to the official AWS CNI image in ECR.
 func (o VpcCniOptionsOutput) Image() pulumi.StringPtrOutput {
@@ -2522,6 +2530,13 @@ func (o VpcCniOptionsOutput) LogFile() pulumi.StringPtrOutput {
 // Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
 func (o VpcCniOptionsOutput) LogLevel() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v VpcCniOptions) *string { return v.LogLevel }).(pulumi.StringPtrOutput)
+}
+
+// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+//
+// Defaults to the official AWS CNI nodeagent image in ECR.
+func (o VpcCniOptionsOutput) NodeAgentImage() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v VpcCniOptions) *string { return v.NodeAgentImage }).(pulumi.StringPtrOutput)
 }
 
 // Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
@@ -2705,7 +2720,7 @@ func (o VpcCniOptionsPtrOutput) ExternalSnat() pulumi.BoolPtrOutput {
 	}).(pulumi.BoolPtrOutput)
 }
 
-// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 //
 // Defaults to the official AWS CNI image in ECR.
 func (o VpcCniOptionsPtrOutput) Image() pulumi.StringPtrOutput {
@@ -2751,6 +2766,18 @@ func (o VpcCniOptionsPtrOutput) LogLevel() pulumi.StringPtrOutput {
 			return nil
 		}
 		return v.LogLevel
+	}).(pulumi.StringPtrOutput)
+}
+
+// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+//
+// Defaults to the official AWS CNI nodeagent image in ECR.
+func (o VpcCniOptionsPtrOutput) NodeAgentImage() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *VpcCniOptions) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NodeAgentImage
 	}).(pulumi.StringPtrOutput)
 }
 

--- a/sdk/go/eks/vpcCni.go
+++ b/sdk/go/eks/vpcCni.go
@@ -91,7 +91,7 @@ type vpcCniArgs struct {
 	//
 	// Defaults to false.
 	ExternalSnat *bool `pulumi:"externalSnat"`
-	// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+	// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 	//
 	// Defaults to the official AWS CNI image in ECR.
 	Image *string `pulumi:"image"`
@@ -110,6 +110,10 @@ type vpcCniArgs struct {
 	// Defaults to "DEBUG"
 	// Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
 	LogLevel *string `pulumi:"logLevel"`
+	// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+	//
+	// Defaults to the official AWS CNI nodeagent image in ECR.
+	NodeAgentImage *string `pulumi:"nodeAgentImage"`
 	// Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
 	//
 	// Defaults to true.
@@ -165,7 +169,7 @@ type VpcCniArgs struct {
 	//
 	// Defaults to false.
 	ExternalSnat pulumi.BoolPtrInput
-	// Specifies the container image to use in the AWS CNI cluster DaemonSet.
+	// Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 	//
 	// Defaults to the official AWS CNI image in ECR.
 	Image pulumi.StringPtrInput
@@ -184,6 +188,10 @@ type VpcCniArgs struct {
 	// Defaults to "DEBUG"
 	// Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
 	LogLevel pulumi.StringPtrInput
+	// Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+	//
+	// Defaults to the official AWS CNI nodeagent image in ECR.
+	NodeAgentImage pulumi.StringPtrInput
 	// Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
 	//
 	// Defaults to true.

--- a/sdk/java/src/main/java/com/pulumi/eks/VpcCniArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/VpcCniArgs.java
@@ -202,7 +202,7 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Specifies the container image to use in the AWS CNI cluster DaemonSet.
+     * Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
      * 
      * Defaults to the official AWS CNI image in ECR.
      * 
@@ -211,7 +211,7 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<String> image;
 
     /**
-     * @return Specifies the container image to use in the AWS CNI cluster DaemonSet.
+     * @return Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
      * 
      * Defaults to the official AWS CNI image in ECR.
      * 
@@ -292,6 +292,25 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<String>> logLevel() {
         return Optional.ofNullable(this.logLevel);
+    }
+
+    /**
+     * Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+     * 
+     * Defaults to the official AWS CNI nodeagent image in ECR.
+     * 
+     */
+    @Import(name="nodeAgentImage")
+    private @Nullable Output<String> nodeAgentImage;
+
+    /**
+     * @return Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+     * 
+     * Defaults to the official AWS CNI nodeagent image in ECR.
+     * 
+     */
+    public Optional<Output<String>> nodeAgentImage() {
+        return Optional.ofNullable(this.nodeAgentImage);
     }
 
     /**
@@ -419,6 +438,7 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
         this.kubeconfig = $.kubeconfig;
         this.logFile = $.logFile;
         this.logLevel = $.logLevel;
+        this.nodeAgentImage = $.nodeAgentImage;
         this.nodePortSupport = $.nodePortSupport;
         this.securityContextPrivileged = $.securityContextPrivileged;
         this.vethPrefix = $.vethPrefix;
@@ -695,7 +715,7 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param image Specifies the container image to use in the AWS CNI cluster DaemonSet.
+         * @param image Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
          * 
          * Defaults to the official AWS CNI image in ECR.
          * 
@@ -708,7 +728,7 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param image Specifies the container image to use in the AWS CNI cluster DaemonSet.
+         * @param image Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
          * 
          * Defaults to the official AWS CNI image in ECR.
          * 
@@ -815,6 +835,31 @@ public final class VpcCniArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder logLevel(String logLevel) {
             return logLevel(Output.of(logLevel));
+        }
+
+        /**
+         * @param nodeAgentImage Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+         * 
+         * Defaults to the official AWS CNI nodeagent image in ECR.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeAgentImage(@Nullable Output<String> nodeAgentImage) {
+            $.nodeAgentImage = nodeAgentImage;
+            return this;
+        }
+
+        /**
+         * @param nodeAgentImage Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+         * 
+         * Defaults to the official AWS CNI nodeagent image in ECR.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeAgentImage(String nodeAgentImage) {
+            return nodeAgentImage(Output.of(nodeAgentImage));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/VpcCniOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/VpcCniOptionsArgs.java
@@ -205,7 +205,7 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Specifies the container image to use in the AWS CNI cluster DaemonSet.
+     * Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
      * 
      * Defaults to the official AWS CNI image in ECR.
      * 
@@ -214,7 +214,7 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<String> image;
 
     /**
-     * @return Specifies the container image to use in the AWS CNI cluster DaemonSet.
+     * @return Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
      * 
      * Defaults to the official AWS CNI image in ECR.
      * 
@@ -280,6 +280,25 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<String>> logLevel() {
         return Optional.ofNullable(this.logLevel);
+    }
+
+    /**
+     * Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+     * 
+     * Defaults to the official AWS CNI nodeagent image in ECR.
+     * 
+     */
+    @Import(name="nodeAgentImage")
+    private @Nullable Output<String> nodeAgentImage;
+
+    /**
+     * @return Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+     * 
+     * Defaults to the official AWS CNI nodeagent image in ECR.
+     * 
+     */
+    public Optional<Output<String>> nodeAgentImage() {
+        return Optional.ofNullable(this.nodeAgentImage);
     }
 
     /**
@@ -406,6 +425,7 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
         this.initImage = $.initImage;
         this.logFile = $.logFile;
         this.logLevel = $.logLevel;
+        this.nodeAgentImage = $.nodeAgentImage;
         this.nodePortSupport = $.nodePortSupport;
         this.securityContextPrivileged = $.securityContextPrivileged;
         this.vethPrefix = $.vethPrefix;
@@ -682,7 +702,7 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param image Specifies the container image to use in the AWS CNI cluster DaemonSet.
+         * @param image Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
          * 
          * Defaults to the official AWS CNI image in ECR.
          * 
@@ -695,7 +715,7 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param image Specifies the container image to use in the AWS CNI cluster DaemonSet.
+         * @param image Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
          * 
          * Defaults to the official AWS CNI image in ECR.
          * 
@@ -781,6 +801,31 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder logLevel(String logLevel) {
             return logLevel(Output.of(logLevel));
+        }
+
+        /**
+         * @param nodeAgentImage Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+         * 
+         * Defaults to the official AWS CNI nodeagent image in ECR.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeAgentImage(@Nullable Output<String> nodeAgentImage) {
+            $.nodeAgentImage = nodeAgentImage;
+            return this;
+        }
+
+        /**
+         * @param nodeAgentImage Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+         * 
+         * Defaults to the official AWS CNI nodeagent image in ECR.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeAgentImage(String nodeAgentImage) {
+            return nodeAgentImage(Output.of(nodeAgentImage));
         }
 
         /**

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -1302,6 +1302,7 @@ class VpcCniOptionsArgs:
                  init_image: Optional[pulumi.Input[str]] = None,
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
+                 node_agent_image: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  veth_prefix: Optional[pulumi.Input[str]] = None,
@@ -1330,7 +1331,7 @@ class VpcCniOptionsArgs:
         :param pulumi.Input[bool] external_snat: Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied.
                
                Defaults to false.
-        :param pulumi.Input[str] image: Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        :param pulumi.Input[str] image: Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
                
                Defaults to the official AWS CNI image in ECR.
         :param pulumi.Input[str] init_image: Specifies the init container image to use in the AWS CNI cluster DaemonSet.
@@ -1343,6 +1344,9 @@ class VpcCniOptionsArgs:
                
                Defaults to "DEBUG"
                Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
+        :param pulumi.Input[str] node_agent_image: Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+               
+               Defaults to the official AWS CNI nodeagent image in ECR.
         :param pulumi.Input[bool] node_port_support: Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
                
                Defaults to true.
@@ -1388,6 +1392,8 @@ class VpcCniOptionsArgs:
             pulumi.set(__self__, "log_file", log_file)
         if log_level is not None:
             pulumi.set(__self__, "log_level", log_level)
+        if node_agent_image is not None:
+            pulumi.set(__self__, "node_agent_image", node_agent_image)
         if node_port_support is not None:
             pulumi.set(__self__, "node_port_support", node_port_support)
         if security_context_privileged is not None:
@@ -1546,7 +1552,7 @@ class VpcCniOptionsArgs:
     @pulumi.getter
     def image(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 
         Defaults to the official AWS CNI image in ECR.
         """
@@ -1598,6 +1604,20 @@ class VpcCniOptionsArgs:
     @log_level.setter
     def log_level(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "log_level", value)
+
+    @property
+    @pulumi.getter(name="nodeAgentImage")
+    def node_agent_image(self) -> Optional[pulumi.Input[str]]:
+        """
+        Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+
+        Defaults to the official AWS CNI nodeagent image in ECR.
+        """
+        return pulumi.get(self, "node_agent_image")
+
+    @node_agent_image.setter
+    def node_agent_image(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_agent_image", value)
 
     @property
     @pulumi.getter(name="nodePortSupport")

--- a/sdk/python/pulumi_eks/vpc_cni.py
+++ b/sdk/python/pulumi_eks/vpc_cni.py
@@ -30,6 +30,7 @@ class VpcCniArgs:
                  init_image: Optional[pulumi.Input[str]] = None,
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
+                 node_agent_image: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  veth_prefix: Optional[pulumi.Input[str]] = None,
@@ -59,7 +60,7 @@ class VpcCniArgs:
         :param pulumi.Input[bool] external_snat: Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied.
                
                Defaults to false.
-        :param pulumi.Input[str] image: Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        :param pulumi.Input[str] image: Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
                
                Defaults to the official AWS CNI image in ECR.
         :param pulumi.Input[str] init_image: Specifies the init container image to use in the AWS CNI cluster DaemonSet.
@@ -72,6 +73,9 @@ class VpcCniArgs:
                
                Defaults to "DEBUG"
                Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
+        :param pulumi.Input[str] node_agent_image: Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+               
+               Defaults to the official AWS CNI nodeagent image in ECR.
         :param pulumi.Input[bool] node_port_support: Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
                
                Defaults to true.
@@ -118,6 +122,8 @@ class VpcCniArgs:
             pulumi.set(__self__, "log_file", log_file)
         if log_level is not None:
             pulumi.set(__self__, "log_level", log_level)
+        if node_agent_image is not None:
+            pulumi.set(__self__, "node_agent_image", node_agent_image)
         if node_port_support is not None:
             pulumi.set(__self__, "node_port_support", node_port_support)
         if security_context_privileged is not None:
@@ -288,7 +294,7 @@ class VpcCniArgs:
     @pulumi.getter
     def image(self) -> Optional[pulumi.Input[str]]:
         """
-        Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
 
         Defaults to the official AWS CNI image in ECR.
         """
@@ -340,6 +346,20 @@ class VpcCniArgs:
     @log_level.setter
     def log_level(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "log_level", value)
+
+    @property
+    @pulumi.getter(name="nodeAgentImage")
+    def node_agent_image(self) -> Optional[pulumi.Input[str]]:
+        """
+        Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+
+        Defaults to the official AWS CNI nodeagent image in ECR.
+        """
+        return pulumi.get(self, "node_agent_image")
+
+    @node_agent_image.setter
+    def node_agent_image(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_agent_image", value)
 
     @property
     @pulumi.getter(name="nodePortSupport")
@@ -443,6 +463,7 @@ class VpcCni(pulumi.CustomResource):
                  kubeconfig: Optional[Any] = None,
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
+                 node_agent_image: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  veth_prefix: Optional[pulumi.Input[str]] = None,
@@ -475,7 +496,7 @@ class VpcCni(pulumi.CustomResource):
         :param pulumi.Input[bool] external_snat: Specifies whether an external NAT gateway should be used to provide SNAT of secondary ENI IP addresses. If set to true, the SNAT iptables rule and off-VPC IP rule are not applied, and these rules are removed if they have already been applied.
                
                Defaults to false.
-        :param pulumi.Input[str] image: Specifies the container image to use in the AWS CNI cluster DaemonSet.
+        :param pulumi.Input[str] image: Specifies the aws-node container image to use in the AWS CNI cluster DaemonSet.
                
                Defaults to the official AWS CNI image in ECR.
         :param pulumi.Input[str] init_image: Specifies the init container image to use in the AWS CNI cluster DaemonSet.
@@ -489,6 +510,9 @@ class VpcCni(pulumi.CustomResource):
                
                Defaults to "DEBUG"
                Valid values: "DEBUG", "INFO", "WARN", "ERROR", or "FATAL".
+        :param pulumi.Input[str] node_agent_image: Specifies the aws-eks-nodeagent container image to use in the AWS CNI cluster DaemonSet.
+               
+               Defaults to the official AWS CNI nodeagent image in ECR.
         :param pulumi.Input[bool] node_port_support: Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
                
                Defaults to true.
@@ -544,6 +568,7 @@ class VpcCni(pulumi.CustomResource):
                  kubeconfig: Optional[Any] = None,
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
+                 node_agent_image: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  veth_prefix: Optional[pulumi.Input[str]] = None,
@@ -577,6 +602,7 @@ class VpcCni(pulumi.CustomResource):
             __props__.__dict__["kubeconfig"] = kubeconfig
             __props__.__dict__["log_file"] = log_file
             __props__.__dict__["log_level"] = log_level
+            __props__.__dict__["node_agent_image"] = node_agent_image
             __props__.__dict__["node_port_support"] = node_port_support
             __props__.__dict__["security_context_privileged"] = security_context_privileged
             __props__.__dict__["veth_prefix"] = veth_prefix


### PR DESCRIPTION
### Proposed changes

This PR exposes an additional option for `VpcCni` resources. The `nodeImage` option will allow users to specify a custom `aws-eks-nodeagent` container image.

#### Changes made:

- Added logic to enable customizing nodeagent container images
- Added jest unit test to validate images can be set
- Exposed the `nodeImage` option as a customizable argument in schema
- Rebuilt SDKs

### Related issues (optional)

Fixes: #1078
