### PR TITLE
Update upgrade test snapshots to v2.5.1 of provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROJECT_NAME := Pulumi Amazon Web Services (AWS) EKS Components
 
 VERSION         := $(shell pulumictl get version)
 TESTPARALLELISM := 12
+UPGRADETESTPARALLELISM := 3
 
 PACK            := eks
 PROVIDER        := pulumi-resource-${PACK}
@@ -177,7 +178,7 @@ test_nodejs:: provider install_nodejs_sdk
 
 test_nodejs_upgrade:: PATH := $(WORKING_DIR)/bin:$(PATH)
 test_nodejs_upgrade:: provider install_nodejs_sdk
-	cd provider && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd provider && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel ${UPGRADETESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 test_python:: install_provider test_build
 	cd examples && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// The baseline version is the version of the provider that the upgrade tests will be run against.
-	baselineVersion = "2.3.0"
+	baselineVersion = "2.5.2"
 
 	// The path to the yarn.lock file that the EKS provider was built with.
 	yarnLockPath = "../nodejs/eks/yarn.lock"


### PR DESCRIPTION
This PR contains commits for 3 changes:

1. Updates the baseline version to v2.5.0
2. Updates the provider snapshots using the new baseline
3. Reduce parallelism in upgrade tests to 3 as a workaround for #1155

It is intended for this PR to be rebased and merged so that we can easily rollback any of these individual commits, if necessary.

Closes: #1145 