### PR TITLE
Remove google-protobuf override

### DIFF
--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -44,11 +44,6 @@
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.6.2"
     },
-    "overrides": {
-      "@pulumi/pulumi": {
-        "google-protobuf": "3.21.4"
-      }
-    },
     "pulumi": {
         "resource": true
     },


### PR DESCRIPTION
It may be sufficient to have the updated version in the yarn.lock file without hard-coding the dependency as a constraint in package.json file.

Fixes changes introduced in https://github.com/pulumi/pulumi-eks/pull/1262

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
