### PR TITLE
Fix undefined panic when using `.map`

### DIFF
--- a/examples/cluster-py/step2/__main__.py
+++ b/examples/cluster-py/step2/__main__.py
@@ -1,0 +1,115 @@
+import pulumi
+import pulumi_aws as aws
+import pulumi_eks as eks
+
+from vpc import Vpc
+
+project_name = pulumi.get_project()
+
+# Create an EKS cluster with the default configuration.
+cluster1 = eks.Cluster(f"{project_name}-1")
+
+# Create an EKS cluster with a non-default configuration.
+# TODO specify tags: { "Name": f"{project_name}-2" }
+vpc = Vpc(f"{project_name}-2")
+
+cluster2 = eks.Cluster('eks-cluster',
+                          vpc_id=vpc.vpc_id,
+                          public_subnet_ids=vpc.public_subnet_ids,
+                          public_access_cidrs=['0.0.0.0/0'],
+                          desired_capacity=2,
+                          min_size=2,
+                          max_size=2,
+                          instance_type='t3.micro',
+                          # set storage class.
+                          storage_classes={"gp2": eks.StorageClassArgs(
+                              type='gp2', allow_volume_expansion=True, default=True, encrypted=True,)},
+                          enabled_cluster_log_types=[
+                              "api",
+                              "audit",
+                              "authenticator",
+                          ],)
+
+iam_role = aws.iam.Role(
+    f"{project_name}-role",
+    assume_role_policy=pulumi.Output.json_dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            }
+        }]
+    })
+)
+
+cluster3 = eks.Cluster(f"{project_name}-3",
+                            vpc_id=vpc.vpc_id,
+                            public_subnet_ids=vpc.public_subnet_ids,
+                            node_group_options=eks.ClusterNodeGroupOptionsArgs(
+                                desired_capacity=1,
+                                min_size=1,
+                                max_size=1,
+                                instance_type="t3.small"
+                            ),
+                            authentication_mode=eks.AuthenticationMode.API_AND_CONFIG_MAP,
+                            access_entries={
+                                f'{project_name}-role': eks.AccessEntryArgs(
+                                    principal_arn=iam_role.arn, kubernetes_groups=["test-group"], access_policies={
+                                        'view': eks.AccessPolicyAssociationArgs(
+                                            policy_arn="arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy",
+                                            access_scope=aws.eks.AccessPolicyAssociationAccessScopeArgs(namespaces=["default", "application"], type="namespace")
+                                        )
+                                    }
+                                )
+                            }
+)
+
+##########################
+###     EKS Addons     ###
+##########################
+
+coredns = eks.Addon(
+    f"{project_name}-cluster3-coredns",
+    cluster=cluster3,
+    addon_name="coredns",
+    addon_version="v1.11.1-eksbuild.9",
+    resolve_conflicts_on_update="PRESERVE",
+    configuration_values={
+    "replicaCount": 4,
+    "resources": {
+      "limits": {
+        "cpu": "100m",
+        "memory": "150Mi",
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "150Mi",
+      },
+    },
+  },
+)
+
+
+##############################
+###     MNG Panic Test     ###
+##############################
+
+# Create a managed node group and attach it to a cluster using ConfigMap auth.
+# Do not add the role to the cluster's aws-auth ConfigMap and we should expect this to fail.
+managed_node_group_infra = eks.ManagedNodeGroup("mng-panic-test",
+    cluster=cluster2,
+    subnet_ids=vpc.private_subnet_ids,
+    node_role=iam_role,
+    scaling_config=aws.eks.NodeGroupScalingConfigArgs(
+        desired_size=1,
+        min_size=1,
+        max_size=1,
+    ),
+)
+
+# Export the clusters' kubeconfig.
+pulumi.export("kubeconfig1", cluster1.kubeconfig)
+pulumi.export("kubeconfig2", cluster2.kubeconfig)
+pulumi.export("kubeconfig3", cluster3.kubeconfig)

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -83,6 +83,7 @@ func TestAccClusterPy(t *testing.T) {
 				{
 					Dir:           path.Join(getCwd(t), "cluster-py", "step2"),
 					ExpectFailure: true,
+					Additive:      true,
 					Stderr:        &output,
 					Stdout:        &output,
 					ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1195,7 +1195,8 @@ ${customUserData}
             if (nodeRootVolumeType === "gp3" && nodeRootVolumeThroughput) {
                 if (!numeric.test(nodeRootVolumeThroughput?.toString())) {
                     throw new pulumi.ResourceError(
-                        "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.", parent
+                        "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
+                        parent,
                     );
                 }
             }
@@ -1681,7 +1682,7 @@ function createManagedNodeGroupInternal(
     const nodegroupRole = pulumi.all([core.instanceRoles, roleArn]).apply(([roles, rArn]) => {
         // Map out the ARNs of all of the instanceRoles. Note that the roles array may be undefined if
         // unspecified by the Pulumi program.
-        let roleArns: pulumi.Output<string>[] = roles ? roles.map((role) => role.arn) : [];
+        const roleArns: pulumi.Output<string>[] = roles ? roles.map((role) => role.arn) : [];
 
         // Try finding the nodeRole in the ARNs array.
         return pulumi.all([roleArns, rArn]).apply(([arns, arn]) => {

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -571,7 +571,7 @@ function createNodeGroupInternal(
 ): NodeGroupData {
     const instanceProfile = core.apply((c) => {
         if (!args.instanceProfile && !c.nodeGroupOptions.instanceProfile) {
-            throw new Error(`an instanceProfile is required`);
+            throw new pulumi.ResourceError(`an instanceProfile is required`, parent);
         }
         return args.instanceProfile ?? c.nodeGroupOptions.instanceProfile!;
     });
@@ -582,21 +582,23 @@ function createNodeGroupInternal(
                 c.nodeSecurityGroupTags &&
                 c.nodeGroupOptions.nodeSecurityGroup.id !== args.nodeSecurityGroup.id
             ) {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     `The NodeGroup's nodeSecurityGroup and the cluster option nodeSecurityGroupTags are mutually exclusive. Choose a single approach`,
+                    parent,
                 );
             }
         }
     });
 
     if (args.nodePublicKey && args.keyName) {
-        throw new Error(
+        throw new pulumi.ResourceError(
             "nodePublicKey and keyName are mutually exclusive. Choose a single approach",
+            parent,
         );
     }
 
     if (args.amiId && args.gpu) {
-        throw new Error("amiId and gpu are mutually exclusive.");
+        throw new pulumi.ResourceError("amiId and gpu are mutually exclusive.", parent);
     }
 
     if (
@@ -607,8 +609,9 @@ function createNodeGroupInternal(
             args.kubeletExtraArgs ||
             args.bootstrapExtraArgs)
     ) {
-        throw new Error(
+        throw new pulumi.ResourceError(
             "nodeUserDataOverride and any combination of {nodeUserData, labels, taints, kubeletExtraArgs, or bootstrapExtraArgs} is mutually exclusive.",
+            parent,
         );
     }
 
@@ -630,8 +633,9 @@ function createNodeGroupInternal(
     if (args.nodeSecurityGroup) {
         nodeSecurityGroup = args.nodeSecurityGroup;
         if (eksClusterIngressRule === undefined) {
-            throw new Error(
+            throw new pulumi.ResourceError(
                 `invalid args for node group ${name}, clusterIngressRule is required when nodeSecurityGroup is manually specified`,
+                parent,
             );
         }
     } else {
@@ -763,29 +767,33 @@ ${customUserData}
         .all([args.nodeRootVolumeIops, args.nodeRootVolumeType, args.nodeRootVolumeThroughput])
         .apply(([nodeRootVolumeIops, nodeRootVolumeType, nodeRootVolumeThroughput]) => {
             if (nodeRootVolumeIops && nodeRootVolumeType !== "io1") {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     "Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).",
+                    parent,
                 );
             }
 
             if (nodeRootVolumeType === "io1" && nodeRootVolumeIops) {
                 if (!numeric.test(nodeRootVolumeIops?.toString())) {
-                    throw new Error(
+                    throw new pulumi.ResourceError(
                         "Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.",
+                        parent,
                     );
                 }
             }
 
             if (nodeRootVolumeThroughput && nodeRootVolumeType !== "gp3") {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     "Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).",
+                    parent,
                 );
             }
 
             if (nodeRootVolumeType === "gp3" && nodeRootVolumeThroughput) {
                 if (!numeric.test(nodeRootVolumeThroughput?.toString())) {
-                    throw new Error(
+                    throw new pulumi.ResourceError(
                         "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
+                        parent,
                     );
                 }
             }
@@ -914,8 +922,9 @@ ${customUserData}
 
     const autoScalingGroupName = cfnStack.outputs.apply((outputs) => {
         if (!("NodeGroup" in outputs)) {
-            throw new Error(
+            throw new pulumi.ResourceError(
                 "CloudFormation stack is not ready. Stack output key 'NodeGroup' does not exist.",
+                parent,
             );
         }
         return outputs["NodeGroup"];
@@ -954,7 +963,7 @@ function createNodeGroupV2Internal(
 ): NodeGroupV2Data {
     const instanceProfileArn = core.apply((c) => {
         if (!args.instanceProfile && !c.nodeGroupOptions.instanceProfile) {
-            throw new Error(`an instanceProfile is required`);
+            throw new pulumi.ResourceError(`an instanceProfile is required`, parent);
         }
         return args.instanceProfile?.arn ?? c.nodeGroupOptions.instanceProfile!.arn;
     });
@@ -965,21 +974,23 @@ function createNodeGroupV2Internal(
                 c.nodeSecurityGroupTags &&
                 c.nodeGroupOptions.nodeSecurityGroup.id !== args.nodeSecurityGroup.id
             ) {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     `The NodeGroup's nodeSecurityGroup and the cluster option nodeSecurityGroupTags are mutually exclusive. Choose a single approach`,
+                    parent,
                 );
             }
         }
     });
 
     if (args.nodePublicKey && args.keyName) {
-        throw new Error(
+        throw new pulumi.ResourceError(
             "nodePublicKey and keyName are mutually exclusive. Choose a single approach",
+            parent,
         );
     }
 
     if (args.amiId && args.gpu) {
-        throw new Error("amiId and gpu are mutually exclusive.");
+        throw new pulumi.ResourceError("amiId and gpu are mutually exclusive.", parent);
     }
 
     if (
@@ -990,8 +1001,9 @@ function createNodeGroupV2Internal(
             args.kubeletExtraArgs ||
             args.bootstrapExtraArgs)
     ) {
-        throw new Error(
+        throw new pulumi.ResourceError(
             "nodeUserDataOverride and any combination of {nodeUserData, labels, taints, kubeletExtraArgs, or bootstrapExtraArgs} is mutually exclusive.",
+            parent,
         );
     }
 
@@ -1013,8 +1025,9 @@ function createNodeGroupV2Internal(
     if (args.nodeSecurityGroup) {
         nodeSecurityGroup = args.nodeSecurityGroup;
         if (eksClusterIngressRule === undefined) {
-            throw new Error(
+            throw new pulumi.ResourceError(
                 `invalid args for node group ${name}, clusterIngressRule is required when nodeSecurityGroup is manually specified`,
+                parent,
             );
         }
     } else {
@@ -1157,29 +1170,32 @@ ${customUserData}
         .all([args.nodeRootVolumeIops, args.nodeRootVolumeType, args.nodeRootVolumeThroughput])
         .apply(([nodeRootVolumeIops, nodeRootVolumeType, nodeRootVolumeThroughput]) => {
             if (nodeRootVolumeIops && nodeRootVolumeType !== "io1") {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     "Cannot create a cluster node root volume of non-io1 type with provisioned IOPS (nodeRootVolumeIops).",
+                    parent,
                 );
             }
 
             if (nodeRootVolumeType === "io1" && nodeRootVolumeIops) {
                 if (!numeric.test(nodeRootVolumeIops?.toString())) {
-                    throw new Error(
+                    throw new pulumi.ResourceError(
                         "Cannot create a cluster node root volume of io1 type without provisioned IOPS (nodeRootVolumeIops) as integer value.",
+                        parent,
                     );
                 }
             }
 
             if (nodeRootVolumeThroughput && nodeRootVolumeType !== "gp3") {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     "Cannot create a cluster node root volume of non-gp3 type with provisioned throughput (nodeRootVolumeThroughput).",
+                    parent,
                 );
             }
 
             if (nodeRootVolumeType === "gp3" && nodeRootVolumeThroughput) {
                 if (!numeric.test(nodeRootVolumeThroughput?.toString())) {
-                    throw new Error(
-                        "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.",
+                    throw new pulumi.ResourceError(
+                        "Cannot create a cluster node root volume of gp3 type without provisioned throughput (nodeRootVolumeThroughput) as integer value.", parent
                     );
                 }
             }
@@ -1637,12 +1653,17 @@ function createManagedNodeGroupInternal(
 ): aws.eks.NodeGroup {
     // Compute the nodegroup role.
     if (!args.nodeRole && !args.nodeRoleArn) {
-        throw new Error(`An IAM role, or role ARN must be provided to create a managed node group`);
+        // throw new pulumi.ResourceError(`An IAM role, or role ARN must be provided to create a managed node group`);
+        throw new pulumi.ResourceError(
+            `An IAM role, or role ARN must be provided to create a managed node group`,
+            parent,
+        );
     }
 
     if (args.nodeRole && args.nodeRoleArn) {
-        throw new Error(
+        throw new pulumi.ResourceError(
             "nodeRole and nodeRoleArn are mutually exclusive to create a managed node group",
+            parent,
         );
     }
 
@@ -1652,7 +1673,7 @@ function createManagedNodeGroupInternal(
     } else if (args.nodeRole) {
         roleArn = pulumi.output(args.nodeRole).apply((r) => r.arn);
     } else {
-        throw new Error("The managed node group role provided is undefined");
+        throw new pulumi.ResourceError("The managed node group role provided is undefined", parent);
     }
 
     // Check that the nodegroup role has been set on the cluster to
@@ -1661,7 +1682,7 @@ function createManagedNodeGroupInternal(
         // Map out the ARNs of all of the instanceRoles. Note that the roles array may be undefined if
         // unspecified by the Pulumi program.
         let roleArns: pulumi.Output<string>[] = roles ? roles.map((role) => role.arn) : [];
-        
+
         // Try finding the nodeRole in the ARNs array.
         return pulumi.all([roleArns, rArn]).apply(([arns, arn]) => {
             return arns.find((a) => a === arn);
@@ -1673,8 +1694,9 @@ function createManagedNodeGroupInternal(
         .apply(([authMode, role]) => {
             // access entries can be added out of band, so we don't require them to be set in the cluster.
             if (!supportsAccessEntries(authMode) && !role) {
-                throw new Error(
+                throw new pulumi.ResourceError(
                     `A managed node group cannot be created without first setting its role in the cluster's instanceRoles`,
+                    parent,
                 );
             }
         });
@@ -1710,8 +1732,9 @@ function createManagedNodeGroupInternal(
         args.launchTemplate &&
         (args.kubeletExtraArgs || args.bootstrapExtraArgs || args.enableIMDSv2)
     ) {
-        throw new Error(
+        throw new pulumi.ResourceError(
             "If you provide a custom launch template, you cannot provide kubeletExtraArgs, bootstrapExtraArgs or enableIMDSv2. Please include these in the launch template that you are providing.",
+            parent,
         );
     }
 
@@ -1874,7 +1897,7 @@ const ec2InstanceRegex = /([a-z]+)([0-9]+)([a-z])?\-?([a-z]+)?\.([a-zA-Z0-9\-]+)
 export function isGravitonInstance(instanceType: string): boolean {
     const match = instanceType.toString().match(ec2InstanceRegex);
     if (!match) {
-        throw new Error(`Invalid EC2 instance type: ${instanceType}`);
+        throw new pulumi.ResourceError(`Invalid EC2 instance type: ${instanceType}`, undefined);
     }
 
     const processorFamily = match[3];

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1658,10 +1658,10 @@ function createManagedNodeGroupInternal(
     // Check that the nodegroup role has been set on the cluster to
     // ensure that the aws-auth configmap was properly formed.
     const nodegroupRole = pulumi.all([core.instanceRoles, roleArn]).apply(([roles, rArn]) => {
-        // Map out the ARNs of all of the instanceRoles.
-        const roleArns = roles.map((role) => {
-            return role.arn;
-        });
+        // Map out the ARNs of all of the instanceRoles. Note that the roles array may be undefined if
+        // unspecified by the Pulumi program.
+        let roleArns: pulumi.Output<string>[] = roles ? roles.map((role) => role.arn) : [];
+        
         // Try finding the nodeRole in the ARNs array.
         return pulumi.all([roleArns, rArn]).apply(([arns, arn]) => {
             return arns.find((a) => a === arn);


### PR DESCRIPTION
### Proposed changes

Adds an `undefined` guard before attempting to use `.map()`. This is due to MLC programs being able to send `undefined` instead of an empty array.

This PR also updates the error handling to throw `pulumi.ResourceError` instead of a generic nodejs error.

### Related issues (optional)


Fixes: #1202
