### PR TITLE
ci: always generate a changelog for GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,8 +209,9 @@ jobs:
       - name: Upload Provider Binaries
         run: aws s3 cp dist s3://get.pulumi.com/releases/plugins/ --recursive
       - name: Create GH Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             dist/*.tar.gz
           prerelease: ${{ env.IS_PRERELEASE }}


### PR DESCRIPTION
### Proposed changes

This PR updates our release step action to `softprops/action-gh-release@v2` and enables generating of release notes.

### Related issues (optional)

Fixes: #1108
