### PR TITLE
Specify the version for the `VpcCni` and `RandomSuffix` resources

### DIFF
--- a/nodejs/eks/cmd/provider/index.ts
+++ b/nodejs/eks/cmd/provider/index.ts
@@ -26,6 +26,7 @@ import {
 import { randomSuffixProviderFactory } from "./randomSuffix";
 import { nodeGroupSecurityGroupProviderFactory } from "./securitygroup";
 import { managedAddonProviderFactory } from "./addon";
+import * as utilities from "../../utilities";
 
 class Provider implements pulumi.provider.Provider {
     // A map of types to provider factories. Calling a factory may return a new instance each
@@ -182,13 +183,7 @@ export function main(args: string[]) {
     const schema: string = readFileSync(require.resolve("./schema.json"), {
         encoding: "utf-8",
     });
-    let version: string = require("../../package.json").version;
-    // Node allows for the version to be prefixed by a "v",
-    // while semver doesn't. If there is a v, strip it off.
-    if (version.startsWith("v")) {
-        version = version.slice(1);
-    }
-
+    const version = utilities.getVersion();
     return pulumi.provider.main(new Provider(version, schema), args);
 }
 

--- a/nodejs/eks/cni.ts
+++ b/nodejs/eks/cni.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+import * as utilities from "./utilities";
 
 /**
  * VpcCniOptions describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes.
@@ -230,11 +231,12 @@ export class VpcCni extends pulumi.CustomResource {
         args?: VpcCniOptions,
         opts?: pulumi.CustomResourceOptions,
     ) {
-        // This was previously implemented as a dynamic provider, so alias the old type.
-        const aliasOpts = {
+        const defaultOpts = {
+            version: utilities.getVersion(),
+            // This was previously implemented as a dynamic provider, so alias the old type.
             aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }],
         };
-        opts = pulumi.mergeOptions(opts, aliasOpts);
+        opts = pulumi.mergeOptions(opts, defaultOpts);
         super(
             "eks:index:VpcCni",
             name,

--- a/nodejs/eks/randomSuffix.ts
+++ b/nodejs/eks/randomSuffix.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
+import * as utilities from "./utilities";
 
 // Dynamic providers don't currently work well with multi-language components [1]. To workaround this, the
 // dynamic providers in this library have been ported to be custom resources implemented by the new provider
@@ -29,11 +30,12 @@ class RandomSuffix extends pulumi.CustomResource {
     public readonly output!: pulumi.Output<string>;
 
     constructor(name: string, input: string, opts?: pulumi.CustomResourceOptions) {
-        // This was previously implemented as a dynamic provider, so alias the old type.
-        const aliasOpts = {
+        const defaultOpts = {
+            version: utilities.getVersion(),
+            // This was previously implemented as a dynamic provider, so alias the old type.
             aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }],
         };
-        opts = pulumi.mergeOptions(opts, aliasOpts);
+        opts = pulumi.mergeOptions(opts, defaultOpts);
         super(
             "eks:index:RandomSuffix",
             name,

--- a/nodejs/eks/utilities.ts
+++ b/nodejs/eks/utilities.ts
@@ -1,0 +1,24 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @internal */
+export function getVersion(): string {
+    let version = require("./package.json").version;
+    // Node allows for the version to be prefixed by a "v", while semver doesn't.
+    // If there is a v, strip it off.
+    if (version.indexOf("v") === 0) {
+        version = version.slice(1);
+    }
+    return version;
+}


### PR DESCRIPTION
We were not passing the version for these, which causes the system to try to look-up the latest version to install the plugin, which can fail when run from GitHub actions.

This change passes the version in with the resource options the same way as in generated provider SDKs.

More details: https://github.com/pulumi/pulumi-eks/issues/1189#issuecomment-2156135938

Fixes #1125
Fixes #1189