### PR TITLE
ci: consistently run build_sdk for golang

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -193,6 +193,7 @@ jobs:
           - python
           - dotnet
           - java
+          - go
   test-nodejs:
     name: Run NodeJS Tests
     needs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -193,6 +193,7 @@ jobs:
           - python
           - dotnet
           - java
+          - go
   publish:
     name: publish
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
           - python
           - dotnet
           - java
+          - go
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest


### PR DESCRIPTION
The build_sdk matrix was running for Go in some scenarios but not on cron, master, release. Specifically for release.yml this caused release failures since the workflows now assume that there is a step generating go.sdk.tar.gz artifact.

