### PR TITLE
Add warning note about using creationRoleProvider for non-nodejs programs

### DIFF
--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -348,7 +348,8 @@ func generateSchema() schema.PackageSpec {
 						},
 						Description: "The IAM Role Provider used to create & authenticate against the EKS cluster. " +
 							"This role is given `[system:masters]` permission in K8S, See: " +
-							"https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
+							"https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html\n\n" +
+							"Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.",
 					},
 					"instanceRoles": {
 						TypeSpec: schema.TypeSpec{
@@ -1047,7 +1048,8 @@ func generateSchema() schema.PackageSpec {
 					Type: "object",
 					Description: "Contains the AWS Role and Provider necessary to override the `[system:master]` " +
 						"entity ARN. This is an optional argument used when creating `Cluster`. Read more: " +
-						"https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
+						"https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html\n\n" +
+						"Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.",
 					Properties: map[string]schema.PropertySpec{
 						"role": {
 							TypeSpec: schema.TypeSpec{

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -289,7 +289,7 @@
             ]
         },
         "eks:index:CreationRoleProvider": {
-            "description": "Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html",
+            "description": "Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html\n\nNote: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.",
             "properties": {
                 "provider": {
                     "$ref": "/aws/v6.5.0/schema.json#/provider",
@@ -687,7 +687,7 @@
                 "creationRoleProvider": {
                     "$ref": "#/types/eks:index:CreationRoleProvider",
                     "plain": true,
-                    "description": "The IAM Role Provider used to create \u0026 authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html"
+                    "description": "The IAM Role Provider used to create \u0026 authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html\n\nNote: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead."
                 },
                 "defaultAddonsToRemove": {
                     "type": "array",

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -164,6 +164,8 @@ namespace Pulumi.Eks
 
         /// <summary>
         /// The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+        /// 
+        /// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
         /// </summary>
         [Input("creationRoleProvider")]
         public Inputs.CreationRoleProviderArgs? CreationRoleProvider { get; set; }

--- a/sdk/dotnet/Inputs/CreationRoleProviderArgs.cs
+++ b/sdk/dotnet/Inputs/CreationRoleProviderArgs.cs
@@ -12,6 +12,8 @@ namespace Pulumi.Eks.Inputs
 
     /// <summary>
     /// Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+    /// 
+    /// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
     /// </summary>
     public sealed class CreationRoleProviderArgs : global::Pulumi.ResourceArgs
     {

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -77,6 +77,8 @@ type clusterArgs struct {
 	//  - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
 	CreateOidcProvider *bool `pulumi:"createOidcProvider"`
 	// The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+	//
+	// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
 	CreationRoleProvider *CreationRoleProvider `pulumi:"creationRoleProvider"`
 	// List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
 	DefaultAddonsToRemove []string `pulumi:"defaultAddonsToRemove"`
@@ -293,6 +295,8 @@ type ClusterArgs struct {
 	//  - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
 	CreateOidcProvider pulumi.BoolPtrInput
 	// The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+	//
+	// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
 	CreationRoleProvider *CreationRoleProviderArgs
 	// List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
 	DefaultAddonsToRemove pulumi.StringArrayInput

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -992,6 +992,8 @@ func (o CoreDataOutput) VpcId() pulumi.StringOutput {
 }
 
 // Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+//
+// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
 type CreationRoleProvider struct {
 	Provider *aws.Provider `pulumi:"provider"`
 	Role     *iam.Role     `pulumi:"role"`
@@ -1009,6 +1011,8 @@ type CreationRoleProviderInput interface {
 }
 
 // Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+//
+// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
 type CreationRoleProviderArgs struct {
 	Provider *aws.Provider `pulumi:"provider"`
 	Role     *iam.Role     `pulumi:"role"`
@@ -1068,6 +1072,8 @@ func (i *creationRoleProviderPtrType) ToCreationRoleProviderPtrOutputWithContext
 }
 
 // Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+//
+// Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
 type CreationRoleProviderOutput struct{ *pulumi.OutputState }
 
 func (CreationRoleProviderOutput) ElementType() reflect.Type {

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -113,12 +113,16 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
      * 
+     * Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
+     * 
      */
     @Import(name="creationRoleProvider")
     private @Nullable CreationRoleProviderArgs creationRoleProvider;
 
     /**
      * @return The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+     * 
+     * Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
      * 
      */
     public Optional<CreationRoleProviderArgs> creationRoleProvider() {
@@ -1159,6 +1163,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
 
         /**
          * @param creationRoleProvider The IAM Role Provider used to create &amp; authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+         * 
+         * Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/CreationRoleProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/CreationRoleProviderArgs.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 /**
  * Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
  * 
+ * Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
+ * 
  */
 public final class CreationRoleProviderArgs extends com.pulumi.resources.ResourceArgs {
 

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -807,6 +807,8 @@ class CreationRoleProviderArgs:
                  role: 'pulumi_aws.iam.Role'):
         """
         Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+
+        Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
         """
         pulumi.set(__self__, "provider", provider)
         pulumi.set(__self__, "role", role)

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -84,6 +84,8 @@ class ClusterArgs:
                 - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
                 - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
         :param 'CreationRoleProviderArgs' creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+               
+               Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] default_addons_to_remove: List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_config_map_mutable: Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.
@@ -394,6 +396,8 @@ class ClusterArgs:
     def creation_role_provider(self) -> Optional['CreationRoleProviderArgs']:
         """
         The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+
+        Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
         """
         return pulumi.get(self, "creation_role_provider")
 
@@ -1098,6 +1102,8 @@ class Cluster(pulumi.ComponentResource):
                 - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
                 - https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/eks/#enabling-iam-roles-for-service-accounts
         :param pulumi.InputType['CreationRoleProviderArgs'] creation_role_provider: The IAM Role Provider used to create & authenticate against the EKS cluster. This role is given `[system:masters]` permission in K8S, See: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+               
+               Note: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] default_addons_to_remove: List of addons to remove upon creation. Any addon listed will be "adopted" and then removed. This allows for the creation of a baremetal cluster where no addon is deployed and direct management of addons via Pulumi Kubernetes resources. Valid entries are kube-proxy, coredns and vpc-cni. Only works on first creation of a cluster.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_config_map_mutable: Sets the 'enableConfigMapMutable' option on the cluster kubernetes provider.


### PR DESCRIPTION
This adds a note to our documentation that `creationRoleProvider` can only be used in nodejs programs, and suggests an alternative option to get the same result.

Validation was added in: https://github.com/pulumi/pulumi-eks/pull/1121

Related: #1123