### PR TITLE
tests: update dependencies for baseline testing

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -125,8 +125,8 @@ func test(dir string, opts ...providertest.Option) *providertest.ProviderTest {
 		// baseline provider version uses the correct dependencies that the older provider version would have used.
 		providertest.WithBaselineVersion("2.2.1"),
 		providertest.WithExtraBaselineDependencies(map[string]string{
-			"aws":        "6.0.4",
-			"kubernetes": "4.1.1",
+			"aws":        "6.27.0",
+			"kubernetes": "4.9.1",
 		}),
 
 		// This region needs to match the one configured in .github for the CI workflows.


### PR DESCRIPTION
### Proposed changes

Fixes the snapshot tests by updating the baselines for the underlying k8s and aws providers/sdks.
