### PR TITLE
fix: use mime-multipart for launch template

### DIFF
--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1770,12 +1770,18 @@ function createMNGCustomLaunchTemplate(
                 args.clusterName,
             ])
             .apply(([clusterName, clusterEndpoint, clusterCertAuthority, argsClusterName]) => {
-                return `#!/bin/bash
+                return `MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
 
-            /etc/eks/bootstrap.sh --apiserver-endpoint "${clusterEndpoint}" --b64-cluster-ca "${clusterCertAuthority}" "${
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+
+/etc/eks/bootstrap.sh --apiserver-endpoint "${clusterEndpoint}" --b64-cluster-ca "${clusterCertAuthority}" "${
                     argsClusterName || clusterName
                 }"${bootstrapExtraArgs}
-            `;
+--==MYBOUNDARY==--`;
             });
 
         // Encode the user data as base64.


### PR DESCRIPTION
### Proposed changes

Uses best practices from https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html to set the LaunchTemplate configuration. Tests were passing in CI, but failing in the upgrade snapshots workflow.

### Related issues (optional)

Fixes: #1162
