### PR TITLE
Fix typo in Download Go SDK path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -702,7 +702,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: go-sdk.tar.gz
-          path: $${{ github.workspace }}/sdk/
+          path: ${{ github.workspace }}/sdk/
       - name: Uncompress Go SDK
         run: tar -zxf ${{ github.workspace }}/sdk/go.tar.gz -C
           ${{ github.workspace }}/sdk/go


### PR DESCRIPTION
It appears that in PR verification we use `${{ github.workspace }}/sdk/` syntax but in release.yml we used `${{ github.workspace }}/sdk/` syntax which broke the alpha release. Trying the consistent syntax here.
