### PR TITLE
fix: expose nodeRootVolume fields in NodeGroup and NodeGroupV2 resources

### DIFF
--- a/examples/nodegroup-py/__main__.py
+++ b/examples/nodegroup-py/__main__.py
@@ -152,5 +152,20 @@ eks.NodeGroup(
     opts=pulumi.ResourceOptions(providers={"kubernetes": cluster2_provider}),
 )
 
+eks.NodeGroup(
+    "example-ng-advanced-spot-gp3-py",
+    cluster=cluster2,
+    instance_type="t3.medium",
+    desired_capacity=1,
+    min_size=1,
+    max_size=2,
+    node_root_volume_type="gp3",
+    spot_price="1",
+    labels={"preemptible": "true"},
+    taints={"special": eks.TaintArgs(value="true", effect="NoSchedule")},
+    instance_profile=instance_profile3,
+    opts=pulumi.ResourceOptions(providers={"kubernetes": cluster2_provider}),
+)
+
 # Export the cluster's kubeconfig.
 pulumi.export("kubeconfig2", cluster2.kubeconfig)

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -658,7 +658,7 @@ func generateSchema() schema.PackageSpec {
 					},
 					"authenticationMode": {
 						TypeSpec: schema.TypeSpec{
-							Ref: "#/types/eks:index:AuthenticationMode",
+							Ref:   "#/types/eks:index:AuthenticationMode",
 							Plain: true,
 						},
 						Description: "The authentication mode of the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP`.\n\n" +
@@ -1587,9 +1587,9 @@ func generateSchema() schema.PackageSpec {
 			},
 			"eks:index:AccessEntryType": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Type:        "string",
+					Type: "string",
 					Description: "The type of the new access entry. Valid values are STANDARD, FARGATE_LINUX, EC2_LINUX, and EC2_WINDOWS.\n" +
-					"Defaults to STANDARD which provides the standard workflow. EC2_LINUX and EC2_WINDOWS types disallow users to input a kubernetesGroup, and prevent associating access policies.",
+						"Defaults to STANDARD which provides the standard workflow. EC2_LINUX and EC2_WINDOWS types disallow users to input a kubernetesGroup, and prevent associating access policies.",
 				},
 				Enum: []schema.EnumValueSpec{
 					{
@@ -1609,16 +1609,16 @@ func generateSchema() schema.PackageSpec {
 					},
 					{
 						Name:        "EC2Windows",
-						Value: 	 	 "EC2_WINDOWS",
+						Value:       "EC2_WINDOWS",
 						Description: "For IAM roles associated with self-managed Windows node groups. Allows the nodes to join the cluster.",
 					},
 				},
 			},
 			"eks:index:AuthenticationMode": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Type:        "string",
+					Type: "string",
 					Description: "The authentication mode of the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP`.\n\n" +
