### PR TITLE
Handle arg inputs as potential Pulumi Outputs

### DIFF
--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -36,7 +36,7 @@ const cluster3 = new eks.Cluster(`${projectName}-3`, {
         desiredCapacity: 1,
         minSize: 1,
         maxSize: 1,
-        instanceType: "t3.small",
+        instanceType: pulumi.output(Promise.resolve("t3.small")),
         enableDetailedMonitoring: false,
     }
 })

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -757,33 +757,38 @@ ${customUserData}
 
     const numeric = new RegExp("^\\d+$");
 
-    if (args.nodeRootVolumeIops && args.nodeRootVolumeType !== "io1") {
-        throw new Error(
-            "Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).",
-        );
-    }
+    // We need to wrap the validation in a pulumi.all as MLCs could supply pulumi.Output<T> or T.
+    pulumi
+        .all([args.nodeRootVolumeIops, args.nodeRootVolumeType, args.nodeRootVolumeThroughput])
+        .apply(([nodeRootVolumeIops, nodeRootVolumeType, nodeRootVolumeThroughput]) => {
+            if (nodeRootVolumeIops && nodeRootVolumeType !== "io1") {
+                throw new Error(
+                    "Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).",
+                );
+            }
 
-    if (args.nodeRootVolumeType === "io1" && args.nodeRootVolumeIops) {
-        if (!numeric.test(args.nodeRootVolumeIops?.toString())) {
-            throw new Error(
-                "Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.",
-            );
-        }
-    }
+            if (nodeRootVolumeType === "io1" && nodeRootVolumeIops) {
+                if (!numeric.test(nodeRootVolumeIops?.toString())) {
+                    throw new Error(
+                        "Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.",
+                    );
+                }
+            }
 
-    if (args.nodeRootVolumeThroughput && args.nodeRootVolumeType !== "gp3") {
-        throw new Error(
-            "Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).",
-        );
-    }
+            if (nodeRootVolumeThroughput && nodeRootVolumeType !== "gp3") {
+                throw new Error(
+                    "Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).",
+                );
+            }
 
-    if (args.nodeRootVolumeType === "gp3" && args.nodeRootVolumeThroughput) {
-        if (!numeric.test(args.nodeRootVolumeThroughput?.toString())) {
-            throw new Error(
-                "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
-            );
-        }
-    }
+            if (nodeRootVolumeType === "gp3" && nodeRootVolumeThroughput) {
+                if (!numeric.test(nodeRootVolumeThroughput?.toString())) {
+                    throw new Error(
+                        "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
+                    );
+                }
+            }
+        });
 
     const nodeLaunchConfiguration = new aws.ec2.LaunchConfiguration(
         `${name}-nodeLaunchConfiguration`,
@@ -1146,33 +1151,38 @@ ${customUserData}
 
     const numeric = new RegExp("^\\d+$");
 
-    if (args.nodeRootVolumeIops && args.nodeRootVolumeType !== "io1") {
-        throw new Error(
-            "Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).",
-        );
-    }
+    // We need to wrap the validation in a pulumi.all as MLCs could supply pulumi.Output<T> or T.
+    pulumi
+        .all([args.nodeRootVolumeIops, args.nodeRootVolumeType, args.nodeRootVolumeThroughput])
+        .apply(([nodeRootVolumeIops, nodeRootVolumeType, nodeRootVolumeThroughput]) => {
+            if (nodeRootVolumeIops && nodeRootVolumeType !== "io1") {
+                throw new Error(
+                    "Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).",
+                );
+            }
 
-    if (args.nodeRootVolumeType === "io1" && args.nodeRootVolumeIops) {
-        if (!numeric.test(args.nodeRootVolumeIops?.toString())) {
-            throw new Error(
-                "Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.",
-            );
-        }
-    }
+            if (nodeRootVolumeType === "io1" && nodeRootVolumeIops) {
+                if (!numeric.test(nodeRootVolumeIops?.toString())) {
+                    throw new Error(
+                        "Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.",
+                    );
+                }
+            }
 
-    if (args.nodeRootVolumeThroughput && args.nodeRootVolumeType !== "gp3") {
-        throw new Error(
-            "Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).",
-        );
-    }
+            if (nodeRootVolumeThroughput && nodeRootVolumeType !== "gp3") {
+                throw new Error(
+                    "Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).",
+                );
+            }
 
-    if (args.nodeRootVolumeType === "gp3" && args.nodeRootVolumeThroughput) {
-        if (!numeric.test(args.nodeRootVolumeThroughput?.toString())) {
-            throw new Error(
-                "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
-            );
-        }
-    }
+            if (nodeRootVolumeType === "gp3" && nodeRootVolumeThroughput) {
+                if (!numeric.test(nodeRootVolumeThroughput?.toString())) {
+                    throw new Error(
+                        "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
+                    );
+                }
+            }
+        });
 
     const marketOptions = args.spotPrice
         ? {
@@ -1829,8 +1839,8 @@ function getRecommendedAMI(
     const instanceType = "instanceType" in args ? args.instanceType : undefined;
 
     const amiType = getAMIType(args.amiType, gpu, instanceType);
-    const amiID = k8sVersion.apply((v) => {
-        const parameterName = `/aws/service/eks/optimized-ami/${v}/${amiType}/recommended/image_id`;
+    const amiID = pulumi.output([k8sVersion, amiType]).apply(([version, type]) => {
+        const parameterName = `/aws/service/eks/optimized-ami/${version}/${type}/recommended/image_id`;
         return pulumi.output(aws.ssm.getParameter({ name: parameterName }, { parent, async: true }))
             .value;
     });
@@ -1876,21 +1886,23 @@ function getAMIType(
     amiType: pulumi.Input<string> | undefined,
     gpu: pulumi.Input<boolean> | undefined,
     instanceType: pulumi.Input<string> | undefined,
-): string {
-    if (amiType) {
-        // Return the user-specified AMI type.
-        return amiType.toString();
-    }
+): pulumi.Output<string> {
+    return pulumi.all([amiType, gpu, instanceType]).apply(([amiType, gpu, instanceType]) => {
+        if (amiType) {
+            // Return the user-specified AMI type.
+            return amiType;
+        }
 
-    if (gpu) {
-        // Return the Amazon Linux 2 GPU AMI type.
-        return "amazon-linux-2-gpu";
-    }
+        if (gpu) {
+            // Return the Amazon Linux 2 GPU AMI type.
+            return "amazon-linux-2-gpu";
+        }
 
-    if (instanceType && isGravitonInstance(instanceType.toString())) {
-        // Return the Amazon Linux 2 ARM64 AMI type.
-        return "amazon-linux-2-arm64";
-    }
+        if (instanceType && isGravitonInstance(instanceType)) {
+            // Return the Amazon Linux 2 ARM64 AMI type.
+            return "amazon-linux-2-arm64";
+        }
 
-    return "amazon-linux-2";
+        return "amazon-linux-2";
+    });
 }

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -755,7 +755,7 @@ ${customUserData}
         nodeAssociatePublicIpAddress = args.nodeAssociatePublicIpAddress;
     }
 
-    const numeric = new RegExp("^d+$");
+    const numeric = new RegExp("^\\d+$");
 
     if (args.nodeRootVolumeIops && args.nodeRootVolumeType !== "io1") {
         throw new Error(
@@ -1144,7 +1144,7 @@ ${customUserData}
         nodeAssociatePublicIpAddress = args.nodeAssociatePublicIpAddress;
     }
 
-    const numeric = new RegExp("^d+$");
+    const numeric = new RegExp("^\\d+$");
 
     if (args.nodeRootVolumeIops && args.nodeRootVolumeType !== "io1") {
         throw new Error(


### PR DESCRIPTION
### Proposed changes

This PR wraps all arg inputs that call `.toString()` with `pulumi.all` incase a `pulumi.Output` value is supplied instead of a `pulumi.Input` or plain type. As this is a MLC component, we needsto correctly deal with output values as we can't just assume that the engine sends Input<string> as a plain string.

##### Tests done:

- Updated existing test case to supply a pulumi.Output<string> instead of a plain string
- Manual testing

### Related issues (optional)

Fixes: #1160
Fixes: #1172 
