### PR TITLE
skipLibCheck for examples/cluster

### DIFF
--- a/examples/cluster/tsconfig.json
+++ b/examples/cluster/tsconfig.json
@@ -16,7 +16,8 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true,
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "skipLibCheck": true
     },
     "files": [
         "index.ts"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This change instructs TypeScript to avoid re-checking node_modules (dependencies) in the examples/cluster.

### Related issues (optional)

This partially addresses https://github.com/pulumi/pulumi-eks/issues/1258

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