-					"See for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html#set-cam",
+						"See for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html#set-cam",
 				},
 				Enum: []schema.EnumValueSpec{
 					{
@@ -1744,6 +1744,26 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		"nodeRootVolumeSize": {
 			TypeSpec:    schema.TypeSpec{Type: "integer"},
 			Description: "The size in GiB of a cluster node's root volume. Defaults to 20.",
+		},
+		"nodeRootVolumeDeleteOnTermination": {
+			TypeSpec:    schema.TypeSpec{Type: "boolean"},
+			Description: "Whether the root block device should be deleted on termination of the instance. Defaults to true.",
+		},
+		"nodeRootVolumeEncrypted": {
+			TypeSpec:    schema.TypeSpec{Type: "boolean"},
+			Description: "Whether to encrypt a cluster node's root volume. Defaults to false.",
+		},
+		"nodeRootVolumeIops": {
+			TypeSpec:    schema.TypeSpec{Type: "integer"},
+			Description: "The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.",
+		},
+		"nodeRootVolumeThroughput": {
+			TypeSpec:    schema.TypeSpec{Type: "integer"},
+			Description: "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.",
+		},
+		"nodeRootVolumeType": {
+			TypeSpec:    schema.TypeSpec{Type: "string"},
+			Description: "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.",
 		},
 		"nodeUserData": {
 			TypeSpec: schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -255,9 +255,29 @@
                     "type": "string",
                     "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
                 },
+                "nodeRootVolumeDeleteOnTermination": {
+                    "type": "boolean",
+                    "description": "Whether the root block device should be deleted on termination of the instance. Defaults to true."
+                },
+                "nodeRootVolumeEncrypted": {
+                    "type": "boolean",
+                    "description": "Whether to encrypt a cluster node's root volume. Defaults to false."
+                },
+                "nodeRootVolumeIops": {
+                    "type": "integer",
+                    "description": "The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'."
+                },
                 "nodeRootVolumeSize": {
                     "type": "integer",
                     "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
+                },
+                "nodeRootVolumeThroughput": {
+                    "type": "integer",
+                    "description": "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'."
+                },
+                "nodeRootVolumeType": {
+                    "type": "string",
+                    "description": "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'."
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
@@ -1425,9 +1445,29 @@
                     "type": "string",
                     "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
                 },
+                "nodeRootVolumeDeleteOnTermination": {
+                    "type": "boolean",
+                    "description": "Whether the root block device should be deleted on termination of the instance. Defaults to true."
+                },
+                "nodeRootVolumeEncrypted": {
+                    "type": "boolean",
+                    "description": "Whether to encrypt a cluster node's root volume. Defaults to false."
+                },
+                "nodeRootVolumeIops": {
+                    "type": "integer",
+                    "description": "The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'."
+                },
                 "nodeRootVolumeSize": {
                     "type": "integer",
                     "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
+                },
+                "nodeRootVolumeThroughput": {
+                    "type": "integer",
+                    "description": "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'."
+                },
+                "nodeRootVolumeType": {
+                    "type": "string",
+                    "description": "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'."
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
@@ -1660,9 +1700,29 @@
                     "type": "string",
                     "description": "Public key material for SSH access to worker nodes. See allowed formats at:\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html\nIf not provided, no SSH access is enabled on VMs."
                 },
+                "nodeRootVolumeDeleteOnTermination": {
+                    "type": "boolean",
+                    "description": "Whether the root block device should be deleted on termination of the instance. Defaults to true."
+                },
+                "nodeRootVolumeEncrypted": {
+                    "type": "boolean",
+                    "description": "Whether to encrypt a cluster node's root volume. Defaults to false."
+                },
+                "nodeRootVolumeIops": {
+                    "type": "integer",
+                    "description": "The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'."
+                },
                 "nodeRootVolumeSize": {
                     "type": "integer",
                     "description": "The size in GiB of a cluster node's root volume. Defaults to 20."
+                },
+                "nodeRootVolumeThroughput": {
+                    "type": "integer",
+                    "description": "Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'."
+                },
+                "nodeRootVolumeType": {
+                    "type": "string",
+                    "description": "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'."
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -195,10 +195,40 @@ namespace Pulumi.Eks.Inputs
         public Input<string>? NodePublicKey { get; set; }
 
         /// <summary>
+        /// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        /// </summary>
+        [Input("nodeRootVolumeDeleteOnTermination")]
+        public Input<bool>? NodeRootVolumeDeleteOnTermination { get; set; }
+
+        /// <summary>
+        /// Whether to encrypt a cluster node's root volume. Defaults to false.
+        /// </summary>
+        [Input("nodeRootVolumeEncrypted")]
+        public Input<bool>? NodeRootVolumeEncrypted { get; set; }
+
+        /// <summary>
+        /// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        /// </summary>
+        [Input("nodeRootVolumeIops")]
+        public Input<int>? NodeRootVolumeIops { get; set; }
+
+        /// <summary>
         /// The size in GiB of a cluster node's root volume. Defaults to 20.
         /// </summary>
         [Input("nodeRootVolumeSize")]
         public Input<int>? NodeRootVolumeSize { get; set; }
+
+        /// <summary>
+        /// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        /// </summary>
+        [Input("nodeRootVolumeThroughput")]
+        public Input<int>? NodeRootVolumeThroughput { get; set; }
+
+        /// <summary>
+        /// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        /// </summary>
+        [Input("nodeRootVolumeType")]
+        public Input<string>? NodeRootVolumeType { get; set; }
 
         /// <summary>
         /// The security group for the worker node group to communicate with the cluster.

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -253,10 +253,40 @@ namespace Pulumi.Eks
         public Input<string>? NodePublicKey { get; set; }
 
         /// <summary>
+        /// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        /// </summary>
+        [Input("nodeRootVolumeDeleteOnTermination")]
+        public Input<bool>? NodeRootVolumeDeleteOnTermination { get; set; }
+
+        /// <summary>
+        /// Whether to encrypt a cluster node's root volume. Defaults to false.
+        /// </summary>
+        [Input("nodeRootVolumeEncrypted")]
+        public Input<bool>? NodeRootVolumeEncrypted { get; set; }
+
+        /// <summary>
+        /// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        /// </summary>
+        [Input("nodeRootVolumeIops")]
+        public Input<int>? NodeRootVolumeIops { get; set; }
+
+        /// <summary>
         /// The size in GiB of a cluster node's root volume. Defaults to 20.
         /// </summary>
         [Input("nodeRootVolumeSize")]
         public Input<int>? NodeRootVolumeSize { get; set; }
+
+        /// <summary>
+        /// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        /// </summary>
+        [Input("nodeRootVolumeThroughput")]
+        public Input<int>? NodeRootVolumeThroughput { get; set; }
+
+        /// <summary>
+        /// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        /// </summary>
+        [Input("nodeRootVolumeType")]
+        public Input<string>? NodeRootVolumeType { get; set; }
 
         /// <summary>
         /// The security group for the worker node group to communicate with the cluster.

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -265,10 +265,40 @@ namespace Pulumi.Eks
         public Input<string>? NodePublicKey { get; set; }
 
         /// <summary>
+        /// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        /// </summary>
+        [Input("nodeRootVolumeDeleteOnTermination")]
+        public Input<bool>? NodeRootVolumeDeleteOnTermination { get; set; }
+
+        /// <summary>
+        /// Whether to encrypt a cluster node's root volume. Defaults to false.
+        /// </summary>
+        [Input("nodeRootVolumeEncrypted")]
+        public Input<bool>? NodeRootVolumeEncrypted { get; set; }
+
+        /// <summary>
+        /// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        /// </summary>
+        [Input("nodeRootVolumeIops")]
+        public Input<int>? NodeRootVolumeIops { get; set; }
+
+        /// <summary>
         /// The size in GiB of a cluster node's root volume. Defaults to 20.
         /// </summary>
         [Input("nodeRootVolumeSize")]
         public Input<int>? NodeRootVolumeSize { get; set; }
+
+        /// <summary>
+        /// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        /// </summary>
+        [Input("nodeRootVolumeThroughput")]
+        public Input<int>? NodeRootVolumeThroughput { get; set; }
+
+        /// <summary>
+        /// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        /// </summary>
+        [Input("nodeRootVolumeType")]
+        public Input<string>? NodeRootVolumeType { get; set; }
 
         /// <summary>
         /// The security group for the worker node group to communicate with the cluster.

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -132,9 +132,29 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly string? NodePublicKey;
         /// <summary>
+        /// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        /// </summary>
+        public readonly bool? NodeRootVolumeDeleteOnTermination;
+        /// <summary>
+        /// Whether to encrypt a cluster node's root volume. Defaults to false.
+        /// </summary>
+        public readonly bool? NodeRootVolumeEncrypted;
+        /// <summary>
+        /// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        /// </summary>
+        public readonly int? NodeRootVolumeIops;
+        /// <summary>
         /// The size in GiB of a cluster node's root volume. Defaults to 20.
         /// </summary>
         public readonly int? NodeRootVolumeSize;
+        /// <summary>
+        /// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        /// </summary>
+        public readonly int? NodeRootVolumeThroughput;
+        /// <summary>
+        /// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        /// </summary>
+        public readonly string? NodeRootVolumeType;
         /// <summary>
         /// The security group for the worker node group to communicate with the cluster.
         /// 
@@ -217,7 +237,17 @@ namespace Pulumi.Eks.Outputs
 
             string? nodePublicKey,
 
+            bool? nodeRootVolumeDeleteOnTermination,
+
+            bool? nodeRootVolumeEncrypted,
+
+            int? nodeRootVolumeIops,
+
             int? nodeRootVolumeSize,
+
+            int? nodeRootVolumeThroughput,
+
+            string? nodeRootVolumeType,
 
             Pulumi.Aws.Ec2.SecurityGroup? nodeSecurityGroup,
 
@@ -253,7 +283,12 @@ namespace Pulumi.Eks.Outputs
             MinSize = minSize;
             NodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             NodePublicKey = nodePublicKey;
+            NodeRootVolumeDeleteOnTermination = nodeRootVolumeDeleteOnTermination;
+            NodeRootVolumeEncrypted = nodeRootVolumeEncrypted;
+            NodeRootVolumeIops = nodeRootVolumeIops;
             NodeRootVolumeSize = nodeRootVolumeSize;
+            NodeRootVolumeThroughput = nodeRootVolumeThroughput;
+            NodeRootVolumeType = nodeRootVolumeType;
             NodeSecurityGroup = nodeSecurityGroup;
             NodeSubnetIds = nodeSubnetIds;
             NodeUserData = nodeUserData;

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -126,8 +126,18 @@ type nodeGroupArgs struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey *string `pulumi:"nodePublicKey"`
+	// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+	NodeRootVolumeDeleteOnTermination *bool `pulumi:"nodeRootVolumeDeleteOnTermination"`
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted *bool `pulumi:"nodeRootVolumeEncrypted"`
+	// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+	NodeRootVolumeIops *int `pulumi:"nodeRootVolumeIops"`
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize *int `pulumi:"nodeRootVolumeSize"`
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+	NodeRootVolumeThroughput *int `pulumi:"nodeRootVolumeThroughput"`
+	// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+	NodeRootVolumeType *string `pulumi:"nodeRootVolumeType"`
 	// The security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
@@ -234,8 +244,18 @@ type NodeGroupArgs struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey pulumi.StringPtrInput
+	// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+	NodeRootVolumeDeleteOnTermination pulumi.BoolPtrInput
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted pulumi.BoolPtrInput
+	// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+	NodeRootVolumeIops pulumi.IntPtrInput
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize pulumi.IntPtrInput
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+	NodeRootVolumeThroughput pulumi.IntPtrInput
+	// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+	NodeRootVolumeType pulumi.StringPtrInput
 	// The security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -128,8 +128,18 @@ type nodeGroupV2Args struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey *string `pulumi:"nodePublicKey"`
+	// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+	NodeRootVolumeDeleteOnTermination *bool `pulumi:"nodeRootVolumeDeleteOnTermination"`
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted *bool `pulumi:"nodeRootVolumeEncrypted"`
+	// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+	NodeRootVolumeIops *int `pulumi:"nodeRootVolumeIops"`
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize *int `pulumi:"nodeRootVolumeSize"`
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+	NodeRootVolumeThroughput *int `pulumi:"nodeRootVolumeThroughput"`
+	// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+	NodeRootVolumeType *string `pulumi:"nodeRootVolumeType"`
 	// The security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
@@ -240,8 +250,18 @@ type NodeGroupV2Args struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey pulumi.StringPtrInput
+	// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+	NodeRootVolumeDeleteOnTermination pulumi.BoolPtrInput
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted pulumi.BoolPtrInput
+	// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+	NodeRootVolumeIops pulumi.IntPtrInput
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize pulumi.IntPtrInput
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+	NodeRootVolumeThroughput pulumi.IntPtrInput
+	// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+	NodeRootVolumeType pulumi.StringPtrInput
 	// The security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -374,8 +374,18 @@ type ClusterNodeGroupOptions struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey *string `pulumi:"nodePublicKey"`
+	// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+	NodeRootVolumeDeleteOnTermination *bool `pulumi:"nodeRootVolumeDeleteOnTermination"`
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted *bool `pulumi:"nodeRootVolumeEncrypted"`
+	// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+	NodeRootVolumeIops *int `pulumi:"nodeRootVolumeIops"`
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize *int `pulumi:"nodeRootVolumeSize"`
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+	NodeRootVolumeThroughput *int `pulumi:"nodeRootVolumeThroughput"`
+	// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+	NodeRootVolumeType *string `pulumi:"nodeRootVolumeType"`
 	// The security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
@@ -491,8 +501,18 @@ type ClusterNodeGroupOptionsArgs struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 	// If not provided, no SSH access is enabled on VMs.
 	NodePublicKey pulumi.StringPtrInput `pulumi:"nodePublicKey"`
+	// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+	NodeRootVolumeDeleteOnTermination pulumi.BoolPtrInput `pulumi:"nodeRootVolumeDeleteOnTermination"`
+	// Whether to encrypt a cluster node's root volume. Defaults to false.
+	NodeRootVolumeEncrypted pulumi.BoolPtrInput `pulumi:"nodeRootVolumeEncrypted"`
+	// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+	NodeRootVolumeIops pulumi.IntPtrInput `pulumi:"nodeRootVolumeIops"`
 	// The size in GiB of a cluster node's root volume. Defaults to 20.
 	NodeRootVolumeSize pulumi.IntPtrInput `pulumi:"nodeRootVolumeSize"`
+	// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+	NodeRootVolumeThroughput pulumi.IntPtrInput `pulumi:"nodeRootVolumeThroughput"`
+	// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+	NodeRootVolumeType pulumi.StringPtrInput `pulumi:"nodeRootVolumeType"`
 	// The security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
@@ -733,9 +753,34 @@ func (o ClusterNodeGroupOptionsOutput) NodePublicKey() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *string { return v.NodePublicKey }).(pulumi.StringPtrOutput)
 }
 
+// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeDeleteOnTermination() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *bool { return v.NodeRootVolumeDeleteOnTermination }).(pulumi.BoolPtrOutput)
+}
+
+// Whether to encrypt a cluster node's root volume. Defaults to false.
+func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeEncrypted() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *bool { return v.NodeRootVolumeEncrypted }).(pulumi.BoolPtrOutput)
+}
+
+// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeIops() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.NodeRootVolumeIops }).(pulumi.IntPtrOutput)
+}
+
 // The size in GiB of a cluster node's root volume. Defaults to 20.
 func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeSize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.NodeRootVolumeSize }).(pulumi.IntPtrOutput)
