### PR TITLE
Relax validations on eks.Cluster instance_roles

### DIFF
--- a/nodejs/eks/authenticationMode.test.ts
+++ b/nodejs/eks/authenticationMode.test.ts
@@ -70,7 +70,7 @@ describe("validateAuthenticationMode", () => {
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
-            "The 'instanceRoles' property is not supported when 'authenticationMode' is set to 'API'.",
+            "The 'instanceRoles' property does not support non-empty values when 'authenticationMode' is set to 'API'.",
         );
     });
 

--- a/nodejs/eks/authenticationMode.test.ts
+++ b/nodejs/eks/authenticationMode.test.ts
@@ -18,10 +18,21 @@ import {
     validateAuthenticationMode,
 } from "./authenticationMode";
 
+import {
+    ClusterOptions, AuthenticationMode
+} from "./cluster";
+
+import * as aws from "@pulumi/aws";
+
 describe("validateAuthenticationMode", () => {
+
+    const testRole: aws.iam.Role = (<any>{"arn": "testRole"});
+
     it("should throw an error for invalid authentication mode", () => {
-        const args = {
-            authenticationMode: "INVALID_MODE",
+        const invalidMode: any = "INVALID_MODE";
+
+        const args: ClusterOptions = {
+            authenticationMode: invalidMode,
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
@@ -30,7 +41,7 @@ describe("validateAuthenticationMode", () => {
     });
 
     it("should throw an error for roleMappings when authentication mode is set to API", () => {
-        const args = {
+        const args: ClusterOptions = {
             authenticationMode: "API",
             roleMappings: [
                 {
@@ -47,7 +58,7 @@ describe("validateAuthenticationMode", () => {
     });
 
     it("should throw an error for userMappings when authentication mode is set to API", () => {
-        const args = {
+        const args: ClusterOptions = {
             authenticationMode: "API",
             userMappings: [
                 {
@@ -64,9 +75,9 @@ describe("validateAuthenticationMode", () => {
     });
 
     it("should throw an error for instanceRoles when authentication mode is set to API", () => {
-        const args = {
+        const args: ClusterOptions = {
             authenticationMode: "API",
-            instanceRoles: ["roleArn"],
+            instanceRoles: [testRole],
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
@@ -75,7 +86,7 @@ describe("validateAuthenticationMode", () => {
     });
 
     it("should not throw an error for instanceRoles=[] when authentication mode is set to API", () => {
-        const args = {
+        const args: ClusterOptions = {
             authenticationMode: "API",
             instanceRoles: [],
         };
@@ -85,13 +96,13 @@ describe("validateAuthenticationMode", () => {
     });
 
     it("should throw an error for accessEntries when authentication mode is set to CONFIG_MAP", () => {
-        const args = {
+        const args: ClusterOptions = {
             authenticationMode: "CONFIG_MAP",
-            accessEntries: [
-                {
+            accessEntries: {
+                "entry1": {
                     principalArn: "roleArn",
                 },
-            ],
+            },
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
@@ -101,11 +112,11 @@ describe("validateAuthenticationMode", () => {
 
     it("should throw an error for accessEntries when authentication mode is not set", () => {
         const args = {
-            accessEntries: [
-                {
+            accessEntries: {
+                "entry1": {
                     principalArn: "roleArn",
                 },
-            ],
+            },
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
@@ -113,7 +124,7 @@ describe("validateAuthenticationMode", () => {
         );
     });
 
-    test.each([
+    const cases: ClusterOptions[][] = [
         [
             {
                 authenticationMode: "CONFIG_MAP",
@@ -131,7 +142,7 @@ describe("validateAuthenticationMode", () => {
                         username: "test-role",
                     },
                 ],
-                instanceRoles: ["roleArn"],
+                instanceRoles: [testRole],
             },
         ],
         [
@@ -151,22 +162,22 @@ describe("validateAuthenticationMode", () => {
                         username: "test-role",
                     },
                 ],
-                instanceRoles: ["roleArn"],
-                accessEntries: [
-                    {
+                instanceRoles: [testRole],
+                accessEntries: {
+                    "entry1": {
                         principalArn: "roleArn",
                     },
-                ],
+                },
             },
         ],
         [
             {
                 authenticationMode: "API",
-                accessEntries: [
-                    {
+                accessEntries: {
+                    "entry1": {
                         principalArn: "roleArn",
                     },
-                ],
+                },
             },
         ],
         [
@@ -184,7 +195,9 @@ describe("validateAuthenticationMode", () => {
                 authenticationMode: "API_AND_CONFIG_MAP",
             },
         ],
-    ])("should not throw an error for valid authentication mode and properties", (args) => {
+    ];
+
+    test.each(cases)("should not throw an error for valid authentication mode and properties", (args) => {
         expect(() => validateAuthenticationMode(args)).not.toThrow();
     });
 });

--- a/nodejs/eks/authenticationMode.test.ts
+++ b/nodejs/eks/authenticationMode.test.ts
@@ -74,6 +74,16 @@ describe("validateAuthenticationMode", () => {
         );
     });
 
+    it("should not throw an error for instanceRoles=[] when authentication mode is set to API", () => {
+        const args = {
+            authenticationMode: "API",
+            instanceRoles: [],
+        };
+
+        // This should not throw exceptions:
+        validateAuthenticationMode(args);
+    });
+
     it("should throw an error for accessEntries when authentication mode is set to CONFIG_MAP", () => {
         const args = {
             authenticationMode: "CONFIG_MAP",

--- a/nodejs/eks/authenticationMode.test.ts
+++ b/nodejs/eks/authenticationMode.test.ts
@@ -42,7 +42,7 @@ describe("validateAuthenticationMode", () => {
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
-            "The 'roleMappings' property is not supported when 'authenticationMode' is set to 'API'.",
+            "The 'roleMappings' property does not support non-empty values when 'authenticationMode' is set to 'API'.",
         );
     });
 
@@ -59,7 +59,7 @@ describe("validateAuthenticationMode", () => {
         };
 
         expect(() => validateAuthenticationMode(args)).toThrowError(
-            "The 'userMappings' property is not supported when 'authenticationMode' is set to 'API'.",
+            "The 'userMappings' property does not support non-empty values when 'authenticationMode' is set to 'API'.",
         );
     });
 

--- a/nodejs/eks/authenticationMode.ts
+++ b/nodejs/eks/authenticationMode.ts
@@ -45,7 +45,7 @@ export function validateAuthenticationMode(args: ClusterOptions) {
         configMapOnlyProperties.forEach((prop) => {
             const arg: any = args[prop];
             if (arg) {
-                // Permit empty roleMappings as a specialCase.
+                // Permit empty instanceRoles as a specialCase.
                 if ((arg.length === 0) && prop === "instanceRoles") {
                     return;
                 }

--- a/nodejs/eks/authenticationMode.ts
+++ b/nodejs/eks/authenticationMode.ts
@@ -36,7 +36,7 @@ export function validateAuthenticationMode(rawArgs: ClusterOptions): ClusterOpti
     }
 
     if (!supportsConfigMap(args.authenticationMode)) {
-        const checkDefined: (prop: string) => (propertyValue: any|undefined) => void = (prop) => (pv) => {
+        const checkDefined: (prop: keyof ClusterOptions) => (propertyValue: any|undefined) => void = (prop) => (pv) => {
             if (pv !== undefined) {
                 throw new Error(
                     `The '${prop}' property is not supported when 'authenticationMode' is set to '${args.authenticationMode}'.`,

--- a/nodejs/eks/authenticationMode.ts
+++ b/nodejs/eks/authenticationMode.ts
@@ -36,7 +36,7 @@ export function validateAuthenticationMode(rawArgs: ClusterOptions): ClusterOpti
     }
 
     if (!supportsConfigMap(args.authenticationMode)) {
-        const check: (prop: string) => (propertyValue: any|undefined) => void = (prop) => (pv) => {
+        const checkDefined: (prop: string) => (propertyValue: any|undefined) => void = (prop) => (pv) => {
             if (pv !== undefined) {
                 throw new Error(
                     `The '${prop}' property is not supported when 'authenticationMode' is set to '${args.authenticationMode}'.`,
@@ -44,8 +44,8 @@ export function validateAuthenticationMode(rawArgs: ClusterOptions): ClusterOpti
             }
         };
 
-        args.roleMappings = validatedInput(args.roleMappings, check("roleMappings"));
-        args.userMappings = validatedInput(args.userMappings, check("userMappings"));
+        args.roleMappings = validatedInput(args.roleMappings, checkDefined("roleMappings"));
+        args.userMappings = validatedInput(args.userMappings, checkDefined("userMappings"));
 
         // InstanceRoles is special as it permits empty values to pass through.
         args.instanceRoles = validatedInput(args.instanceRoles, pv => {

--- a/nodejs/eks/authenticationMode.ts
+++ b/nodejs/eks/authenticationMode.ts
@@ -43,7 +43,13 @@ export function validateAuthenticationMode(args: ClusterOptions) {
 
     if (!supportsConfigMap(args.authenticationMode)) {
         configMapOnlyProperties.forEach((prop) => {
-            if (args[prop]) {
+            const arg: any = args[prop];
+            if (arg) {
+                // Permit empty roleMappings as a specialCase.
+                if ((arg.length === 0) && prop === "instanceRoles") {
+                    return;
+                }
+
                 throw new Error(
                     `The '${prop}' property is not supported when 'authenticationMode' is set to '${args.authenticationMode}'.`,
                 );

--- a/nodejs/eks/authenticationMode.ts
+++ b/nodejs/eks/authenticationMode.ts
@@ -36,26 +36,18 @@ export function validateAuthenticationMode(rawArgs: ClusterOptions): ClusterOpti
     }
 
     if (!supportsConfigMap(args.authenticationMode)) {
-        const checkDefined: (prop: keyof ClusterOptions) => (propertyValue: any|undefined) => void = (prop) => (pv) => {
-            if (pv !== undefined) {
+        const checkNonEmpty: (prop: keyof ClusterOptions) => (_: any|undefined) => void = (prop) => (pv) => {
+            if (pv !== undefined && pv.length !== 0) {
                 throw new Error(
-                    `The '${prop}' property is not supported when 'authenticationMode' is set to '${args.authenticationMode}'.`,
+                    `The '${prop}' property does not support non-empty values when 'authenticationMode' is set to `+
+                        `'${args.authenticationMode}'.`,
                 );
             }
         };
 
-        args.roleMappings = validatedInput(args.roleMappings, checkDefined("roleMappings"));
-        args.userMappings = validatedInput(args.userMappings, checkDefined("userMappings"));
-
-        // InstanceRoles is special as it permits empty values to pass through.
-        args.instanceRoles = validatedInput(args.instanceRoles, pv => {
-            if (pv !== undefined && pv.length !== 0) {
-                throw new Error(
-                    `The 'instanceRoles' property does not support non-empty values when 'authenticationMode' is set `+
-                        `to '${args.authenticationMode}'.`,
-                );
-            }
-        });
+        args.roleMappings = validatedInput(args.roleMappings, checkNonEmpty("roleMappings"));
+        args.userMappings = validatedInput(args.userMappings, checkNonEmpty("userMappings"));
+        args.instanceRoles = validatedInput(args.instanceRoles, checkNonEmpty("instanceRoles"));
     }
 
     if (!supportsAccessEntries(args.authenticationMode)) {

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -396,7 +396,7 @@ export function getRoleProvider(
  */
 export function createCore(
     name: string,
-    args: ClusterOptions,
+    rawArgs: ClusterOptions,
     parent: pulumi.ComponentResource,
     provider?: pulumi.ProviderResource,
 ): CoreData {
@@ -407,7 +407,7 @@ export function createCore(
     // k8s resources later.
     assertCompatibleKubectlVersionExists();
 
-    validateAuthenticationMode(args);
+    const args = validateAuthenticationMode(rawArgs);
 
     if (args.instanceRole && args.instanceRoles) {
         throw new Error(

--- a/nodejs/eks/tsconfig.json
+++ b/nodejs/eks/tsconfig.json
@@ -33,6 +33,10 @@
         "cmd/provider/index.ts",
         "cmd/provider/nodegroup.ts",
         "cmd/provider/randomSuffix.ts",
-        "cmd/provider/securitygroup.ts"
+        "cmd/provider/securitygroup.ts",
+
+        "authenticationMode.test.ts",
+        "dependencies.test.ts",
+        "nodegroup.test.ts",
     ]
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"fmt"
 	"github.com/pulumi/providertest"
 	"github.com/pulumi/providertest/optproviderupgrade"
 	"github.com/pulumi/providertest/pulumitest"
@@ -87,6 +88,50 @@ func TestExamplesUpgrades(t *testing.T) {
 
 func TestReportUpgradeCoverage(t *testing.T) {
 	providertest.ReportUpgradeCoverage(t)
+}
+
+func TestEksClusterInputValidations(t *testing.T) {
+	props := []string{"instanceRoles", "roleMappings", "userMappings"}
+	for _, p := range props {
+		for n := 0; n < 2; n++ {
+			t.Run(fmt.Sprintf("%s_%d", p, n), func(t *testing.T) {
+				checkEksClusterInputValidations(t, p, n, n > 0)
+			})
+		}
+	}
+}
+
+func checkEksClusterInputValidations(t *testing.T, property string, n int, expectFailure bool) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	dir := filepath.Join("test-programs", "cluster-input-validations")
+	options := []opttest.Option{
+		opttest.LocalProviderPath("eks", filepath.Join(cwd, "..", "bin")),
+		opttest.YarnLink("@pulumi/eks"),
+	}
+	tw := &testWrapper{PT: t, expectFailure: expectFailure}
+	test := pulumitest.NewPulumiTest(tw, dir, options...)
+	test.SetConfig("property", property)
+	test.SetConfig("n", fmt.Sprintf("%d", n))
+	test.Preview()
+	if expectFailure {
+		require.Truef(t, tw.failed, "Expected preview to fail due to invalid inputs but it succeeded")
+	}
+}
+
+type testWrapper struct {
+	pulumitest.PT
+	expectFailure bool
+	failed        bool
+}
+
+func (tw *testWrapper) FailNow() {
+	if tw.expectFailure {
+		tw.PT.Log("Ignoring expected FailNow()")
+		tw.failed = true
+	} else {
+		tw.PT.FailNow()
+	}
 }
 
 func testProviderUpgrade(t *testing.T, example string) {

--- a/provider/test-programs/cluster-input-validations/.gitignore
+++ b/provider/test-programs/cluster-input-validations/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/provider/test-programs/cluster-input-validations/Pulumi.yaml
+++ b/provider/test-programs/cluster-input-validations/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: cluster-input-validations
+runtime:
+  name: nodejs
+  options:
+    packagemanager: npm
+description: A minimal AWS TypeScript Pulumi program
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/provider/test-programs/cluster-input-validations/index.ts
+++ b/provider/test-programs/cluster-input-validations/index.ts
@@ -1,0 +1,59 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+
+const cfg = new pulumi.Config();
+
+const property: string = cfg.require("property");
+const n: number = cfg.requireNumber("n");
+
+const testRole = new aws.iam.Role("test_role", {
+    name: "test_role",
+    assumeRolePolicy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Sid: "",
+            Principal: {
+                Service: "ec2.amazonaws.com",
+            },
+        }],
+    })
+});
+
+function asOutput<T>(x: T): pulumi.Output<T> {
+    const p = new Promise<number>(resolve => setTimeout(() => resolve(0), 10));
+    return pulumi.output(p).apply(_ => x);
+}
+
+const opts: eks.ClusterOptions = {
+    nodeAmiId: "ami-0384725f0d30527c7",
+    authenticationMode: "API",
+};
+
+const testARN: aws.ARN = "arn";
+
+if (property === "instanceRoles") {
+    if (n === 0) {
+        opts.instanceRoles = asOutput([]);
+    } else if (n == 1) {
+        opts.instanceRoles = asOutput([testRole]);
+    }
+} else if (property == "userMappings") {
+    if (n == 0) {
+        opts.userMappings = asOutput([]);
+    } else if (n == 1) {
+        opts.userMappings = asOutput([{userArn: testARN, username: "u", groups: []}]);
+    }
+} else if (property == "roleMappings") {
+    if (n == 0) {
+        opts.roleMappings = asOutput([]);
+    } else if (n == 1) {
+        opts.roleMappings = asOutput([{roleArn: testARN, username: "u", groups: []}]);
+    }
+}
+
+const cluster = new eks.Cluster("c", opts);
+
+export const kubeconfigJson = cluster.kubeconfigJson

--- a/provider/test-programs/cluster-input-validations/package.json
+++ b/provider/test-programs/cluster-input-validations/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "cluster-input-validations",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/eks": "^2.7.3",
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/provider/test-programs/cluster-input-validations/tsconfig.json
+++ b/provider/test-programs/cluster-input-validations/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This change allows a program to set empty `instance_roles=[]` on an eks.Cluster with custom `authentication_mode` without triggering a warning on these properties being incompatible.

roleMappings and userMappings are treated symmetrically.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Fixes #1220  