### PR TITLE
Guarantee JSON output of awscli to generate kubeconfig

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -203,7 +203,7 @@ export function generateKubeconfig(
     certData?: pulumi.Input<string>,
     opts?: KubeconfigOptions,
 ) {
-    let args = ["eks", "get-token", "--cluster-name", clusterName];
+    let args = ["eks", "get-token", "--cluster-name", clusterName, "--output", "json"];
     const env: ExecEnvVar[] = [
         {
             name: "KUBERNETES_EXEC_INFO",


### PR DESCRIPTION
### Proposed changes

Specify `--output json` args of the `aws` command in generated `kubeconfig` files.

The default output format of `aws` might be configured in `~/.aws/config` by the user. Hence, the output is not guaranteed to be in JSON format without the `--output` argument.