+}
+
+// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeThroughput() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.NodeRootVolumeThroughput }).(pulumi.IntPtrOutput)
+}
+
+// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeType() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *string { return v.NodeRootVolumeType }).(pulumi.StringPtrOutput)
 }
 
 // The security group for the worker node group to communicate with the cluster.
@@ -1043,6 +1088,36 @@ func (o ClusterNodeGroupOptionsPtrOutput) NodePublicKey() pulumi.StringPtrOutput
 	}).(pulumi.StringPtrOutput)
 }
 
+// Whether the root block device should be deleted on termination of the instance. Defaults to true.
+func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeDeleteOnTermination() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.NodeRootVolumeDeleteOnTermination
+	}).(pulumi.BoolPtrOutput)
+}
+
+// Whether to encrypt a cluster node's root volume. Defaults to false.
+func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeEncrypted() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.NodeRootVolumeEncrypted
+	}).(pulumi.BoolPtrOutput)
+}
+
+// The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeIops() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *int {
+		if v == nil {
+			return nil
+		}
+		return v.NodeRootVolumeIops
+	}).(pulumi.IntPtrOutput)
+}
+
 // The size in GiB of a cluster node's root volume. Defaults to 20.
 func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeSize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *ClusterNodeGroupOptions) *int {
@@ -1051,6 +1126,26 @@ func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeSize() pulumi.IntPtrOutp
 		}
 		return v.NodeRootVolumeSize
 	}).(pulumi.IntPtrOutput)
+}
+
+// Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeThroughput() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *int {
+		if v == nil {
+			return nil
+		}
+		return v.NodeRootVolumeThroughput
+	}).(pulumi.IntPtrOutput)
+}
+
+// Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+func (o ClusterNodeGroupOptionsPtrOutput) NodeRootVolumeType() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NodeRootVolumeType
+	}).(pulumi.StringPtrOutput)
 }
 
 // The security group for the worker node group to communicate with the cluster.

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -412,6 +412,51 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    @Import(name="nodeRootVolumeDeleteOnTermination")
+    private @Nullable Output<Boolean> nodeRootVolumeDeleteOnTermination;
+
+    /**
+     * @return Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    public Optional<Output<Boolean>> nodeRootVolumeDeleteOnTermination() {
+        return Optional.ofNullable(this.nodeRootVolumeDeleteOnTermination);
+    }
+
+    /**
+     * Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    @Import(name="nodeRootVolumeEncrypted")
+    private @Nullable Output<Boolean> nodeRootVolumeEncrypted;
+
+    /**
+     * @return Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    public Optional<Output<Boolean>> nodeRootVolumeEncrypted() {
+        return Optional.ofNullable(this.nodeRootVolumeEncrypted);
+    }
+
+    /**
+     * The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeIops")
+    private @Nullable Output<Integer> nodeRootVolumeIops;
+
+    /**
+     * @return The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    public Optional<Output<Integer>> nodeRootVolumeIops() {
+        return Optional.ofNullable(this.nodeRootVolumeIops);
+    }
+
+    /**
      * The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
      * 
      */
