### PR TITLE
Set default test name to `TestExamplesUpgrades` for record snapshot action

### DIFF
--- a/.github/workflows/record.yml
+++ b/.github/workflows/record.yml
@@ -4,8 +4,9 @@ on:
     inputs:
       runTests:
         type: string
-        description: 'The tests in examples to record snapshots for, as a regex for `go test -run`'
+        description: 'The tests in examples to record snapshots for, as a regex for `go test -run`. Defaults to `TestExamplesUpgrades`'
         required: true
+        default: "TestExamplesUpgrades"
       targetBranch:
         type: string
         description: 'The branch to open the PR against'


### PR DESCRIPTION
This sets the default workflow dispatch action to run `TestExamplesUpgrades` so we don't need to manually specify it all the time.