### PR TITLE
tests: set amiID for upgrade tests

### DIFF
--- a/examples/aws-profile-role/index.ts
+++ b/examples/aws-profile-role/index.ts
@@ -48,6 +48,7 @@ const cluster = new eks.Cluster(`${projectName}`, {
     providerCredentialOpts: {
         profileName: aws.config.profile,
     },
+    nodeAmiId: "ami-0384725f0d30527c7",
     roleMappings: [
         {
             groups: ["system:masters"],

--- a/examples/cluster-with-serviceiprange/index.ts
+++ b/examples/cluster-with-serviceiprange/index.ts
@@ -16,6 +16,7 @@ const cluster = new eks.Cluster(`${projectName}`, {
     desiredCapacity: 2,
     minSize: 2,
     maxSize: 2,
+    nodeAmiId: "ami-0384725f0d30527c7",
     deployDashboard: false,
     enabledClusterLogTypes: [
         "api",

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -35,8 +35,8 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
 const cluster3 = new eks.Cluster(`${projectName}-3`, {
     vpcId: vpc.vpcId,
     publicSubnetIds: vpc.publicSubnetIds,
-    nodeAmiId: "ami-0384725f0d30527c7",
     nodeGroupOptions: {
+        amiId: "ami-0384725f0d30527c7",
         desiredCapacity: 1,
         minSize: 1,
         maxSize: 1,

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -5,7 +5,9 @@ import * as eks from "@pulumi/eks";
 const projectName = pulumi.getProject();
 
 // Create an EKS cluster with the default configuration.
-const cluster1 = new eks.Cluster(`${projectName}-1`);
+const cluster1 = new eks.Cluster(`${projectName}-1`, {
+    nodeAmiId: "ami-0384725f0d30527c7",
+});
 
 // Create an EKS cluster with a non-default configuration.
 const vpc = new awsx.ec2.Vpc(`${projectName}-2`, {
@@ -18,6 +20,7 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
     desiredCapacity: 2,
     minSize: 2,
     maxSize: 2,
+    nodeAmiId: "ami-0384725f0d30527c7",
     deployDashboard: false,
     enabledClusterLogTypes: [
         "api",
@@ -32,6 +35,7 @@ const cluster2 = new eks.Cluster(`${projectName}-2`, {
 const cluster3 = new eks.Cluster(`${projectName}-3`, {
     vpcId: vpc.vpcId,
     publicSubnetIds: vpc.publicSubnetIds,
+    nodeAmiId: "ami-0384725f0d30527c7",
     nodeGroupOptions: {
         desiredCapacity: 1,
         minSize: 1,
@@ -46,6 +50,7 @@ const cluster3 = new eks.Cluster(`${projectName}-3`, {
 const cluster4 = new eks.Cluster(`${projectName}-4`, {
     vpcId: vpc.vpcId,
     publicSubnetIds: vpc.publicSubnetIds,
+    nodeAmiId: "ami-0384725f0d30527c7",
     instanceType: "t4g.small",
 })
 

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -50,7 +50,7 @@ const cluster3 = new eks.Cluster(`${projectName}-3`, {
 const cluster4 = new eks.Cluster(`${projectName}-4`, {
     vpcId: vpc.vpcId,
     publicSubnetIds: vpc.publicSubnetIds,
-    nodeAmiId: "ami-0384725f0d30527c7",
+    nodeAmiId: "ami-0350263ff18287b83",
     instanceType: "t4g.small",
 })
 

--- a/examples/encryption-provider/index.ts
+++ b/examples/encryption-provider/index.ts
@@ -26,6 +26,7 @@ export const aliasArn = alias.arn;
 // Create an EKS cluster with a KMS encryption provider.
 const cluster = new eks.Cluster(`${projectName}`, {
     encryptionConfigKeyArn: alias.targetKeyArn,
+    nodeAmiId: "ami-0384725f0d30527c7",
 });
 
 // Export the cluster kubeconfig.

--- a/examples/extra-sg/index.ts
+++ b/examples/extra-sg/index.ts
@@ -40,6 +40,7 @@ const cluster = new eks.Cluster(`${projectName}`, {
   skipDefaultNodeGroup: true,
   instanceRoles: [ngRole],
   nodeGroupOptions: {
+    amiId: "ami-0384725f0d30527c7",
     instanceType: "t3.small",
   },
 });
@@ -94,6 +95,7 @@ const publicInternetEgressRule = new aws.ec2.SecurityGroupRule(
 cluster.createNodeGroup("example-ng", {
   instanceProfile: ngInstanceProfile,
   extraNodeSecurityGroups: [customSecurityGroup],
+  amiId: "ami-0384725f0d30527c7",
   instanceType: "t3.small",
 });
 
@@ -103,6 +105,7 @@ const ng = new eks.NodeGroupV2("example-mng", {
   cluster: cluster,
   instanceProfile: ngInstanceProfile,
   instanceType: "t3.small",
+  amiId: "ami-0384725f0d30527c7",
   extraNodeSecurityGroups: [
     customSecurityGroup, // Plain type
     cluster.nodeSecurityGroup, // Input type

--- a/examples/nodegroup/index.ts
+++ b/examples/nodegroup/index.ts
@@ -21,6 +21,7 @@ const instanceProfile0 = new aws.iam.InstanceProfile("example-instanceProfile0",
 const cluster1 = new eks.Cluster("example-nodegroup-iam-simple", {
     skipDefaultNodeGroup: true,
     deployDashboard: false,
+    nodeAmiId: "ami-0384725f0d30527c7",
     instanceRole: role0,
 });
 
@@ -35,6 +36,7 @@ cluster1.createNodeGroup("example-ng-simple-ondemand", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile0,
 });
@@ -45,6 +47,7 @@ const ng = new eks.NodeGroupV2("example-ng2-simple-ondemand", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile0,
 });
@@ -56,6 +59,7 @@ const spot = new eks.NodeGroup("example-ng-simple-spot", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     spotPrice: "1",
     labels: {"preemptible": "true"},
     taints: {
@@ -76,6 +80,7 @@ const withLaunchTemplateTagSpecifications = new eks.NodeGroupV2("example-ng2-lau
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: { "ondemand": "true" },
     instanceProfile: instanceProfile0,
     launchTemplateTagSpecifications: [
@@ -114,6 +119,7 @@ const cluster2 = new eks.Cluster("example-nodegroup-iam-advanced", {
     skipDefaultNodeGroup: true,
     deployDashboard: false,
     instanceRoles: [role1, role2, role3],
+    nodeAmiId: "ami-0384725f0d30527c7",
 });
 
 // Create node groups using a different `instanceProfile` tied to one of the many
@@ -123,6 +129,7 @@ cluster2.createNodeGroup("example-ng-advanced-ondemand", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile1,
 });
@@ -133,6 +140,7 @@ const ng2 = new eks.NodeGroupV2("example-ng-advanced-ondemand", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile2,
 });
@@ -144,6 +152,7 @@ const spot2 = new eks.NodeGroup("example-ng-advanced-spot", {
     spotPrice: "1",
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: {"preemptible": "true"},
     taints: {
         "special": {

--- a/examples/oidc-iam-sa/index.ts
+++ b/examples/oidc-iam-sa/index.ts
@@ -10,6 +10,7 @@ const projectName = pulumi.getProject();
 const cluster = new eks.Cluster(`${projectName}`, {
     deployDashboard: false,
     createOidcProvider: true,
+    nodeAmiId: "ami-0384725f0d30527c7",
 });
 
 // Export the cluster's kubeconfig.

--- a/examples/storage-classes/index.ts
+++ b/examples/storage-classes/index.ts
@@ -7,6 +7,7 @@ const projectName = pulumi.getProject();
 const cluster1 = new eks.Cluster(`${projectName}-1`, {
     deployDashboard: false,
     storageClasses: "io1",
+    nodeAmiId: "ami-0384725f0d30527c7",
 });
 
 if (cluster1.core.storageClasses) {
@@ -26,6 +27,7 @@ export const kubeconfig1 = cluster1.kubeconfig;
 // Create an EKS cluster with many storage classes as a map.
 const cluster2 = new eks.Cluster(`${projectName}-2`, {
     deployDashboard: false,
+    nodeAmiId: "ami-0384725f0d30527c7",
     storageClasses: {
         "mygp2": {
             type: "gp2",

--- a/examples/subnet-tags/index.ts
+++ b/examples/subnet-tags/index.ts
@@ -43,6 +43,7 @@ const cluster = new eks.Cluster(`${projectName}`, {
     vpcId: vpc.vpcId,
     publicSubnetIds: vpc.publicSubnetIds,
     privateSubnetIds: vpc.privateSubnetIds,
+    nodeAmiId: "ami-0384725f0d30527c7",
     tags,
 });
 

--- a/examples/tags/index.ts
+++ b/examples/tags/index.ts
@@ -8,6 +8,7 @@ const cluster1 = new eks.Cluster("example-tags-cluster1", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    nodeAmiId: "ami-0384725f0d30527c7",
     tags: {
         "project": "foobar",
         "org": "barfoo",
@@ -48,6 +49,7 @@ cluster2.createNodeGroup("example-ng-tags-ondemand", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     labels: {"ondemand": "true"},
     instanceProfile: instanceProfile0,
     cloudFormationTags: { "myCloudFormationTag2": "true" },
@@ -61,6 +63,7 @@ const spot = new eks.NodeGroup("example-ng-tags-spot", {
     desiredCapacity: 1,
     minSize: 1,
     maxSize: 2,
+    amiId: "ami-0384725f0d30527c7",
     spotPrice: "1",
     instanceProfile: instanceProfile0,
     labels: {"preemptible": "true"},


### PR DESCRIPTION
### Proposed changes

Explicitly set the AMI ID for our nodes and clusters to prevent constantly needing to update our test snapshots. The current AMI set in this PR is obtained from what we currently store in our test snapshots (example: https://github.com/pulumi/pulumi-eks/blob/b19f15552956f80a45493f887c3bf32e6cea08d0/provider/testdata/recorded/TestProviderUpgrade/tags/2.5.2/stack.json#L2051).

Explicitly setting the AMI ID is a much lower engineering lift than attempting to parse the automation API's change summary since it only returns an operation type/enum, and doesn't include what field is to be replaced. Furthermore, blanket ignoring a replacement of AMI IDs may inadvertently mask some replacement bugs we may have in the future. Note: we also have existing integration tests to also test that the provider can obtain and use a recommended ID., so we are not losing coverage of this logic flow.

### Related issues (optional)
Fixes: #1181