@@ -424,6 +469,36 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<Integer>> nodeRootVolumeSize() {
         return Optional.ofNullable(this.nodeRootVolumeSize);
+    }
+
+    /**
+     * Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeThroughput")
+    private @Nullable Output<Integer> nodeRootVolumeThroughput;
+
+    /**
+     * @return Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    public Optional<Output<Integer>> nodeRootVolumeThroughput() {
+        return Optional.ofNullable(this.nodeRootVolumeThroughput);
+    }
+
+    /**
+     * Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeType")
+    private @Nullable Output<String> nodeRootVolumeType;
+
+    /**
+     * @return Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    public Optional<Output<String>> nodeRootVolumeType() {
+        return Optional.ofNullable(this.nodeRootVolumeType);
     }
 
     /**
@@ -577,7 +652,12 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         this.minSize = $.minSize;
         this.nodeAssociatePublicIpAddress = $.nodeAssociatePublicIpAddress;
         this.nodePublicKey = $.nodePublicKey;
+        this.nodeRootVolumeDeleteOnTermination = $.nodeRootVolumeDeleteOnTermination;
+        this.nodeRootVolumeEncrypted = $.nodeRootVolumeEncrypted;
+        this.nodeRootVolumeIops = $.nodeRootVolumeIops;
         this.nodeRootVolumeSize = $.nodeRootVolumeSize;
+        this.nodeRootVolumeThroughput = $.nodeRootVolumeThroughput;
+        this.nodeRootVolumeType = $.nodeRootVolumeType;
         this.nodeSecurityGroup = $.nodeSecurityGroup;
         this.nodeSubnetIds = $.nodeSubnetIds;
         this.nodeUserData = $.nodeUserData;
@@ -1099,6 +1179,69 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param nodeRootVolumeDeleteOnTermination Whether the root block device should be deleted on termination of the instance. Defaults to true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeDeleteOnTermination(@Nullable Output<Boolean> nodeRootVolumeDeleteOnTermination) {
+            $.nodeRootVolumeDeleteOnTermination = nodeRootVolumeDeleteOnTermination;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeDeleteOnTermination Whether the root block device should be deleted on termination of the instance. Defaults to true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeDeleteOnTermination(Boolean nodeRootVolumeDeleteOnTermination) {
+            return nodeRootVolumeDeleteOnTermination(Output.of(nodeRootVolumeDeleteOnTermination));
+        }
+
+        /**
+         * @param nodeRootVolumeEncrypted Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeEncrypted(@Nullable Output<Boolean> nodeRootVolumeEncrypted) {
+            $.nodeRootVolumeEncrypted = nodeRootVolumeEncrypted;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeEncrypted Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeEncrypted(Boolean nodeRootVolumeEncrypted) {
+            return nodeRootVolumeEncrypted(Output.of(nodeRootVolumeEncrypted));
+        }
+
+        /**
+         * @param nodeRootVolumeIops The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeIops(@Nullable Output<Integer> nodeRootVolumeIops) {
+            $.nodeRootVolumeIops = nodeRootVolumeIops;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeIops The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeIops(Integer nodeRootVolumeIops) {
+            return nodeRootVolumeIops(Output.of(nodeRootVolumeIops));
+        }
+
+        /**
          * @param nodeRootVolumeSize The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
          * 
          * @return builder
@@ -1117,6 +1260,48 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder nodeRootVolumeSize(Integer nodeRootVolumeSize) {
             return nodeRootVolumeSize(Output.of(nodeRootVolumeSize));
+        }
+
+        /**
+         * @param nodeRootVolumeThroughput Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeThroughput(@Nullable Output<Integer> nodeRootVolumeThroughput) {
+            $.nodeRootVolumeThroughput = nodeRootVolumeThroughput;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeThroughput Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeThroughput(Integer nodeRootVolumeThroughput) {
+            return nodeRootVolumeThroughput(Output.of(nodeRootVolumeThroughput));
+        }
+
+        /**
+         * @param nodeRootVolumeType Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeType(@Nullable Output<String> nodeRootVolumeType) {
+            $.nodeRootVolumeType = nodeRootVolumeType;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeType Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeType(String nodeRootVolumeType) {
+            return nodeRootVolumeType(Output.of(nodeRootVolumeType));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -443,6 +443,51 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    @Import(name="nodeRootVolumeDeleteOnTermination")
+    private @Nullable Output<Boolean> nodeRootVolumeDeleteOnTermination;
+
+    /**
+     * @return Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    public Optional<Output<Boolean>> nodeRootVolumeDeleteOnTermination() {
+        return Optional.ofNullable(this.nodeRootVolumeDeleteOnTermination);
+    }
+
+    /**
+     * Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    @Import(name="nodeRootVolumeEncrypted")
+    private @Nullable Output<Boolean> nodeRootVolumeEncrypted;
+
+    /**
+     * @return Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    public Optional<Output<Boolean>> nodeRootVolumeEncrypted() {
+        return Optional.ofNullable(this.nodeRootVolumeEncrypted);
+    }
+
+    /**
+     * The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeIops")
+    private @Nullable Output<Integer> nodeRootVolumeIops;
+
+    /**
+     * @return The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    public Optional<Output<Integer>> nodeRootVolumeIops() {
+        return Optional.ofNullable(this.nodeRootVolumeIops);
+    }
+
+    /**
      * The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
      * 
      */
@@ -455,6 +500,36 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<Integer>> nodeRootVolumeSize() {
         return Optional.ofNullable(this.nodeRootVolumeSize);
+    }
+
+    /**
+     * Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeThroughput")
+    private @Nullable Output<Integer> nodeRootVolumeThroughput;
+
+    /**
+     * @return Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    public Optional<Output<Integer>> nodeRootVolumeThroughput() {
+        return Optional.ofNullable(this.nodeRootVolumeThroughput);
+    }
+
+    /**
+     * Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeType")
+    private @Nullable Output<String> nodeRootVolumeType;
+
+    /**
+     * @return Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    public Optional<Output<String>> nodeRootVolumeType() {
+        return Optional.ofNullable(this.nodeRootVolumeType);
     }
 
     /**
@@ -610,7 +685,12 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         this.minSize = $.minSize;
         this.nodeAssociatePublicIpAddress = $.nodeAssociatePublicIpAddress;
         this.nodePublicKey = $.nodePublicKey;
+        this.nodeRootVolumeDeleteOnTermination = $.nodeRootVolumeDeleteOnTermination;
+        this.nodeRootVolumeEncrypted = $.nodeRootVolumeEncrypted;
+        this.nodeRootVolumeIops = $.nodeRootVolumeIops;
         this.nodeRootVolumeSize = $.nodeRootVolumeSize;
+        this.nodeRootVolumeThroughput = $.nodeRootVolumeThroughput;
+        this.nodeRootVolumeType = $.nodeRootVolumeType;
         this.nodeSecurityGroup = $.nodeSecurityGroup;
         this.nodeSubnetIds = $.nodeSubnetIds;
         this.nodeUserData = $.nodeUserData;
@@ -1184,6 +1264,69 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param nodeRootVolumeDeleteOnTermination Whether the root block device should be deleted on termination of the instance. Defaults to true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeDeleteOnTermination(@Nullable Output<Boolean> nodeRootVolumeDeleteOnTermination) {
+            $.nodeRootVolumeDeleteOnTermination = nodeRootVolumeDeleteOnTermination;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeDeleteOnTermination Whether the root block device should be deleted on termination of the instance. Defaults to true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeDeleteOnTermination(Boolean nodeRootVolumeDeleteOnTermination) {
+            return nodeRootVolumeDeleteOnTermination(Output.of(nodeRootVolumeDeleteOnTermination));
+        }
+
+        /**
+         * @param nodeRootVolumeEncrypted Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeEncrypted(@Nullable Output<Boolean> nodeRootVolumeEncrypted) {
+            $.nodeRootVolumeEncrypted = nodeRootVolumeEncrypted;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeEncrypted Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeEncrypted(Boolean nodeRootVolumeEncrypted) {
+            return nodeRootVolumeEncrypted(Output.of(nodeRootVolumeEncrypted));
+        }
+
+        /**
+         * @param nodeRootVolumeIops The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeIops(@Nullable Output<Integer> nodeRootVolumeIops) {
+            $.nodeRootVolumeIops = nodeRootVolumeIops;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeIops The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeIops(Integer nodeRootVolumeIops) {
+            return nodeRootVolumeIops(Output.of(nodeRootVolumeIops));
+        }
+
+        /**
          * @param nodeRootVolumeSize The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
          * 
          * @return builder
@@ -1202,6 +1345,48 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          */
         public Builder nodeRootVolumeSize(Integer nodeRootVolumeSize) {
             return nodeRootVolumeSize(Output.of(nodeRootVolumeSize));
+        }
+
+        /**
+         * @param nodeRootVolumeThroughput Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeThroughput(@Nullable Output<Integer> nodeRootVolumeThroughput) {
+            $.nodeRootVolumeThroughput = nodeRootVolumeThroughput;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeThroughput Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeThroughput(Integer nodeRootVolumeThroughput) {
+            return nodeRootVolumeThroughput(Output.of(nodeRootVolumeThroughput));
+        }
+
+        /**
+         * @param nodeRootVolumeType Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeType(@Nullable Output<String> nodeRootVolumeType) {
+            $.nodeRootVolumeType = nodeRootVolumeType;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeType Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeType(String nodeRootVolumeType) {
+            return nodeRootVolumeType(Output.of(nodeRootVolumeType));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -398,6 +398,51 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
+     * Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    @Import(name="nodeRootVolumeDeleteOnTermination")
+    private @Nullable Output<Boolean> nodeRootVolumeDeleteOnTermination;
+
+    /**
+     * @return Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    public Optional<Output<Boolean>> nodeRootVolumeDeleteOnTermination() {
+        return Optional.ofNullable(this.nodeRootVolumeDeleteOnTermination);
+    }
+
+    /**
+     * Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    @Import(name="nodeRootVolumeEncrypted")
+    private @Nullable Output<Boolean> nodeRootVolumeEncrypted;
+
+    /**
+     * @return Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    public Optional<Output<Boolean>> nodeRootVolumeEncrypted() {
+        return Optional.ofNullable(this.nodeRootVolumeEncrypted);
+    }
+
+    /**
+     * The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeIops")
+    private @Nullable Output<Integer> nodeRootVolumeIops;
+
+    /**
+     * @return The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    public Optional<Output<Integer>> nodeRootVolumeIops() {
+        return Optional.ofNullable(this.nodeRootVolumeIops);
+    }
+
+    /**
      * The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
      * 
      */
