### PR TITLE
Expose KubeletExtraArgs and BootstrapExtraArgs for managed nodegroups

### DIFF
--- a/examples/managed-nodegroups-go/main.go
+++ b/examples/managed-nodegroups-go/main.go
@@ -95,8 +95,9 @@ func main() {
 		_, err = eks.NewManagedNodeGroup(ctx,
 			"aws-managed-ng0",
 			&eks.ManagedNodeGroupArgs{
-				Cluster:  cluster,
-				NodeRole: role0,
+				Cluster:          cluster,
+				NodeRole:         role0,
+				KubeletExtraArgs: pulumi.StringRef("--max-pods=50"),
 			})
 		if err != nil {
 			return err

--- a/examples/managed-nodegroups-go/main.go
+++ b/examples/managed-nodegroups-go/main.go
@@ -97,7 +97,7 @@ func main() {
 			&eks.ManagedNodeGroupArgs{
 				Cluster:          cluster,
 				NodeRole:         role0,
-				KubeletExtraArgs: pulumi.StringRef("--max-pods=50"),
+				KubeletExtraArgs: pulumi.StringRef("--max-pods=500"),
 			})
 		if err != nil {
 			return err

--- a/examples/managed-nodegroups/index.ts
+++ b/examples/managed-nodegroups/index.ts
@@ -22,6 +22,7 @@ export const kubeconfig = cluster.kubeconfig;
 const managedNodeGroup0 = eks.createManagedNodeGroup("example-managed-ng0", {
     cluster: cluster,
     nodeRole: role0,
+    kubeletExtraArgs: "--max-pods=500",
 });
 
 // Create a simple AWS managed node group using a cluster as input and the

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1439,7 +1439,8 @@ export type ManagedNodeGroupOptions = Omit<
 
     /**
      * Extra args to pass to the Kubelet.  Corresponds to the options passed in the `--kubeletExtraArgs` flag to
-     * `/etc/eks/bootstrap.sh`.  For example, '--port=10251 --address=0.0.0.0'.
+     * `/etc/eks/bootstrap.sh`.  For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra args
+     * value, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
      * 
      * Note that this field conflicts with `launchTemplate`.
      */

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1709,7 +1709,7 @@ function createManagedNodeGroupInternal(
                 };
             }),
             subnetIds: subnetIds,
-            launchTemplate: launchTemplate ? { id: launchTemplate.id, version: "$Latest"} : undefined,
+            launchTemplate: launchTemplate ? { id: launchTemplate.id, version: launchTemplate.latestVersion.apply((version) => {return `${version}`})} : undefined,
         },
         { parent: parent, dependsOn: ngDeps, provider },
     );

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -838,9 +838,8 @@ func generateSchema() schema.PackageSpec {
 						},
 						Description: "Extra args to pass to the Kubelet. Corresponds to the options passed in the " +
 							"`--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, " +
