### PR TITLE
Fix ManagedNodeGroup for cluster with API authentication mode

### DIFF
--- a/examples/custom-managed-nodegroup/index.ts
+++ b/examples/custom-managed-nodegroup/index.ts
@@ -23,7 +23,13 @@ const cluster = new eks.Cluster("example-managed-nodegroup", {
   publicSubnetIds: eksVpc.publicSubnetIds,
   // Private subnets will be used for cluster nodes
   privateSubnetIds: eksVpc.privateSubnetIds,
-  instanceRoles: [instanceRole],
+  authenticationMode: eks.AuthenticationMode.API,
+  accessEntries: {
+    instanceRole: {
+      principalArn: instanceRole.arn,
+      type: eks.AccessEntryType.EC2_LINUX,
+    }
+  }
 });
 
 // Export the cluster's kubeconfig.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Adding a ManagedNodeGroup to a cluster with API authentication mode fails because there's verification logic that expects the role for the EC2 instances to be present in the instanceRoles list of the cluster.
If the necessary authentication configuration for the EC2 instances was added as access entries, this verification will fail.

This change fixes that by excluding this check in case the cluster supports access entries.
### Related issues (optional)

fixes #1197