@@ -410,6 +455,36 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      */
     public Optional<Output<Integer>> nodeRootVolumeSize() {
         return Optional.ofNullable(this.nodeRootVolumeSize);
+    }
+
+    /**
+     * Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeThroughput")
+    private @Nullable Output<Integer> nodeRootVolumeThroughput;
+
+    /**
+     * @return Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    public Optional<Output<Integer>> nodeRootVolumeThroughput() {
+        return Optional.ofNullable(this.nodeRootVolumeThroughput);
+    }
+
+    /**
+     * Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    @Import(name="nodeRootVolumeType")
+    private @Nullable Output<String> nodeRootVolumeType;
+
+    /**
+     * @return Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    public Optional<Output<String>> nodeRootVolumeType() {
+        return Optional.ofNullable(this.nodeRootVolumeType);
     }
 
     /**
@@ -562,7 +637,12 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         this.minSize = $.minSize;
         this.nodeAssociatePublicIpAddress = $.nodeAssociatePublicIpAddress;
         this.nodePublicKey = $.nodePublicKey;
+        this.nodeRootVolumeDeleteOnTermination = $.nodeRootVolumeDeleteOnTermination;
+        this.nodeRootVolumeEncrypted = $.nodeRootVolumeEncrypted;
+        this.nodeRootVolumeIops = $.nodeRootVolumeIops;
         this.nodeRootVolumeSize = $.nodeRootVolumeSize;
+        this.nodeRootVolumeThroughput = $.nodeRootVolumeThroughput;
+        this.nodeRootVolumeType = $.nodeRootVolumeType;
         this.nodeSecurityGroup = $.nodeSecurityGroup;
         this.nodeSubnetIds = $.nodeSubnetIds;
         this.nodeUserData = $.nodeUserData;
@@ -1043,6 +1123,69 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         }
 
         /**
+         * @param nodeRootVolumeDeleteOnTermination Whether the root block device should be deleted on termination of the instance. Defaults to true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeDeleteOnTermination(@Nullable Output<Boolean> nodeRootVolumeDeleteOnTermination) {
+            $.nodeRootVolumeDeleteOnTermination = nodeRootVolumeDeleteOnTermination;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeDeleteOnTermination Whether the root block device should be deleted on termination of the instance. Defaults to true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeDeleteOnTermination(Boolean nodeRootVolumeDeleteOnTermination) {
+            return nodeRootVolumeDeleteOnTermination(Output.of(nodeRootVolumeDeleteOnTermination));
+        }
+
+        /**
+         * @param nodeRootVolumeEncrypted Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeEncrypted(@Nullable Output<Boolean> nodeRootVolumeEncrypted) {
+            $.nodeRootVolumeEncrypted = nodeRootVolumeEncrypted;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeEncrypted Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeEncrypted(Boolean nodeRootVolumeEncrypted) {
+            return nodeRootVolumeEncrypted(Output.of(nodeRootVolumeEncrypted));
+        }
+
+        /**
+         * @param nodeRootVolumeIops The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeIops(@Nullable Output<Integer> nodeRootVolumeIops) {
+            $.nodeRootVolumeIops = nodeRootVolumeIops;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeIops The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeIops(Integer nodeRootVolumeIops) {
+            return nodeRootVolumeIops(Output.of(nodeRootVolumeIops));
+        }
+
+        /**
          * @param nodeRootVolumeSize The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
          * 
          * @return builder
@@ -1061,6 +1204,48 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          */
         public Builder nodeRootVolumeSize(Integer nodeRootVolumeSize) {
             return nodeRootVolumeSize(Output.of(nodeRootVolumeSize));
+        }
+
+        /**
+         * @param nodeRootVolumeThroughput Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeThroughput(@Nullable Output<Integer> nodeRootVolumeThroughput) {
+            $.nodeRootVolumeThroughput = nodeRootVolumeThroughput;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeThroughput Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeThroughput(Integer nodeRootVolumeThroughput) {
+            return nodeRootVolumeThroughput(Output.of(nodeRootVolumeThroughput));
+        }
+
+        /**
+         * @param nodeRootVolumeType Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeType(@Nullable Output<String> nodeRootVolumeType) {
+            $.nodeRootVolumeType = nodeRootVolumeType;
+            return this;
+        }
+
+        /**
+         * @param nodeRootVolumeType Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeRootVolumeType(String nodeRootVolumeType) {
+            return nodeRootVolumeType(Output.of(nodeRootVolumeType));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -155,10 +155,35 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable String nodePublicKey;
     /**
+     * @return Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    private @Nullable Boolean nodeRootVolumeDeleteOnTermination;
+    /**
+     * @return Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    private @Nullable Boolean nodeRootVolumeEncrypted;
+    /**
+     * @return The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    private @Nullable Integer nodeRootVolumeIops;
+    /**
      * @return The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
      * 
      */
     private @Nullable Integer nodeRootVolumeSize;