-							"'--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will " +
-							"be applied to this list (using `--node-labels` and `--register-with-taints` " +
-							"respectively) after to the explicit `kubeletExtraArgs`.\n\n" +
+							"'--port=10251 --address=0.0.0.0'. To escape characters in the extra args" +
+							"value, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls \"net.core.somaxconn\"'`.\n" +
 							"Note that this field conflicts with `launchTemplate`.",
 					},
 					"bootstrapExtraArgs": {
@@ -1667,7 +1666,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		},
 		"enableDetailedMonitoring": {
 			TypeSpec: schema.TypeSpec{
-				Type:  "boolean",
+				Type: "boolean",
 			},
 			Description: "Enables/disables detailed monitoring of the EC2 instances.\n\n" +
 				"With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.\n" +

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -754,8 +754,9 @@ func generateSchema() schema.PackageSpec {
 							"will not be managed.",
 					},
 					"launchTemplate": {
-						TypeSpec:    schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate")},
-						Description: "Launch Template settings.",
+						TypeSpec: schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate")},
+						Description: "Launch Template settings.\n\n" +
+							"Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.",
 					},
 					"nodeGroupName": {
 						TypeSpec: schema.TypeSpec{Type: "string"},
@@ -829,6 +830,30 @@ func generateSchema() schema.PackageSpec {
 					},
 					"version": {
 						TypeSpec: schema.TypeSpec{Type: "string"},
+					},
+					"kubeletExtraArgs": {
+						TypeSpec: schema.TypeSpec{
+							Type:  "string",
+							Plain: true,
+						},
+						Description: "Extra args to pass to the Kubelet. Corresponds to the options passed in the " +
+							"`--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, " +
+							"'--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will " +
+							"be applied to this list (using `--node-labels` and `--register-with-taints` " +
+							"respectively) after to the explicit `kubeletExtraArgs`.\n\n" +
+							"Note that this field conflicts with `launchTemplate`.",
+					},
+					"bootstrapExtraArgs": {
+						TypeSpec: schema.TypeSpec{
+							Type:  "string",
+							Plain: true,
+						},
+						Description: "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on " +
+							"available options, see: " +
+							"https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. " +
+							"Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` " +
+							"flags are included automatically based on other configuration parameters.\n\n" +
+							"Note that this field conflicts with `launchTemplate`.",
 					},
 				},
 				RequiredInputs: []string{"cluster"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -1026,7 +1026,7 @@
                 "kubeletExtraArgs": {
                     "type": "string",
                     "plain": true,
-                    "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.\n\nNote that this field conflicts with `launchTemplate`."
+                    "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls \"net.core.somaxconn\"'`.\nNote that this field conflicts with `launchTemplate`."
                 },
                 "labels": {
                     "type": "object",

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -984,6 +984,11 @@
                     "type": "string",
                     "description": "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. See the AWS documentation (https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) for valid AMI Types. This provider will only perform drift detection if a configuration value is provided."
                 },
+                "bootstrapExtraArgs": {
+                    "type": "string",
+                    "plain": true,
+                    "description": "Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.\n\nNote that this field conflicts with `launchTemplate`."
+                },
                 "capacityType": {
                     "type": "string",
                     "description": "Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided."
@@ -1018,6 +1023,11 @@
                     },
                     "description": "Set of instance types associated with the EKS Node Group. Defaults to `[\"t3.medium\"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set."
                 },
+                "kubeletExtraArgs": {
+                    "type": "string",
+                    "plain": true,
+                    "description": "Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.\n\nNote that this field conflicts with `launchTemplate`."
+                },
                 "labels": {
                     "type": "object",
                     "additionalProperties": {
@@ -1027,7 +1037,7 @@
                 },
                 "launchTemplate": {
                     "$ref": "/aws/v6.5.0/schema.json#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate",
-                    "description": "Launch Template settings."
+                    "description": "Launch Template settings.\n\nNote: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`."
                 },
                 "nodeGroupName": {
                     "type": "string",

--- a/sdk/dotnet/ManagedNodeGroup.cs
+++ b/sdk/dotnet/ManagedNodeGroup.cs
@@ -59,6 +59,14 @@ namespace Pulumi.Eks
         public Input<string>? AmiType { get; set; }
 
         /// <summary>
+        /// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+        /// 
+        /// Note that this field conflicts with `launchTemplate`.
+        /// </summary>
+        [Input("bootstrapExtraArgs")]
+        public string? BootstrapExtraArgs { get; set; }
+
+        /// <summary>
         /// Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
         /// </summary>
         [Input("capacityType")]
@@ -100,6 +108,14 @@ namespace Pulumi.Eks
             set => _instanceTypes = value;
         }
 
+        /// <summary>
+        /// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+        /// 
+        /// Note that this field conflicts with `launchTemplate`.
+        /// </summary>
+        [Input("kubeletExtraArgs")]
+        public string? KubeletExtraArgs { get; set; }
+
         [Input("labels")]
         private InputMap<string>? _labels;
 
@@ -114,6 +130,8 @@ namespace Pulumi.Eks
 
         /// <summary>
         /// Launch Template settings.
+        /// 
+        /// Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
         /// </summary>
         [Input("launchTemplate")]
         public Input<Pulumi.Aws.Eks.Inputs.NodeGroupLaunchTemplateArgs>? LaunchTemplate { get; set; }

--- a/sdk/dotnet/ManagedNodeGroup.cs
+++ b/sdk/dotnet/ManagedNodeGroup.cs
@@ -109,8 +109,7 @@ namespace Pulumi.Eks
         }
 
         /// <summary>
-        /// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-        /// 
+        /// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
         /// Note that this field conflicts with `launchTemplate`.
         /// </summary>
         [Input("kubeletExtraArgs")]

--- a/sdk/go/eks/managedNodeGroup.go
+++ b/sdk/go/eks/managedNodeGroup.go
@@ -63,8 +63,7 @@ type managedNodeGroupArgs struct {
 	ForceUpdateVersion *bool `pulumi:"forceUpdateVersion"`
 	// Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
 	InstanceTypes []string `pulumi:"instanceTypes"`
-	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-	//
+	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
 	// Note that this field conflicts with `launchTemplate`.
 	KubeletExtraArgs *string `pulumi:"kubeletExtraArgs"`
 	// Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
@@ -132,8 +131,7 @@ type ManagedNodeGroupArgs struct {
 	ForceUpdateVersion pulumi.BoolPtrInput
 	// Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
 	InstanceTypes pulumi.StringArrayInput
-	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-	//
+	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
 	// Note that this field conflicts with `launchTemplate`.
 	KubeletExtraArgs *string
 	// Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.

--- a/sdk/go/eks/managedNodeGroup.go
+++ b/sdk/go/eks/managedNodeGroup.go
@@ -47,6 +47,10 @@ func NewManagedNodeGroup(ctx *pulumi.Context,
 type managedNodeGroupArgs struct {
 	// Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. See the AWS documentation (https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) for valid AMI Types. This provider will only perform drift detection if a configuration value is provided.
 	AmiType *string `pulumi:"amiType"`
+	// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+	//
+	// Note that this field conflicts with `launchTemplate`.
+	BootstrapExtraArgs *string `pulumi:"bootstrapExtraArgs"`
 	// Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
 	CapacityType *string `pulumi:"capacityType"`
 	// The target EKS cluster.
@@ -59,9 +63,15 @@ type managedNodeGroupArgs struct {
 	ForceUpdateVersion *bool `pulumi:"forceUpdateVersion"`
 	// Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
 	InstanceTypes []string `pulumi:"instanceTypes"`
+	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+	//
+	// Note that this field conflicts with `launchTemplate`.
+	KubeletExtraArgs *string `pulumi:"kubeletExtraArgs"`
 	// Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 	Labels map[string]string `pulumi:"labels"`
 	// Launch Template settings.
+	//
+	// Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
 	LaunchTemplate *eks.NodeGroupLaunchTemplate `pulumi:"launchTemplate"`
 	// Name of the EKS Node Group. If omitted, this provider will assign a random, unique name. Conflicts with `nodeGroupNamePrefix`.
 	NodeGroupName *string `pulumi:"nodeGroupName"`
@@ -106,6 +116,10 @@ type managedNodeGroupArgs struct {
 type ManagedNodeGroupArgs struct {
 	// Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. See the AWS documentation (https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) for valid AMI Types. This provider will only perform drift detection if a configuration value is provided.
 	AmiType pulumi.StringPtrInput
+	// Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+	//
+	// Note that this field conflicts with `launchTemplate`.
+	BootstrapExtraArgs *string
 	// Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
 	CapacityType pulumi.StringPtrInput
 	// The target EKS cluster.
@@ -118,9 +132,15 @@ type ManagedNodeGroupArgs struct {
 	ForceUpdateVersion pulumi.BoolPtrInput
 	// Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
 	InstanceTypes pulumi.StringArrayInput
+	// Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+	//
+	// Note that this field conflicts with `launchTemplate`.
+	KubeletExtraArgs *string
 	// Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 	Labels pulumi.StringMapInput
 	// Launch Template settings.
+	//
+	// Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
 	LaunchTemplate eks.NodeGroupLaunchTemplatePtrInput
 	// Name of the EKS Node Group. If omitted, this provider will assign a random, unique name. Conflicts with `nodeGroupNamePrefix`.
 	NodeGroupName pulumi.StringPtrInput

--- a/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroupArgs.java
@@ -152,8 +152,7 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
-     * Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-     * 
+     * Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = &#39;--allowed-unsafe-sysctls &#34;net.core.somaxconn&#34;&#39;`.
      * Note that this field conflicts with `launchTemplate`.
      * 
      */
@@ -161,8 +160,7 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     private @Nullable String kubeletExtraArgs;
 
     /**
-     * @return Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-     * 
+     * @return Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = &#39;--allowed-unsafe-sysctls &#34;net.core.somaxconn&#34;&#39;`.
      * Note that this field conflicts with `launchTemplate`.
      * 
      */
@@ -629,8 +627,7 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
-         * @param kubeletExtraArgs Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-         * 
+         * @param kubeletExtraArgs Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = &#39;--allowed-unsafe-sysctls &#34;net.core.somaxconn&#34;&#39;`.
          * Note that this field conflicts with `launchTemplate`.
          * 
          * @return builder

--- a/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroupArgs.java
@@ -43,6 +43,25 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
+     * Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+     * 
+     * Note that this field conflicts with `launchTemplate`.
+     * 
+     */
+    @Import(name="bootstrapExtraArgs")
+    private @Nullable String bootstrapExtraArgs;
+
+    /**
+     * @return Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+     * 
+     * Note that this field conflicts with `launchTemplate`.
+     * 
+     */
+    public Optional<String> bootstrapExtraArgs() {
+        return Optional.ofNullable(this.bootstrapExtraArgs);
+    }
+
+    /**
      * Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
      * 
      */
@@ -133,6 +152,25 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
+     * Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+     * 
+     * Note that this field conflicts with `launchTemplate`.
+     * 
+     */
+    @Import(name="kubeletExtraArgs")
+    private @Nullable String kubeletExtraArgs;
+
+    /**
+     * @return Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+     * 
+     * Note that this field conflicts with `launchTemplate`.
+     * 
+     */
+    public Optional<String> kubeletExtraArgs() {
+        return Optional.ofNullable(this.kubeletExtraArgs);
+    }
+
+    /**
      * Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
      * 
      */
@@ -150,12 +188,16 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     /**
      * Launch Template settings.
      * 
+     * Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
+     * 
      */
     @Import(name="launchTemplate")
     private @Nullable Output<NodeGroupLaunchTemplateArgs> launchTemplate;
 
     /**
      * @return Launch Template settings.
+     * 
+     * Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
      * 
      */
     public Optional<Output<NodeGroupLaunchTemplateArgs>> launchTemplate() {
@@ -355,12 +397,14 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
 
     private ManagedNodeGroupArgs(ManagedNodeGroupArgs $) {
         this.amiType = $.amiType;
+        this.bootstrapExtraArgs = $.bootstrapExtraArgs;
         this.capacityType = $.capacityType;
         this.cluster = $.cluster;
         this.clusterName = $.clusterName;
         this.diskSize = $.diskSize;
         this.forceUpdateVersion = $.forceUpdateVersion;
         this.instanceTypes = $.instanceTypes;
+        this.kubeletExtraArgs = $.kubeletExtraArgs;
         this.labels = $.labels;
         this.launchTemplate = $.launchTemplate;
         this.nodeGroupName = $.nodeGroupName;
@@ -413,6 +457,19 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
          */
         public Builder amiType(String amiType) {
             return amiType(Output.of(amiType));
+        }
+
+        /**
+         * @param bootstrapExtraArgs Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+         * 
+         * Note that this field conflicts with `launchTemplate`.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder bootstrapExtraArgs(@Nullable String bootstrapExtraArgs) {
+            $.bootstrapExtraArgs = bootstrapExtraArgs;
+            return this;
         }
 
         /**
@@ -572,6 +629,19 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
         }
 
         /**
+         * @param kubeletExtraArgs Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, &#39;--port=10251 --address=0.0.0.0&#39;. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+         * 
+         * Note that this field conflicts with `launchTemplate`.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeletExtraArgs(@Nullable String kubeletExtraArgs) {
+            $.kubeletExtraArgs = kubeletExtraArgs;
+            return this;
+        }
+
+        /**
          * @param labels Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
          * 
          * @return builder
@@ -595,6 +665,8 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
         /**
          * @param launchTemplate Launch Template settings.
          * 
+         * Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
+         * 
          * @return builder
          * 
          */
@@ -605,6 +677,8 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
 
         /**
          * @param launchTemplate Launch Template settings.
+         * 
+         * Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
          * 
          * @return builder
          * 

--- a/sdk/python/pulumi_eks/managed_node_group.py
+++ b/sdk/python/pulumi_eks/managed_node_group.py
@@ -53,8 +53,7 @@ class ManagedNodeGroupArgs:
         :param pulumi.Input[int] disk_size: Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[bool] force_update_version: Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] instance_types: Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
-        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-               
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
                Note that this field conflicts with `launchTemplate`.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input['pulumi_aws.eks.NodeGroupLaunchTemplateArgs'] launch_template: Launch Template settings.
@@ -233,8 +232,7 @@ class ManagedNodeGroupArgs:
     @pulumi.getter(name="kubeletExtraArgs")
     def kubelet_extra_args(self) -> Optional[str]:
         """
-        Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-
+        Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
         Note that this field conflicts with `launchTemplate`.
         """
         return pulumi.get(self, "kubelet_extra_args")
@@ -461,8 +459,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
         :param pulumi.Input[int] disk_size: Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[bool] force_update_version: Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] instance_types: Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
-        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
-               
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. To escape characters in the extra argsvalue, wrap the value in quotes. For example, `kubeletExtraArgs = '--allowed-unsafe-sysctls "net.core.somaxconn"'`.
                Note that this field conflicts with `launchTemplate`.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupLaunchTemplateArgs']] launch_template: Launch Template settings.

--- a/sdk/python/pulumi_eks/managed_node_group.py
+++ b/sdk/python/pulumi_eks/managed_node_group.py
@@ -21,11 +21,13 @@ class ManagedNodeGroupArgs:
     def __init__(__self__, *,
                  cluster: pulumi.Input[Union['Cluster', 'CoreDataArgs']],
                  ami_type: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  capacity_type: Optional[pulumi.Input[str]] = None,
                  cluster_name: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[int]] = None,
                  force_update_version: Optional[pulumi.Input[bool]] = None,
                  instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  launch_template: Optional[pulumi.Input['pulumi_aws.eks.NodeGroupLaunchTemplateArgs']] = None,
                  node_group_name: Optional[pulumi.Input[str]] = None,
@@ -43,13 +45,21 @@ class ManagedNodeGroupArgs:
         The set of arguments for constructing a ManagedNodeGroup resource.
         :param pulumi.Input[Union['Cluster', 'CoreDataArgs']] cluster: The target EKS cluster.
         :param pulumi.Input[str] ami_type: Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. See the AWS documentation (https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) for valid AMI Types. This provider will only perform drift detection if a configuration value is provided.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+               
+               Note that this field conflicts with `launchTemplate`.
         :param pulumi.Input[str] capacity_type: Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[str] cluster_name: Name of the EKS Cluster.
         :param pulumi.Input[int] disk_size: Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[bool] force_update_version: Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] instance_types: Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+               
+               Note that this field conflicts with `launchTemplate`.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input['pulumi_aws.eks.NodeGroupLaunchTemplateArgs'] launch_template: Launch Template settings.
+               
+               Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
         :param pulumi.Input[str] node_group_name: Name of the EKS Node Group. If omitted, this provider will assign a random, unique name. Conflicts with `nodeGroupNamePrefix`.
         :param pulumi.Input[str] node_group_name_prefix: Creates a unique name beginning with the specified prefix. Conflicts with `nodeGroupName`.
         :param pulumi.Input['pulumi_aws.iam.Role'] node_role: The IAM Role that provides permissions for the EKS Node Group.
@@ -80,6 +90,8 @@ class ManagedNodeGroupArgs:
         pulumi.set(__self__, "cluster", cluster)
         if ami_type is not None:
             pulumi.set(__self__, "ami_type", ami_type)
+        if bootstrap_extra_args is not None:
+            pulumi.set(__self__, "bootstrap_extra_args", bootstrap_extra_args)
         if capacity_type is not None:
             pulumi.set(__self__, "capacity_type", capacity_type)
         if cluster_name is not None:
@@ -90,6 +102,8 @@ class ManagedNodeGroupArgs:
             pulumi.set(__self__, "force_update_version", force_update_version)
         if instance_types is not None:
             pulumi.set(__self__, "instance_types", instance_types)
+        if kubelet_extra_args is not None:
+            pulumi.set(__self__, "kubelet_extra_args", kubelet_extra_args)
         if labels is not None:
             pulumi.set(__self__, "labels", labels)
         if launch_template is not None:
@@ -140,6 +154,20 @@ class ManagedNodeGroupArgs:
     @ami_type.setter
     def ami_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "ami_type", value)
+
+    @property
+    @pulumi.getter(name="bootstrapExtraArgs")
+    def bootstrap_extra_args(self) -> Optional[str]:
+        """
+        Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+
+        Note that this field conflicts with `launchTemplate`.
+        """
+        return pulumi.get(self, "bootstrap_extra_args")
+
+    @bootstrap_extra_args.setter
+    def bootstrap_extra_args(self, value: Optional[str]):
+        pulumi.set(self, "bootstrap_extra_args", value)
 
     @property
     @pulumi.getter(name="capacityType")
@@ -202,6 +230,20 @@ class ManagedNodeGroupArgs:
         pulumi.set(self, "instance_types", value)
 
     @property
+    @pulumi.getter(name="kubeletExtraArgs")
+    def kubelet_extra_args(self) -> Optional[str]:
+        """
+        Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+
+        Note that this field conflicts with `launchTemplate`.
+        """
+        return pulumi.get(self, "kubelet_extra_args")
+
+    @kubelet_extra_args.setter
+    def kubelet_extra_args(self, value: Optional[str]):
+        pulumi.set(self, "kubelet_extra_args", value)
+
+    @property
     @pulumi.getter
     def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
@@ -218,6 +260,8 @@ class ManagedNodeGroupArgs:
     def launch_template(self) -> Optional[pulumi.Input['pulumi_aws.eks.NodeGroupLaunchTemplateArgs']]:
         """
         Launch Template settings.
+
+        Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
         """
         return pulumi.get(self, "launch_template")
 
@@ -377,12 +421,14 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  capacity_type: Optional[pulumi.Input[str]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
                  cluster_name: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[int]] = None,
                  force_update_version: Optional[pulumi.Input[bool]] = None,
                  instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  launch_template: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupLaunchTemplateArgs']]] = None,
                  node_group_name: Optional[pulumi.Input[str]] = None,
@@ -406,14 +452,22 @@ class ManagedNodeGroup(pulumi.ComponentResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] ami_type: Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. See the AWS documentation (https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) for valid AMI Types. This provider will only perform drift detection if a configuration value is provided.
+        :param str bootstrap_extra_args: Additional args to pass directly to `/etc/eks/bootstrap.sh`. For details on available options, see: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh. Note that the `--apiserver-endpoint`, `--b64-cluster-ca` and `--kubelet-extra-args` flags are included automatically based on other configuration parameters.
+               
+               Note that this field conflicts with `launchTemplate`.
         :param pulumi.Input[str] capacity_type: Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
         :param pulumi.Input[str] cluster_name: Name of the EKS Cluster.
         :param pulumi.Input[int] disk_size: Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[bool] force_update_version: Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] instance_types: Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. This provider will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
+        :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
+               
+               Note that this field conflicts with `launchTemplate`.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] labels: Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
         :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupLaunchTemplateArgs']] launch_template: Launch Template settings.
+               
+               Note: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`.
         :param pulumi.Input[str] node_group_name: Name of the EKS Node Group. If omitted, this provider will assign a random, unique name. Conflicts with `nodeGroupNamePrefix`.
         :param pulumi.Input[str] node_group_name_prefix: Creates a unique name beginning with the specified prefix. Conflicts with `nodeGroupName`.
         :param pulumi.Input['pulumi_aws.iam.Role'] node_role: The IAM Role that provides permissions for the EKS Node Group.
@@ -469,12 +523,14 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  ami_type: Optional[pulumi.Input[str]] = None,
+                 bootstrap_extra_args: Optional[str] = None,
                  capacity_type: Optional[pulumi.Input[str]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
                  cluster_name: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[int]] = None,
                  force_update_version: Optional[pulumi.Input[bool]] = None,
                  instance_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 kubelet_extra_args: Optional[str] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  launch_template: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupLaunchTemplateArgs']]] = None,
                  node_group_name: Optional[pulumi.Input[str]] = None,
@@ -500,6 +556,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
             __props__ = ManagedNodeGroupArgs.__new__(ManagedNodeGroupArgs)
 
             __props__.__dict__["ami_type"] = ami_type
+            __props__.__dict__["bootstrap_extra_args"] = bootstrap_extra_args
             __props__.__dict__["capacity_type"] = capacity_type
             if cluster is None and not opts.urn:
                 raise TypeError("Missing required property 'cluster'")
@@ -508,6 +565,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
             __props__.__dict__["disk_size"] = disk_size
             __props__.__dict__["force_update_version"] = force_update_version
             __props__.__dict__["instance_types"] = instance_types
+            __props__.__dict__["kubelet_extra_args"] = kubelet_extra_args
             __props__.__dict__["labels"] = labels
             __props__.__dict__["launch_template"] = launch_template
             __props__.__dict__["node_group_name"] = node_group_name


### PR DESCRIPTION
### Proposed changes

This PR enables setting kubelet and bootstrap extra args by creating a custom launch template if the arguments are supplied. Existing ManagedNodeGroups will not have a diff since we only create and use a custom launch template if these options are used by the Pulumi program.

#### Tests:

- Updated existing NodeJS and Golang test cases to ensure MNGs can supply kubelet extra args and the launch template is used
- Manually tested and verified within the AWS console that the user data is set correctly when these options are supplied

### Related issues (optional)
Closes: #611