### PR TITLE
Run unit tests in CI

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,7 +27,7 @@ env:
   JAVAVERSION: "11"
 jobs:
   lint:
-    name: lint
+    name: Lint and unit test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -51,6 +51,8 @@ jobs:
           echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
       - name: Run lint
         run: make lint
+      - name: Run unit tests
+        run: make test_unit_tests
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ env:
   JAVAVERSION: "11"
 jobs:
   lint:
-    name: lint
+    name: Lint and unit test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -51,6 +51,8 @@ jobs:
           echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
       - name: Run lint
         run: make lint
+      - name: Run unit tests
+        run: make test_unit_tests
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ env:
   IS_PRERELEASE: ${{ contains(github.ref_name,'-') }}
 jobs:
   lint:
-    name: lint
+    name: Lint and unit test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -52,6 +52,8 @@ jobs:
           echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
       - name: Run lint
         run: make lint
+      - name: Run unit tests
+        run: make test_unit_tests
   build_sdk:
     name: build_sdk
     runs-on: ubuntu-latest

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -47,7 +47,7 @@ jobs:
           body: |
             Please view the PR build - ${{ steps.vars.outputs.run-url }}
   lint:
-    name: lint
+    name: Lint and unit test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -71,6 +71,8 @@ jobs:
           echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
       - name: Run lint
         run: make lint
+      - name: Run unit tests
+        run: make test_unit_tests
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,11 @@ test_dotnet:: install_provider
 test_java:: install_provider
 	cd examples && go test -tags=java -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
 
+test_unit_tests:
+	cd nodejs/eks && \
+		yarn install && \
+		yarn run test
+
 specific_test:: install_nodejs_sdk test_build
 	cd examples && go test -tags=$(LanguageTags) -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . --run=TestAcc$(TestName) 2>&1 | tee /tmp/gotest.log | gotestfmt
 


### PR DESCRIPTION
### Proposed changes

This PR adds a new Makefile entry point `test_unit_tests` and enables running these tests in our CI workflows.

Instead of creating another job that requires setting up node/yarn etc, I've added the unit test running step to the existing linting step. The unit tests are fairly quick to run (~1.5 seconds).

### Related issues (optional)

Closes: #1104