### PR TITLE
Remove ClusterInternal reference in typescript provider

### DIFF
--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -84,10 +84,10 @@ const coredns = new eks.Addon("coredns", {
 });
 
 // Export the clusters' kubeconfig.
-export const kubeconfig1 = cluster1.kubeconfig;
-export const kubeconfig2 = cluster2.kubeconfig;
-export const kubeconfig3 = cluster3.kubeconfig;
-export const kubeconfig4 = cluster4.kubeconfig;
+export const kubeconfig1: pulumi.Output<any> = cluster1.kubeconfig;
+export const kubeconfig2: pulumi.Output<any> = cluster2.kubeconfig;
+export const kubeconfig3: pulumi.Output<any> = cluster3.kubeconfig;
+export const kubeconfig4: pulumi.Output<any> = cluster4.kubeconfig;
 
 // export the IAM Role ARN of the cluster
-export const iamRoleArn = cluster1.core.clusterIamRole.arn;
+export const iamRoleArn: pulumi.Output<string> = cluster1.core.clusterIamRole.arn;

--- a/examples/cluster/package.json
+++ b/examples/cluster/package.json
@@ -8,5 +8,8 @@
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/awsx": "^2.0.2",
         "@pulumi/eks": "latest"
+    },
+    "scripts": {
+        "build": "tsc"
     }
 }

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -43,6 +43,7 @@ func TestAccCluster(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "./cluster"),
 			RunUpdateTest: false,
+			RunBuild:      true, // ensure that we can transpile the TypeScript program
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
 				utils.RunEKSSmokeTest(t,
 					info.Deployment.Resources,

--- a/nodejs/eks/addon.ts
+++ b/nodejs/eks/addon.ts
@@ -14,7 +14,7 @@
 
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import { Cluster, ClusterInternal } from "./cluster";
+import { Cluster } from "./cluster";
 
 /**
  * AddonOptions describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes. This is obtained from
@@ -23,7 +23,7 @@ import { Cluster, ClusterInternal } from "./cluster";
  */
 export interface AddonOptions
     extends Omit<aws.eks.AddonArgs, "resolveConflicts" | "clusterName" | "configurationValues"> {
-    cluster: Cluster | ClusterInternal;
+    cluster: Cluster;
     configurationValues?: object;
 }
 


### PR DESCRIPTION
### Proposed changes

The ClusterInternal type is a internal TS type. When users attempt to transpile their typescript programs to javascript, they'll encounter a symbol not found error, since internal types won't be exposed in the type annotations file. `ClusterInternal` isn't necessary since its used for MLC codegen, so this will not be a breaking change.

#### Testing:

- Updated existing typescript test to also run the build step

### Related issues (optional)

Fixes: #1205
