### PR TITLE
Add parameter for configuring monitoring options of NodeGroups

### DIFF
--- a/examples/cluster-go/step1/main.go
+++ b/examples/cluster-go/step1/main.go
@@ -36,9 +36,10 @@ func main() {
 		// https://github.com/pulumi/pulumi-eks/pull/813
 		cluster3, err := eks.NewCluster(ctx, "example-cluster-3", &eks.ClusterArgs{
 			NodeGroupOptions: &eks.ClusterNodeGroupOptionsArgs{
-				DesiredCapacity: pulumi.IntPtr(2),
-				MinSize:         pulumi.IntPtr(2),
-				MaxSize:         pulumi.IntPtr(2),
+				DesiredCapacity:          pulumi.IntPtr(2),
+				MinSize:                  pulumi.IntPtr(2),
+				MaxSize:                  pulumi.IntPtr(2),
+				EnableDetailedMonitoring: pulumi.Bool(false),
 			},
 		})
 		if err != nil {

--- a/examples/cluster-go/step2/main.go
+++ b/examples/cluster-go/step2/main.go
@@ -37,9 +37,10 @@ func main() {
 		// https://github.com/pulumi/pulumi-eks/pull/813
 		cluster3, err := eks.NewCluster(ctx, "example-cluster-3", &eks.ClusterArgs{
 			NodeGroupOptions: &eks.ClusterNodeGroupOptionsArgs{
-				DesiredCapacity: pulumi.IntPtr(2),
-				MinSize:         pulumi.IntPtr(2),
-				MaxSize:         pulumi.IntPtr(2),
+				DesiredCapacity:          pulumi.IntPtr(2),
+				MinSize:                  pulumi.IntPtr(2),
+				MaxSize:                  pulumi.IntPtr(2),
+				EnableDetailedMonitoring: pulumi.Bool(false),
 			},
 		})
 		if err != nil {

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -37,6 +37,7 @@ const cluster3 = new eks.Cluster(`${projectName}-3`, {
         minSize: 1,
         maxSize: 1,
         instanceType: "t3.small",
+        enableDetailedMonitoring: false,
     }
 })
 

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -275,7 +275,7 @@ export interface NodeGroupBaseOptions {
     /**
      * Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -271,6 +271,17 @@ export interface NodeGroupBaseOptions {
      * `autoScalingGroupTags` or `cloudFormationTags`, but not both.
      */
     cloudFormationTags?: InputTags;
+
+    /**
+     * Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+     */
+    enableDetailedMonitoring?: pulumi.Input<boolean>;
 }
 
 /**
@@ -795,6 +806,7 @@ ${customUserData}
                 deleteOnTermination: args.nodeRootVolumeDeleteOnTermination ?? true,
             },
             userData: args.nodeUserDataOverride || userdata,
+            enableMonitoring: args.enableDetailedMonitoring,
         },
         { parent, provider },
     );
@@ -1219,6 +1231,9 @@ ${customUserData}
             metadataOptions: args.metadataOptions,
             userData: userdata,
             tagSpecifications: args.launchTemplateTagSpecifications,
+            monitoring: {
+                enabled: args.enableDetailedMonitoring,
+            },
         },
         { parent, provider },
     );

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1645,7 +1645,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				Type:  "boolean",
 			},
 			Description: "Enables/disables detailed monitoring of the EC2 instances.\n\n" +
-				"With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\n" +
+				"With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.\n" +
 				"When enabled, you can also get aggregated data across groups of similar instances.\n\n" +
 				"Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\n" +
 				"For more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/.",

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1640,6 +1640,16 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not " +
 				"both.",
 		},
+		"enableDetailedMonitoring": {
+			TypeSpec: schema.TypeSpec{
+				Type:  "boolean",
+			},
+			Description: "Enables/disables detailed monitoring of the EC2 instances.\n\n" +
+				"With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\n" +
+				"When enabled, you can also get aggregated data across groups of similar instances.\n\n" +
+				"Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\n" +
+				"For more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/.",
+		},
 	}
 
 	if cluster {

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -84,6 +84,10 @@
                     "type": "integer",
                     "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
                 },
+                "enableDetailedMonitoring": {
+                    "type": "boolean",
+                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
+                },
                 "encryptRootBlockDevice": {
                     "type": "boolean",
                     "description": "Encrypt the root block device of the nodes in the node group."
@@ -1159,6 +1163,10 @@
                     "type": "integer",
                     "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
                 },
+                "enableDetailedMonitoring": {
+                    "type": "boolean",
+                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
+                },
                 "encryptRootBlockDevice": {
                     "type": "boolean",
                     "description": "Encrypt the root block device of the nodes in the node group."
@@ -1378,6 +1386,10 @@
                 "desiredCapacity": {
                     "type": "integer",
                     "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
+                },
+                "enableDetailedMonitoring": {
+                    "type": "boolean",
+                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
                 },
                 "encryptRootBlockDevice": {
                     "type": "boolean",

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -86,7 +86,7 @@
                 },
                 "enableDetailedMonitoring": {
                     "type": "boolean",
-                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
+                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
                 },
                 "encryptRootBlockDevice": {
                     "type": "boolean",
@@ -1165,7 +1165,7 @@
                 },
                 "enableDetailedMonitoring": {
                     "type": "boolean",
-                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
+                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
                 },
                 "encryptRootBlockDevice": {
                     "type": "boolean",
@@ -1389,7 +1389,7 @@
                 },
                 "enableDetailedMonitoring": {
                     "type": "boolean",
-                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
+                    "description": "Enables/disables detailed monitoring of the EC2 instances.\n\nWith detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.\nWhen enabled, you can also get aggregated data across groups of similar instances.\n\nNote: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.\nFor more information, see \"Paid tier\" and \"Example 1 - EC2 Detailed Monitoring\" here https://aws.amazon.com/cloudwatch/pricing/."
                 },
                 "encryptRootBlockDevice": {
                     "type": "boolean",

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -87,6 +87,18 @@ namespace Pulumi.Eks.Inputs
         public Input<int>? DesiredCapacity { get; set; }
 
         /// <summary>
+        /// Enables/disables detailed monitoring of the EC2 instances.
+        /// 
+        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// When enabled, you can also get aggregated data across groups of similar instances.
+        /// 
+        /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        /// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        /// </summary>
+        [Input("enableDetailedMonitoring")]
+        public Input<bool>? EnableDetailedMonitoring { get; set; }
+
+        /// <summary>
         /// Encrypt the root block device of the nodes in the node group.
         /// </summary>
         [Input("encryptRootBlockDevice")]

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -89,7 +89,7 @@ namespace Pulumi.Eks.Inputs
         /// <summary>
         /// Enables/disables detailed monitoring of the EC2 instances.
         /// 
-        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         /// When enabled, you can also get aggregated data across groups of similar instances.
         /// 
         /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -147,7 +147,7 @@ namespace Pulumi.Eks
         /// <summary>
         /// Enables/disables detailed monitoring of the EC2 instances.
         /// 
-        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         /// When enabled, you can also get aggregated data across groups of similar instances.
         /// 
         /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -145,6 +145,18 @@ namespace Pulumi.Eks
         public Input<int>? DesiredCapacity { get; set; }
 
         /// <summary>
+        /// Enables/disables detailed monitoring of the EC2 instances.
+        /// 
+        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// When enabled, you can also get aggregated data across groups of similar instances.
+        /// 
+        /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        /// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        /// </summary>
+        [Input("enableDetailedMonitoring")]
+        public Input<bool>? EnableDetailedMonitoring { get; set; }
+
+        /// <summary>
         /// Encrypt the root block device of the nodes in the node group.
         /// </summary>
         [Input("encryptRootBlockDevice")]

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -139,6 +139,18 @@ namespace Pulumi.Eks
         public Input<int>? DesiredCapacity { get; set; }
 
         /// <summary>
+        /// Enables/disables detailed monitoring of the EC2 instances.
+        /// 
+        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// When enabled, you can also get aggregated data across groups of similar instances.
+        /// 
+        /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        /// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        /// </summary>
+        [Input("enableDetailedMonitoring")]
+        public Input<bool>? EnableDetailedMonitoring { get; set; }
+
+        /// <summary>
         /// Encrypt the root block device of the nodes in the node group.
         /// </summary>
         [Input("encryptRootBlockDevice")]

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -141,7 +141,7 @@ namespace Pulumi.Eks
         /// <summary>
         /// Enables/disables detailed monitoring of the EC2 instances.
         /// 
-        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         /// When enabled, you can also get aggregated data across groups of similar instances.
         /// 
         /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -64,7 +64,7 @@ namespace Pulumi.Eks.Outputs
         /// <summary>
         /// Enables/disables detailed monitoring of the EC2 instances.
         /// 
-        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         /// When enabled, you can also get aggregated data across groups of similar instances.
         /// 
         /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -62,6 +62,16 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly int? DesiredCapacity;
         /// <summary>
+        /// Enables/disables detailed monitoring of the EC2 instances.
+        /// 
+        /// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        /// When enabled, you can also get aggregated data across groups of similar instances.
+        /// 
+        /// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        /// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        /// </summary>
+        public readonly bool? EnableDetailedMonitoring;
+        /// <summary>
         /// Encrypt the root block device of the nodes in the node group.
         /// </summary>
         public readonly bool? EncryptRootBlockDevice;
@@ -181,6 +191,8 @@ namespace Pulumi.Eks.Outputs
 
             int? desiredCapacity,
 
+            bool? enableDetailedMonitoring,
+
             bool? encryptRootBlockDevice,
 
             ImmutableArray<Pulumi.Aws.Ec2.SecurityGroup> extraNodeSecurityGroups,
@@ -228,6 +240,7 @@ namespace Pulumi.Eks.Outputs
             CloudFormationTags = cloudFormationTags;
             ClusterIngressRule = clusterIngressRule;
             DesiredCapacity = desiredCapacity;
+            EnableDetailedMonitoring = enableDetailedMonitoring;
             EncryptRootBlockDevice = encryptRootBlockDevice;
             ExtraNodeSecurityGroups = extraNodeSecurityGroups;
             Gpu = gpu;

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -84,7 +84,7 @@ type nodeGroupArgs struct {
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
 	//
-	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 	// When enabled, you can also get aggregated data across groups of similar instances.
 	//
 	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -192,7 +192,7 @@ type NodeGroupArgs struct {
 	DesiredCapacity pulumi.IntPtrInput
 	// Enables/disables detailed monitoring of the EC2 instances.
 	//
-	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 	// When enabled, you can also get aggregated data across groups of similar instances.
 	//
 	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -82,6 +82,14 @@ type nodeGroupArgs struct {
 	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
+	// Enables/disables detailed monitoring of the EC2 instances.
+	//
+	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// When enabled, you can also get aggregated data across groups of similar instances.
+	//
+	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+	// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+	EnableDetailedMonitoring *bool `pulumi:"enableDetailedMonitoring"`
 	// Encrypt the root block device of the nodes in the node group.
 	EncryptRootBlockDevice *bool `pulumi:"encryptRootBlockDevice"`
 	// Extra security groups to attach on all nodes in this worker node group.
@@ -182,6 +190,14 @@ type NodeGroupArgs struct {
 	ClusterIngressRule ec2.SecurityGroupRuleInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
+	// Enables/disables detailed monitoring of the EC2 instances.
+	//
+	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// When enabled, you can also get aggregated data across groups of similar instances.
+	//
+	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+	// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+	EnableDetailedMonitoring pulumi.BoolPtrInput
 	// Encrypt the root block device of the nodes in the node group.
 	EncryptRootBlockDevice pulumi.BoolPtrInput
 	// Extra security groups to attach on all nodes in this worker node group.

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -82,7 +82,7 @@ type nodeGroupV2Args struct {
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
 	//
-	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 	// When enabled, you can also get aggregated data across groups of similar instances.
 	//
 	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -194,7 +194,7 @@ type NodeGroupV2Args struct {
 	DesiredCapacity pulumi.IntPtrInput
 	// Enables/disables detailed monitoring of the EC2 instances.
 	//
-	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 	// When enabled, you can also get aggregated data across groups of similar instances.
 	//
 	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -80,6 +80,14 @@ type nodeGroupV2Args struct {
 	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
+	// Enables/disables detailed monitoring of the EC2 instances.
+	//
+	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// When enabled, you can also get aggregated data across groups of similar instances.
+	//
+	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+	// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+	EnableDetailedMonitoring *bool `pulumi:"enableDetailedMonitoring"`
 	// Encrypt the root block device of the nodes in the node group.
 	EncryptRootBlockDevice *bool `pulumi:"encryptRootBlockDevice"`
 	// Extra security groups to attach on all nodes in this worker node group.
@@ -184,6 +192,14 @@ type NodeGroupV2Args struct {
 	ClusterIngressRule ec2.SecurityGroupRuleInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
+	// Enables/disables detailed monitoring of the EC2 instances.
+	//
+	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// When enabled, you can also get aggregated data across groups of similar instances.
+	//
+	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+	// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+	EnableDetailedMonitoring pulumi.BoolPtrInput
 	// Encrypt the root block device of the nodes in the node group.
 	EncryptRootBlockDevice pulumi.BoolPtrInput
 	// Extra security groups to attach on all nodes in this worker node group.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -55,6 +55,14 @@ type ClusterNodeGroupOptions struct {
 	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
+	// Enables/disables detailed monitoring of the EC2 instances.
+	//
+	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// When enabled, you can also get aggregated data across groups of similar instances.
+	//
+	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+	// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+	EnableDetailedMonitoring *bool `pulumi:"enableDetailedMonitoring"`
 	// Encrypt the root block device of the nodes in the node group.
 	EncryptRootBlockDevice *bool `pulumi:"encryptRootBlockDevice"`
 	// Extra security groups to attach on all nodes in this worker node group.
@@ -164,6 +172,14 @@ type ClusterNodeGroupOptionsArgs struct {
 	ClusterIngressRule ec2.SecurityGroupRuleInput `pulumi:"clusterIngressRule"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput `pulumi:"desiredCapacity"`
+	// Enables/disables detailed monitoring of the EC2 instances.
+	//
+	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// When enabled, you can also get aggregated data across groups of similar instances.
+	//
+	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+	// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+	EnableDetailedMonitoring pulumi.BoolPtrInput `pulumi:"enableDetailedMonitoring"`
 	// Encrypt the root block device of the nodes in the node group.
 	EncryptRootBlockDevice pulumi.BoolPtrInput `pulumi:"encryptRootBlockDevice"`
 	// Extra security groups to attach on all nodes in this worker node group.
@@ -357,6 +373,17 @@ func (o ClusterNodeGroupOptionsOutput) ClusterIngressRule() ec2.SecurityGroupRul
 // The number of worker nodes that should be running in the cluster. Defaults to 2.
 func (o ClusterNodeGroupOptionsOutput) DesiredCapacity() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.DesiredCapacity }).(pulumi.IntPtrOutput)
+}
+
+// Enables/disables detailed monitoring of the EC2 instances.
+//
+// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+// When enabled, you can also get aggregated data across groups of similar instances.
+//
+// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+func (o ClusterNodeGroupOptionsOutput) EnableDetailedMonitoring() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *bool { return v.EnableDetailedMonitoring }).(pulumi.BoolPtrOutput)
 }
 
 // Encrypt the root block device of the nodes in the node group.
@@ -591,6 +618,22 @@ func (o ClusterNodeGroupOptionsPtrOutput) DesiredCapacity() pulumi.IntPtrOutput 
 		}
 		return v.DesiredCapacity
 	}).(pulumi.IntPtrOutput)
+}
+
+// Enables/disables detailed monitoring of the EC2 instances.
+//
+// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+// When enabled, you can also get aggregated data across groups of similar instances.
+//
+// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+// For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+func (o ClusterNodeGroupOptionsPtrOutput) EnableDetailedMonitoring() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.EnableDetailedMonitoring
+	}).(pulumi.BoolPtrOutput)
 }
 
 // Encrypt the root block device of the nodes in the node group.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -57,7 +57,7 @@ type ClusterNodeGroupOptions struct {
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
 	//
-	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 	// When enabled, you can also get aggregated data across groups of similar instances.
 	//
 	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -174,7 +174,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	DesiredCapacity pulumi.IntPtrInput `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
 	//
-	// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+	// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 	// When enabled, you can also get aggregated data across groups of similar instances.
 	//
 	// Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -377,7 +377,7 @@ func (o ClusterNodeGroupOptionsOutput) DesiredCapacity() pulumi.IntPtrOutput {
 
 // Enables/disables detailed monitoring of the EC2 instances.
 //
-// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 // When enabled, you can also get aggregated data across groups of similar instances.
 //
 // Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -622,7 +622,7 @@ func (o ClusterNodeGroupOptionsPtrOutput) DesiredCapacity() pulumi.IntPtrOutput 
 
 // Enables/disables detailed monitoring of the EC2 instances.
 //
-// With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+// With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
 // When enabled, you can also get aggregated data across groups of similar instances.
 //
 // Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -181,6 +181,33 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    @Import(name="enableDetailedMonitoring")
+    private @Nullable Output<Boolean> enableDetailedMonitoring;
+
+    /**
+     * @return Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    public Optional<Output<Boolean>> enableDetailedMonitoring() {
+        return Optional.ofNullable(this.enableDetailedMonitoring);
+    }
+
+    /**
      * Encrypt the root block device of the nodes in the node group.
      * 
      */
@@ -537,6 +564,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         this.cluster = $.cluster;
         this.clusterIngressRule = $.clusterIngressRule;
         this.desiredCapacity = $.desiredCapacity;
+        this.enableDetailedMonitoring = $.enableDetailedMonitoring;
         this.encryptRootBlockDevice = $.encryptRootBlockDevice;
         this.extraNodeSecurityGroups = $.extraNodeSecurityGroups;
         this.gpu = $.gpu;
@@ -787,6 +815,39 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder desiredCapacity(Integer desiredCapacity) {
             return desiredCapacity(Output.of(desiredCapacity));
+        }
+
+        /**
+         * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
+         * 
+         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * When enabled, you can also get aggregated data across groups of similar instances.
+         * 
+         * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+         * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableDetailedMonitoring(@Nullable Output<Boolean> enableDetailedMonitoring) {
+            $.enableDetailedMonitoring = enableDetailedMonitoring;
+            return this;
+        }
+
+        /**
+         * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
+         * 
+         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * When enabled, you can also get aggregated data across groups of similar instances.
+         * 
+         * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+         * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableDetailedMonitoring(Boolean enableDetailedMonitoring) {
+            return enableDetailedMonitoring(Output.of(enableDetailedMonitoring));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -183,7 +183,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -196,7 +196,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * @return Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -820,7 +820,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         /**
          * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
          * 
-         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
          * When enabled, you can also get aggregated data across groups of similar instances.
          * 
          * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -837,7 +837,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         /**
          * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
          * 
-         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
          * When enabled, you can also get aggregated data across groups of similar instances.
          * 
          * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -184,7 +184,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     /**
      * Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -197,7 +197,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     /**
      * @return Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -853,7 +853,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         /**
          * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
          * 
-         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
          * When enabled, you can also get aggregated data across groups of similar instances.
          * 
          * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -870,7 +870,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         /**
          * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
          * 
-         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
          * When enabled, you can also get aggregated data across groups of similar instances.
          * 
          * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -182,6 +182,33 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    @Import(name="enableDetailedMonitoring")
+    private @Nullable Output<Boolean> enableDetailedMonitoring;
+
+    /**
+     * @return Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    public Optional<Output<Boolean>> enableDetailedMonitoring() {
+        return Optional.ofNullable(this.enableDetailedMonitoring);
+    }
+
+    /**
      * Encrypt the root block device of the nodes in the node group.
      * 
      */
@@ -568,6 +595,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         this.cluster = $.cluster;
         this.clusterIngressRule = $.clusterIngressRule;
         this.desiredCapacity = $.desiredCapacity;
+        this.enableDetailedMonitoring = $.enableDetailedMonitoring;
         this.encryptRootBlockDevice = $.encryptRootBlockDevice;
         this.extraNodeSecurityGroups = $.extraNodeSecurityGroups;
         this.gpu = $.gpu;
@@ -820,6 +848,39 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          */
         public Builder desiredCapacity(Integer desiredCapacity) {
             return desiredCapacity(Output.of(desiredCapacity));
+        }
+
+        /**
+         * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
+         * 
+         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * When enabled, you can also get aggregated data across groups of similar instances.
+         * 
+         * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+         * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableDetailedMonitoring(@Nullable Output<Boolean> enableDetailedMonitoring) {
+            $.enableDetailedMonitoring = enableDetailedMonitoring;
+            return this;
+        }
+
+        /**
+         * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
+         * 
+         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * When enabled, you can also get aggregated data across groups of similar instances.
+         * 
+         * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+         * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableDetailedMonitoring(Boolean enableDetailedMonitoring) {
+            return enableDetailedMonitoring(Output.of(enableDetailedMonitoring));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -167,6 +167,33 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
+     * Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    @Import(name="enableDetailedMonitoring")
+    private @Nullable Output<Boolean> enableDetailedMonitoring;
+
+    /**
+     * @return Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    public Optional<Output<Boolean>> enableDetailedMonitoring() {
+        return Optional.ofNullable(this.enableDetailedMonitoring);
+    }
+
+    /**
      * Encrypt the root block device of the nodes in the node group.
      * 
      */
@@ -522,6 +549,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         this.cloudFormationTags = $.cloudFormationTags;
         this.clusterIngressRule = $.clusterIngressRule;
         this.desiredCapacity = $.desiredCapacity;
+        this.enableDetailedMonitoring = $.enableDetailedMonitoring;
         this.encryptRootBlockDevice = $.encryptRootBlockDevice;
         this.extraNodeSecurityGroups = $.extraNodeSecurityGroups;
         this.gpu = $.gpu;
@@ -731,6 +759,39 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          */
         public Builder desiredCapacity(Integer desiredCapacity) {
             return desiredCapacity(Output.of(desiredCapacity));
+        }
+
+        /**
+         * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
+         * 
+         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * When enabled, you can also get aggregated data across groups of similar instances.
+         * 
+         * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+         * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableDetailedMonitoring(@Nullable Output<Boolean> enableDetailedMonitoring) {
+            $.enableDetailedMonitoring = enableDetailedMonitoring;
+            return this;
+        }
+
+        /**
+         * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
+         * 
+         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * When enabled, you can also get aggregated data across groups of similar instances.
+         * 
+         * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+         * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableDetailedMonitoring(Boolean enableDetailedMonitoring) {
+            return enableDetailedMonitoring(Output.of(enableDetailedMonitoring));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -169,7 +169,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     /**
      * Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -182,7 +182,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     /**
      * @return Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -764,7 +764,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         /**
          * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
          * 
-         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
          * When enabled, you can also get aggregated data across groups of similar instances.
          * 
          * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -781,7 +781,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         /**
          * @param enableDetailedMonitoring Enables/disables detailed monitoring of the EC2 instances.
          * 
-         * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+         * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
          * When enabled, you can also get aggregated data across groups of similar instances.
          * 
          * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -72,6 +72,17 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable Integer desiredCapacity;
     /**
+     * @return Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    private @Nullable Boolean enableDetailedMonitoring;
+    /**
      * @return Encrypt the root block device of the nodes in the node group.
      * 
      */
@@ -263,6 +274,19 @@ public final class ClusterNodeGroupOptions {
         return Optional.ofNullable(this.desiredCapacity);
     }
     /**
+     * @return Enables/disables detailed monitoring of the EC2 instances.
+     * 
+     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * When enabled, you can also get aggregated data across groups of similar instances.
+     * 
+     * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+     * For more information, see &#34;Paid tier&#34; and &#34;Example 1 - EC2 Detailed Monitoring&#34; here https://aws.amazon.com/cloudwatch/pricing/.
+     * 
+     */
+    public Optional<Boolean> enableDetailedMonitoring() {
+        return Optional.ofNullable(this.enableDetailedMonitoring);
+    }
+    /**
      * @return Encrypt the root block device of the nodes in the node group.
      * 
      */
@@ -442,6 +466,7 @@ public final class ClusterNodeGroupOptions {
         private @Nullable Map<String,String> cloudFormationTags;
         private @Nullable SecurityGroupRule clusterIngressRule;
         private @Nullable Integer desiredCapacity;
+        private @Nullable Boolean enableDetailedMonitoring;
         private @Nullable Boolean encryptRootBlockDevice;
         private @Nullable List<SecurityGroup> extraNodeSecurityGroups;
         private @Nullable Boolean gpu;
@@ -472,6 +497,7 @@ public final class ClusterNodeGroupOptions {
     	      this.cloudFormationTags = defaults.cloudFormationTags;
     	      this.clusterIngressRule = defaults.clusterIngressRule;
     	      this.desiredCapacity = defaults.desiredCapacity;
+    	      this.enableDetailedMonitoring = defaults.enableDetailedMonitoring;
     	      this.encryptRootBlockDevice = defaults.encryptRootBlockDevice;
     	      this.extraNodeSecurityGroups = defaults.extraNodeSecurityGroups;
     	      this.gpu = defaults.gpu;
@@ -527,6 +553,11 @@ public final class ClusterNodeGroupOptions {
         @CustomType.Setter
         public Builder desiredCapacity(@Nullable Integer desiredCapacity) {
             this.desiredCapacity = desiredCapacity;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder enableDetailedMonitoring(@Nullable Boolean enableDetailedMonitoring) {
+            this.enableDetailedMonitoring = enableDetailedMonitoring;
             return this;
         }
         @CustomType.Setter
@@ -644,6 +675,7 @@ public final class ClusterNodeGroupOptions {
             _resultValue.cloudFormationTags = cloudFormationTags;
             _resultValue.clusterIngressRule = clusterIngressRule;
             _resultValue.desiredCapacity = desiredCapacity;
+            _resultValue.enableDetailedMonitoring = enableDetailedMonitoring;
             _resultValue.encryptRootBlockDevice = encryptRootBlockDevice;
             _resultValue.extraNodeSecurityGroups = extraNodeSecurityGroups;
             _resultValue.gpu = gpu;

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -74,7 +74,7 @@ public final class ClusterNodeGroupOptions {
     /**
      * @return Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -276,7 +276,7 @@ public final class ClusterNodeGroupOptions {
     /**
      * @return Enables/disables detailed monitoring of the EC2 instances.
      * 
-     * With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+     * With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
      * When enabled, you can also get aggregated data across groups of similar instances.
      * 
      * Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -84,7 +84,7 @@ class ClusterNodeGroupOptionsArgs:
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
-               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
                When enabled, you can also get aggregated data across groups of similar instances.
                
                Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -297,7 +297,7 @@ class ClusterNodeGroupOptionsArgs:
         """
         Enables/disables detailed monitoring of the EC2 instances.
 
-        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         When enabled, you can also get aggregated data across groups of similar instances.
 
         Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -35,6 +35,7 @@ class ClusterNodeGroupOptionsArgs:
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -81,6 +82,13 @@ class ClusterNodeGroupOptionsArgs:
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
+               
+               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               When enabled, you can also get aggregated data across groups of similar instances.
+               
+               Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+               For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
@@ -139,6 +147,8 @@ class ClusterNodeGroupOptionsArgs:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
+        if enable_detailed_monitoring is not None:
+            pulumi.set(__self__, "enable_detailed_monitoring", enable_detailed_monitoring)
         if encrypt_root_block_device is not None:
             pulumi.set(__self__, "encrypt_root_block_device", encrypt_root_block_device)
         if extra_node_security_groups is not None:
@@ -280,6 +290,24 @@ class ClusterNodeGroupOptionsArgs:
     @desired_capacity.setter
     def desired_capacity(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "desired_capacity", value)
+
+    @property
+    @pulumi.getter(name="enableDetailedMonitoring")
+    def enable_detailed_monitoring(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables/disables detailed monitoring of the EC2 instances.
+
+        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        When enabled, you can also get aggregated data across groups of similar instances.
+
+        Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        """
+        return pulumi.get(self, "enable_detailed_monitoring")
+
+    @enable_detailed_monitoring.setter
+    def enable_detailed_monitoring(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_detailed_monitoring", value)
 
     @property
     @pulumi.getter(name="encryptRootBlockDevice")

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -77,7 +77,7 @@ class NodeGroupArgs:
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
-               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
                When enabled, you can also get aggregated data across groups of similar instances.
                
                Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -303,7 +303,7 @@ class NodeGroupArgs:
         """
         Enables/disables detailed monitoring of the EC2 instances.
 
-        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         When enabled, you can also get aggregated data across groups of similar instances.
 
         Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -646,7 +646,7 @@ class NodeGroup(pulumi.ComponentResource):
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
-               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
                When enabled, you can also get aggregated data across groups of similar instances.
                
                Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -27,6 +27,7 @@ class NodeGroupArgs:
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -74,6 +75,13 @@ class NodeGroupArgs:
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
+               
+               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               When enabled, you can also get aggregated data across groups of similar instances.
+               
+               Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+               For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
@@ -133,6 +141,8 @@ class NodeGroupArgs:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
+        if enable_detailed_monitoring is not None:
+            pulumi.set(__self__, "enable_detailed_monitoring", enable_detailed_monitoring)
         if encrypt_root_block_device is not None:
             pulumi.set(__self__, "encrypt_root_block_device", encrypt_root_block_device)
         if extra_node_security_groups is not None:
@@ -286,6 +296,24 @@ class NodeGroupArgs:
     @desired_capacity.setter
     def desired_capacity(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "desired_capacity", value)
+
+    @property
+    @pulumi.getter(name="enableDetailedMonitoring")
+    def enable_detailed_monitoring(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables/disables detailed monitoring of the EC2 instances.
+
+        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        When enabled, you can also get aggregated data across groups of similar instances.
+
+        Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        """
+        return pulumi.get(self, "enable_detailed_monitoring")
+
+    @enable_detailed_monitoring.setter
+    def enable_detailed_monitoring(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_detailed_monitoring", value)
 
     @property
     @pulumi.getter(name="encryptRootBlockDevice")
@@ -564,6 +592,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -615,6 +644,13 @@ class NodeGroup(pulumi.ComponentResource):
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
+               
+               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               When enabled, you can also get aggregated data across groups of similar instances.
+               
+               Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+               For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
@@ -691,6 +727,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -732,6 +769,7 @@ class NodeGroup(pulumi.ComponentResource):
             __props__.__dict__["cluster"] = cluster
             __props__.__dict__["cluster_ingress_rule"] = cluster_ingress_rule
             __props__.__dict__["desired_capacity"] = desired_capacity
+            __props__.__dict__["enable_detailed_monitoring"] = enable_detailed_monitoring
             __props__.__dict__["encrypt_root_block_device"] = encrypt_root_block_device
             __props__.__dict__["extra_node_security_groups"] = extra_node_security_groups
             __props__.__dict__["gpu"] = gpu

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -27,6 +27,7 @@ class NodeGroupV2Args:
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -76,6 +77,13 @@ class NodeGroupV2Args:
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
+               
+               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               When enabled, you can also get aggregated data across groups of similar instances.
+               
+               Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+               For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
@@ -137,6 +145,8 @@ class NodeGroupV2Args:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
+        if enable_detailed_monitoring is not None:
+            pulumi.set(__self__, "enable_detailed_monitoring", enable_detailed_monitoring)
         if encrypt_root_block_device is not None:
             pulumi.set(__self__, "encrypt_root_block_device", encrypt_root_block_device)
         if extra_node_security_groups is not None:
@@ -294,6 +304,24 @@ class NodeGroupV2Args:
     @desired_capacity.setter
     def desired_capacity(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "desired_capacity", value)
+
+    @property
+    @pulumi.getter(name="enableDetailedMonitoring")
+    def enable_detailed_monitoring(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enables/disables detailed monitoring of the EC2 instances.
+
+        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        When enabled, you can also get aggregated data across groups of similar instances.
+
+        Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        """
+        return pulumi.get(self, "enable_detailed_monitoring")
+
+    @enable_detailed_monitoring.setter
+    def enable_detailed_monitoring(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_detailed_monitoring", value)
 
     @property
     @pulumi.getter(name="encryptRootBlockDevice")
@@ -596,6 +624,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -649,6 +678,13 @@ class NodeGroupV2(pulumi.ComponentResource):
         :param pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]] cluster: The target EKS cluster.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
+               
+               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               When enabled, you can also get aggregated data across groups of similar instances.
+               
+               Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+               For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
         :param pulumi.Input[bool] encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
@@ -727,6 +763,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cluster: Optional[pulumi.Input[Union['Cluster', pulumi.InputType['CoreDataArgs']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
+                 enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
                  extra_node_security_groups: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -770,6 +807,7 @@ class NodeGroupV2(pulumi.ComponentResource):
             __props__.__dict__["cluster"] = cluster
             __props__.__dict__["cluster_ingress_rule"] = cluster_ingress_rule
             __props__.__dict__["desired_capacity"] = desired_capacity
+            __props__.__dict__["enable_detailed_monitoring"] = enable_detailed_monitoring
             __props__.__dict__["encrypt_root_block_device"] = encrypt_root_block_device
             __props__.__dict__["extra_node_security_groups"] = extra_node_security_groups
             __props__.__dict__["gpu"] = gpu

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -79,7 +79,7 @@ class NodeGroupV2Args:
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
-               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
                When enabled, you can also get aggregated data across groups of similar instances.
                
                Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -311,7 +311,7 @@ class NodeGroupV2Args:
         """
         Enables/disables detailed monitoring of the EC2 instances.
 
-        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         When enabled, you can also get aggregated data across groups of similar instances.
 
         Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -680,7 +680,7 @@ class NodeGroupV2(pulumi.ComponentResource):
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
-               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
                When enabled, you can also get aggregated data across groups of similar instances.
                
                Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -145,7 +145,7 @@ class ClusterNodeGroupOptions(dict):
         :param int desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param bool enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
-               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
                When enabled, you can also get aggregated data across groups of similar instances.
                
                Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
@@ -330,7 +330,7 @@ class ClusterNodeGroupOptions(dict):
         """
         Enables/disables detailed monitoring of the EC2 instances.
 
-        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        With detailed monitoring, all metrics, including status check metrics, are available in 1-minute intervals.
         When enabled, you can also get aggregated data across groups of similar instances.
 
         Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -42,6 +42,8 @@ class ClusterNodeGroupOptions(dict):
             suggest = "cluster_ingress_rule"
         elif key == "desiredCapacity":
             suggest = "desired_capacity"
+        elif key == "enableDetailedMonitoring":
+            suggest = "enable_detailed_monitoring"
         elif key == "encryptRootBlockDevice":
             suggest = "encrypt_root_block_device"
         elif key == "extraNodeSecurityGroups":
@@ -94,6 +96,7 @@ class ClusterNodeGroupOptions(dict):
                  cloud_formation_tags: Optional[Mapping[str, str]] = None,
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
                  desired_capacity: Optional[int] = None,
+                 enable_detailed_monitoring: Optional[bool] = None,
                  encrypt_root_block_device: Optional[bool] = None,
                  extra_node_security_groups: Optional[Sequence['pulumi_aws.ec2.SecurityGroup']] = None,
                  gpu: Optional[bool] = None,
@@ -140,6 +143,13 @@ class ClusterNodeGroupOptions(dict):
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
         :param int desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
+        :param bool enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
+               
+               With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+               When enabled, you can also get aggregated data across groups of similar instances.
+               
+               Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+               For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
         :param bool encrypt_root_block_device: Encrypt the root block device of the nodes in the node group.
         :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: Extra security groups to attach on all nodes in this worker node group.
                
@@ -198,6 +208,8 @@ class ClusterNodeGroupOptions(dict):
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
+        if enable_detailed_monitoring is not None:
+            pulumi.set(__self__, "enable_detailed_monitoring", enable_detailed_monitoring)
         if encrypt_root_block_device is not None:
             pulumi.set(__self__, "encrypt_root_block_device", encrypt_root_block_device)
         if extra_node_security_groups is not None:
@@ -311,6 +323,20 @@ class ClusterNodeGroupOptions(dict):
         The number of worker nodes that should be running in the cluster. Defaults to 2.
         """
         return pulumi.get(self, "desired_capacity")
+
+    @property
+    @pulumi.getter(name="enableDetailedMonitoring")
+    def enable_detailed_monitoring(self) -> Optional[bool]:
+        """
+        Enables/disables detailed monitoring of the EC2 instances.
+
+        With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods.
+        When enabled, you can also get aggregated data across groups of similar instances.
+
+        Note: You are charged per metric that is sent to CloudWatch. You are not charged for data storage.
+        For more information, see "Paid tier" and "Example 1 - EC2 Detailed Monitoring" here https://aws.amazon.com/cloudwatch/pricing/.
+        """
+        return pulumi.get(self, "enable_detailed_monitoring")
 
     @property
     @pulumi.getter(name="encryptRootBlockDevice")


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Expose parameter for configuring monitoring settings of NodeGroups.
With detailed monitoring all metrics, including status check metrics, are available in 1-minute periods. When enabled, you can also get aggregated data across groups of similar instances.

What's notable that this cannot be turned on for ManagedNodeGroups because AWS doesn't expose controls for the underlying ASG (https://github.com/aws/containers-roadmap/issues/762)

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #1032