+    /**
+     * @return Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    private @Nullable Integer nodeRootVolumeThroughput;
+    /**
+     * @return Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    private @Nullable String nodeRootVolumeType;
     /**
      * @return The security group for the worker node group to communicate with the cluster.
      * 
@@ -383,11 +408,46 @@ public final class ClusterNodeGroupOptions {
         return Optional.ofNullable(this.nodePublicKey);
     }
     /**
+     * @return Whether the root block device should be deleted on termination of the instance. Defaults to true.
+     * 
+     */
+    public Optional<Boolean> nodeRootVolumeDeleteOnTermination() {
+        return Optional.ofNullable(this.nodeRootVolumeDeleteOnTermination);
+    }
+    /**
+     * @return Whether to encrypt a cluster node&#39;s root volume. Defaults to false.
+     * 
+     */
+    public Optional<Boolean> nodeRootVolumeEncrypted() {
+        return Optional.ofNullable(this.nodeRootVolumeEncrypted);
+    }
+    /**
+     * @return The amount of provisioned IOPS. This is only valid with a volumeType of &#39;io1&#39;.
+     * 
+     */
+    public Optional<Integer> nodeRootVolumeIops() {
+        return Optional.ofNullable(this.nodeRootVolumeIops);
+    }
+    /**
      * @return The size in GiB of a cluster node&#39;s root volume. Defaults to 20.
      * 
      */
     public Optional<Integer> nodeRootVolumeSize() {
         return Optional.ofNullable(this.nodeRootVolumeSize);
+    }
+    /**
+     * @return Provisioned throughput performance in integer MiB/s for a cluster node&#39;s root volume. This is only valid with a volumeType of &#39;gp3&#39;.
+     * 
+     */
+    public Optional<Integer> nodeRootVolumeThroughput() {
+        return Optional.ofNullable(this.nodeRootVolumeThroughput);
+    }
+    /**
+     * @return Configured EBS type for a cluster node&#39;s root volume. Default is &#39;gp2&#39;. Supported values are &#39;standard&#39;, &#39;gp2&#39;, &#39;gp3&#39;, &#39;st1&#39;, &#39;sc1&#39;, &#39;io1&#39;.
+     * 
+     */
+    public Optional<String> nodeRootVolumeType() {
+        return Optional.ofNullable(this.nodeRootVolumeType);
     }
     /**
      * @return The security group for the worker node group to communicate with the cluster.
@@ -479,7 +539,12 @@ public final class ClusterNodeGroupOptions {
         private @Nullable Integer minSize;
         private @Nullable Boolean nodeAssociatePublicIpAddress;
         private @Nullable String nodePublicKey;
+        private @Nullable Boolean nodeRootVolumeDeleteOnTermination;
+        private @Nullable Boolean nodeRootVolumeEncrypted;
+        private @Nullable Integer nodeRootVolumeIops;
         private @Nullable Integer nodeRootVolumeSize;
+        private @Nullable Integer nodeRootVolumeThroughput;
+        private @Nullable String nodeRootVolumeType;
         private @Nullable SecurityGroup nodeSecurityGroup;
         private @Nullable List<String> nodeSubnetIds;
         private @Nullable String nodeUserData;
@@ -510,7 +575,12 @@ public final class ClusterNodeGroupOptions {
     	      this.minSize = defaults.minSize;
     	      this.nodeAssociatePublicIpAddress = defaults.nodeAssociatePublicIpAddress;
     	      this.nodePublicKey = defaults.nodePublicKey;
+    	      this.nodeRootVolumeDeleteOnTermination = defaults.nodeRootVolumeDeleteOnTermination;
+    	      this.nodeRootVolumeEncrypted = defaults.nodeRootVolumeEncrypted;
+    	      this.nodeRootVolumeIops = defaults.nodeRootVolumeIops;
     	      this.nodeRootVolumeSize = defaults.nodeRootVolumeSize;
+    	      this.nodeRootVolumeThroughput = defaults.nodeRootVolumeThroughput;
+    	      this.nodeRootVolumeType = defaults.nodeRootVolumeType;
     	      this.nodeSecurityGroup = defaults.nodeSecurityGroup;
     	      this.nodeSubnetIds = defaults.nodeSubnetIds;
     	      this.nodeUserData = defaults.nodeUserData;
@@ -624,8 +694,33 @@ public final class ClusterNodeGroupOptions {
             return this;
         }
         @CustomType.Setter
+        public Builder nodeRootVolumeDeleteOnTermination(@Nullable Boolean nodeRootVolumeDeleteOnTermination) {
+            this.nodeRootVolumeDeleteOnTermination = nodeRootVolumeDeleteOnTermination;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder nodeRootVolumeEncrypted(@Nullable Boolean nodeRootVolumeEncrypted) {
+            this.nodeRootVolumeEncrypted = nodeRootVolumeEncrypted;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder nodeRootVolumeIops(@Nullable Integer nodeRootVolumeIops) {
+            this.nodeRootVolumeIops = nodeRootVolumeIops;
+            return this;
+        }
+        @CustomType.Setter
         public Builder nodeRootVolumeSize(@Nullable Integer nodeRootVolumeSize) {
             this.nodeRootVolumeSize = nodeRootVolumeSize;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder nodeRootVolumeThroughput(@Nullable Integer nodeRootVolumeThroughput) {
+            this.nodeRootVolumeThroughput = nodeRootVolumeThroughput;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder nodeRootVolumeType(@Nullable String nodeRootVolumeType) {
+            this.nodeRootVolumeType = nodeRootVolumeType;
             return this;
         }
         @CustomType.Setter
@@ -688,7 +783,12 @@ public final class ClusterNodeGroupOptions {
             _resultValue.minSize = minSize;
             _resultValue.nodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             _resultValue.nodePublicKey = nodePublicKey;
+            _resultValue.nodeRootVolumeDeleteOnTermination = nodeRootVolumeDeleteOnTermination;
+            _resultValue.nodeRootVolumeEncrypted = nodeRootVolumeEncrypted;
+            _resultValue.nodeRootVolumeIops = nodeRootVolumeIops;
             _resultValue.nodeRootVolumeSize = nodeRootVolumeSize;
+            _resultValue.nodeRootVolumeThroughput = nodeRootVolumeThroughput;
+            _resultValue.nodeRootVolumeType = nodeRootVolumeType;
             _resultValue.nodeSecurityGroup = nodeSecurityGroup;
             _resultValue.nodeSubnetIds = nodeSubnetIds;
             _resultValue.nodeUserData = nodeUserData;

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -200,7 +200,12 @@ class ClusterNodeGroupOptionsArgs:
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -265,7 +270,12 @@ class ClusterNodeGroupOptionsArgs:
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
@@ -325,8 +335,18 @@ class ClusterNodeGroupOptionsArgs:
             pulumi.set(__self__, "node_associate_public_ip_address", node_associate_public_ip_address)
         if node_public_key is not None:
             pulumi.set(__self__, "node_public_key", node_public_key)
+        if node_root_volume_delete_on_termination is not None:
+            pulumi.set(__self__, "node_root_volume_delete_on_termination", node_root_volume_delete_on_termination)
+        if node_root_volume_encrypted is not None:
+            pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
+        if node_root_volume_iops is not None:
+            pulumi.set(__self__, "node_root_volume_iops", node_root_volume_iops)
         if node_root_volume_size is not None:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
+        if node_root_volume_throughput is not None:
+            pulumi.set(__self__, "node_root_volume_throughput", node_root_volume_throughput)
+        if node_root_volume_type is not None:
+            pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
         if node_subnet_ids is not None:
@@ -618,6 +638,42 @@ class ClusterNodeGroupOptionsArgs:
         pulumi.set(self, "node_public_key", value)
 
     @property
+    @pulumi.getter(name="nodeRootVolumeDeleteOnTermination")
+    def node_root_volume_delete_on_termination(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        """
+        return pulumi.get(self, "node_root_volume_delete_on_termination")
+
+    @node_root_volume_delete_on_termination.setter
+    def node_root_volume_delete_on_termination(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_delete_on_termination", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeEncrypted")
+    def node_root_volume_encrypted(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether to encrypt a cluster node's root volume. Defaults to false.
+        """
+        return pulumi.get(self, "node_root_volume_encrypted")
+
+    @node_root_volume_encrypted.setter
+    def node_root_volume_encrypted(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_encrypted", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeIops")
+    def node_root_volume_iops(self) -> Optional[pulumi.Input[int]]:
+        """
+        The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_iops")
+
+    @node_root_volume_iops.setter
+    def node_root_volume_iops(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_iops", value)
+
+    @property
     @pulumi.getter(name="nodeRootVolumeSize")
     def node_root_volume_size(self) -> Optional[pulumi.Input[int]]:
         """
@@ -628,6 +684,30 @@ class ClusterNodeGroupOptionsArgs:
     @node_root_volume_size.setter
     def node_root_volume_size(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "node_root_volume_size", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeThroughput")
+    def node_root_volume_throughput(self) -> Optional[pulumi.Input[int]]:
+        """
+        Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        """
+        return pulumi.get(self, "node_root_volume_throughput")
+
+    @node_root_volume_throughput.setter
+    def node_root_volume_throughput(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_throughput", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeType")
+    def node_root_volume_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_type")
+
+    @node_root_volume_type.setter
+    def node_root_volume_type(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_root_volume_type", value)
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -41,7 +41,12 @@ class NodeGroupArgs:
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -107,7 +112,12 @@ class NodeGroupArgs:
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
@@ -168,8 +178,18 @@ class NodeGroupArgs:
             pulumi.set(__self__, "node_associate_public_ip_address", node_associate_public_ip_address)
         if node_public_key is not None:
             pulumi.set(__self__, "node_public_key", node_public_key)
+        if node_root_volume_delete_on_termination is not None:
+            pulumi.set(__self__, "node_root_volume_delete_on_termination", node_root_volume_delete_on_termination)
+        if node_root_volume_encrypted is not None:
+            pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
+        if node_root_volume_iops is not None:
+            pulumi.set(__self__, "node_root_volume_iops", node_root_volume_iops)
         if node_root_volume_size is not None:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
+        if node_root_volume_throughput is not None:
+            pulumi.set(__self__, "node_root_volume_throughput", node_root_volume_throughput)
+        if node_root_volume_type is not None:
+            pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
         if node_subnet_ids is not None:
@@ -473,6 +493,42 @@ class NodeGroupArgs:
         pulumi.set(self, "node_public_key", value)
 
     @property
+    @pulumi.getter(name="nodeRootVolumeDeleteOnTermination")
+    def node_root_volume_delete_on_termination(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        """
+        return pulumi.get(self, "node_root_volume_delete_on_termination")
+
+    @node_root_volume_delete_on_termination.setter
+    def node_root_volume_delete_on_termination(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_delete_on_termination", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeEncrypted")
+    def node_root_volume_encrypted(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether to encrypt a cluster node's root volume. Defaults to false.
+        """
+        return pulumi.get(self, "node_root_volume_encrypted")
+
+    @node_root_volume_encrypted.setter
+    def node_root_volume_encrypted(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_encrypted", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeIops")
+    def node_root_volume_iops(self) -> Optional[pulumi.Input[int]]:
+        """
+        The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_iops")
+
+    @node_root_volume_iops.setter
+    def node_root_volume_iops(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_iops", value)
+
+    @property
     @pulumi.getter(name="nodeRootVolumeSize")
     def node_root_volume_size(self) -> Optional[pulumi.Input[int]]:
         """
@@ -483,6 +539,30 @@ class NodeGroupArgs:
     @node_root_volume_size.setter
     def node_root_volume_size(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "node_root_volume_size", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeThroughput")
+    def node_root_volume_throughput(self) -> Optional[pulumi.Input[int]]:
+        """
+        Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        """
+        return pulumi.get(self, "node_root_volume_throughput")
+
+    @node_root_volume_throughput.setter
+    def node_root_volume_throughput(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_throughput", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeType")
+    def node_root_volume_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_type")
+
+    @node_root_volume_type.setter
+    def node_root_volume_type(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_root_volume_type", value)
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
@@ -606,7 +686,12 @@ class NodeGroup(pulumi.ComponentResource):
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -676,7 +761,12 @@ class NodeGroup(pulumi.ComponentResource):
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
@@ -741,7 +831,12 @@ class NodeGroup(pulumi.ComponentResource):
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -783,7 +878,12 @@ class NodeGroup(pulumi.ComponentResource):
             __props__.__dict__["min_size"] = min_size
             __props__.__dict__["node_associate_public_ip_address"] = node_associate_public_ip_address
             __props__.__dict__["node_public_key"] = node_public_key
+            __props__.__dict__["node_root_volume_delete_on_termination"] = node_root_volume_delete_on_termination
+            __props__.__dict__["node_root_volume_encrypted"] = node_root_volume_encrypted
+            __props__.__dict__["node_root_volume_iops"] = node_root_volume_iops
             __props__.__dict__["node_root_volume_size"] = node_root_volume_size
+            __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
+            __props__.__dict__["node_root_volume_type"] = node_root_volume_type
             __props__.__dict__["node_security_group"] = node_security_group
             __props__.__dict__["node_subnet_ids"] = node_subnet_ids
             __props__.__dict__["node_user_data"] = node_user_data

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -43,7 +43,12 @@ class NodeGroupV2Args:
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -111,7 +116,12 @@ class NodeGroupV2Args:
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
@@ -176,8 +186,18 @@ class NodeGroupV2Args:
             pulumi.set(__self__, "node_associate_public_ip_address", node_associate_public_ip_address)
         if node_public_key is not None:
             pulumi.set(__self__, "node_public_key", node_public_key)
+        if node_root_volume_delete_on_termination is not None:
+            pulumi.set(__self__, "node_root_volume_delete_on_termination", node_root_volume_delete_on_termination)
+        if node_root_volume_encrypted is not None:
+            pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
+        if node_root_volume_iops is not None:
+            pulumi.set(__self__, "node_root_volume_iops", node_root_volume_iops)
         if node_root_volume_size is not None:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
+        if node_root_volume_throughput is not None:
+            pulumi.set(__self__, "node_root_volume_throughput", node_root_volume_throughput)
+        if node_root_volume_type is not None:
+            pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
         if node_subnet_ids is not None:
@@ -505,6 +525,42 @@ class NodeGroupV2Args:
         pulumi.set(self, "node_public_key", value)
 
     @property
+    @pulumi.getter(name="nodeRootVolumeDeleteOnTermination")
+    def node_root_volume_delete_on_termination(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        """
+        return pulumi.get(self, "node_root_volume_delete_on_termination")
+
+    @node_root_volume_delete_on_termination.setter
+    def node_root_volume_delete_on_termination(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_delete_on_termination", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeEncrypted")
+    def node_root_volume_encrypted(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether to encrypt a cluster node's root volume. Defaults to false.
+        """
+        return pulumi.get(self, "node_root_volume_encrypted")
+
+    @node_root_volume_encrypted.setter
+    def node_root_volume_encrypted(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "node_root_volume_encrypted", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeIops")
+    def node_root_volume_iops(self) -> Optional[pulumi.Input[int]]:
+        """
+        The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_iops")
+
+    @node_root_volume_iops.setter
+    def node_root_volume_iops(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_iops", value)
+
+    @property
     @pulumi.getter(name="nodeRootVolumeSize")
     def node_root_volume_size(self) -> Optional[pulumi.Input[int]]:
         """
@@ -515,6 +571,30 @@ class NodeGroupV2Args:
     @node_root_volume_size.setter
     def node_root_volume_size(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "node_root_volume_size", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeThroughput")
+    def node_root_volume_throughput(self) -> Optional[pulumi.Input[int]]:
+        """
+        Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        """
+        return pulumi.get(self, "node_root_volume_throughput")
+
+    @node_root_volume_throughput.setter
+    def node_root_volume_throughput(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "node_root_volume_throughput", value)
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeType")
+    def node_root_volume_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_type")
+
+    @node_root_volume_type.setter
+    def node_root_volume_type(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_root_volume_type", value)
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
@@ -640,7 +720,12 @@ class NodeGroupV2(pulumi.ComponentResource):
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -712,7 +797,12 @@ class NodeGroupV2(pulumi.ComponentResource):
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param pulumi.Input[bool] node_root_volume_delete_on_termination: Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        :param pulumi.Input[bool] node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param pulumi.Input[int] node_root_volume_iops: The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
         :param pulumi.Input[int] node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param pulumi.Input[int] node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        :param pulumi.Input[str] node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
@@ -779,7 +869,12 @@ class NodeGroupV2(pulumi.ComponentResource):
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
+                 node_root_volume_delete_on_termination: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_encrypted: Optional[pulumi.Input[bool]] = None,
+                 node_root_volume_iops: Optional[pulumi.Input[int]] = None,
                  node_root_volume_size: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
+                 node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
@@ -823,7 +918,12 @@ class NodeGroupV2(pulumi.ComponentResource):
             __props__.__dict__["min_size"] = min_size
             __props__.__dict__["node_associate_public_ip_address"] = node_associate_public_ip_address
             __props__.__dict__["node_public_key"] = node_public_key
+            __props__.__dict__["node_root_volume_delete_on_termination"] = node_root_volume_delete_on_termination
+            __props__.__dict__["node_root_volume_encrypted"] = node_root_volume_encrypted
+            __props__.__dict__["node_root_volume_iops"] = node_root_volume_iops
             __props__.__dict__["node_root_volume_size"] = node_root_volume_size
+            __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
+            __props__.__dict__["node_root_volume_type"] = node_root_volume_type
             __props__.__dict__["node_security_group"] = node_security_group
             __props__.__dict__["node_subnet_ids"] = node_subnet_ids
             __props__.__dict__["node_user_data"] = node_user_data

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -236,8 +236,18 @@ class ClusterNodeGroupOptions(dict):
             suggest = "node_associate_public_ip_address"
         elif key == "nodePublicKey":
             suggest = "node_public_key"
+        elif key == "nodeRootVolumeDeleteOnTermination":
+            suggest = "node_root_volume_delete_on_termination"
+        elif key == "nodeRootVolumeEncrypted":
+            suggest = "node_root_volume_encrypted"
+        elif key == "nodeRootVolumeIops":
+            suggest = "node_root_volume_iops"
         elif key == "nodeRootVolumeSize":
             suggest = "node_root_volume_size"
+        elif key == "nodeRootVolumeThroughput":
+            suggest = "node_root_volume_throughput"
+        elif key == "nodeRootVolumeType":
+            suggest = "node_root_volume_type"
         elif key == "nodeSecurityGroup":
             suggest = "node_security_group"
         elif key == "nodeSubnetIds":
@@ -281,7 +291,12 @@ class ClusterNodeGroupOptions(dict):
                  min_size: Optional[int] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[str] = None,
+                 node_root_volume_delete_on_termination: Optional[bool] = None,
+                 node_root_volume_encrypted: Optional[bool] = None,
+                 node_root_volume_iops: Optional[int] = None,
                  node_root_volume_size: Optional[int] = None,
+                 node_root_volume_throughput: Optional[int] = None,
+                 node_root_volume_type: Optional[str] = None,
                  node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
                  node_subnet_ids: Optional[Sequence[str]] = None,
                  node_user_data: Optional[str] = None,
@@ -346,7 +361,12 @@ class ClusterNodeGroupOptions(dict):
         :param str node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
                https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
                If not provided, no SSH access is enabled on VMs.
+        :param bool node_root_volume_delete_on_termination: Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        :param bool node_root_volume_encrypted: Whether to encrypt a cluster node's root volume. Defaults to false.
+        :param int node_root_volume_iops: The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
         :param int node_root_volume_size: The size in GiB of a cluster node's root volume. Defaults to 20.
+        :param int node_root_volume_throughput: Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        :param str node_root_volume_type: Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
         :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
@@ -406,8 +426,18 @@ class ClusterNodeGroupOptions(dict):
             pulumi.set(__self__, "node_associate_public_ip_address", node_associate_public_ip_address)
         if node_public_key is not None:
             pulumi.set(__self__, "node_public_key", node_public_key)
+        if node_root_volume_delete_on_termination is not None:
+            pulumi.set(__self__, "node_root_volume_delete_on_termination", node_root_volume_delete_on_termination)
+        if node_root_volume_encrypted is not None:
+            pulumi.set(__self__, "node_root_volume_encrypted", node_root_volume_encrypted)
+        if node_root_volume_iops is not None:
+            pulumi.set(__self__, "node_root_volume_iops", node_root_volume_iops)
         if node_root_volume_size is not None:
             pulumi.set(__self__, "node_root_volume_size", node_root_volume_size)
+        if node_root_volume_throughput is not None:
+            pulumi.set(__self__, "node_root_volume_throughput", node_root_volume_throughput)
+        if node_root_volume_type is not None:
+            pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
         if node_subnet_ids is not None:
@@ -619,12 +649,52 @@ class ClusterNodeGroupOptions(dict):
         return pulumi.get(self, "node_public_key")
 
     @property
+    @pulumi.getter(name="nodeRootVolumeDeleteOnTermination")
+    def node_root_volume_delete_on_termination(self) -> Optional[bool]:
+        """
+        Whether the root block device should be deleted on termination of the instance. Defaults to true.
+        """
+        return pulumi.get(self, "node_root_volume_delete_on_termination")
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeEncrypted")
+    def node_root_volume_encrypted(self) -> Optional[bool]:
+        """
+        Whether to encrypt a cluster node's root volume. Defaults to false.
+        """
+        return pulumi.get(self, "node_root_volume_encrypted")
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeIops")
+    def node_root_volume_iops(self) -> Optional[int]:
+        """
+        The amount of provisioned IOPS. This is only valid with a volumeType of 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_iops")
+
+    @property
     @pulumi.getter(name="nodeRootVolumeSize")
     def node_root_volume_size(self) -> Optional[int]:
         """
         The size in GiB of a cluster node's root volume. Defaults to 20.
         """
         return pulumi.get(self, "node_root_volume_size")
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeThroughput")
+    def node_root_volume_throughput(self) -> Optional[int]:
+        """
+        Provisioned throughput performance in integer MiB/s for a cluster node's root volume. This is only valid with a volumeType of 'gp3'.
+        """
+        return pulumi.get(self, "node_root_volume_throughput")
+
+    @property
+    @pulumi.getter(name="nodeRootVolumeType")
+    def node_root_volume_type(self) -> Optional[str]:
+        """
+        Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'.
+        """
+        return pulumi.get(self, "node_root_volume_type")
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")


### PR DESCRIPTION
### Proposed changes

Update schema to expose the nodeRootVolume fields that is already present in Typescript.

- Exposed existing fields to schema and regenerated SDKs
- Added a new nodegroup in Python to test `gp3` volume type
- Manually inspecting created cluster from Python test to verify gp3 is created

### Related issues (optional)

Fixes: #895
Fixes: #677
Fixes: #784
Fixes: #718