### PR TITLE
Allow using user provided version for retrieving node group AMIs

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -811,3 +811,21 @@ func TestAccManagedNodeGroupCustom(t *testing.T) {
 
 	integration.ProgramTest(t, &test)
 }
+
+func TestAccManagedNodeGroupWithVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "tests", "managed-ng-with-version"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}

--- a/examples/tests/managed-ng-with-version/Pulumi.yaml
+++ b/examples/tests/managed-ng-with-version/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: managed-ng-with-version
+description: Tests that the versions of managed node groups can be configured
+runtime: nodejs

--- a/examples/tests/managed-ng-with-version/README.md
+++ b/examples/tests/managed-ng-with-version/README.md
@@ -1,0 +1,3 @@
+# tests/managed-ng-with-version
+
+Tests that the versions of managed node groups can be configured

--- a/examples/tests/managed-ng-with-version/iam.ts
+++ b/examples/tests/managed-ng-with-version/iam.ts
@@ -1,0 +1,40 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import * as iam from "./iam";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+];
+
+// Creates a role and attaches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}
+
+// Creates a collection of IAM roles.
+export function createRoles(name: string, quantity: number): aws.iam.Role[] {
+    const roles: aws.iam.Role[] = [];
+
+    for (let i = 0; i < quantity; i++) {
+        roles.push(iam.createRole(`${name}-role-${i}`));
+    }
+
+    return roles;
+}

--- a/examples/tests/managed-ng-with-version/index.ts
+++ b/examples/tests/managed-ng-with-version/index.ts
@@ -1,0 +1,45 @@
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as iam from "./iam";
+
+// IAM roles for the node groups.
+const role0 = iam.createRole("example-role0");
+const role1 = iam.createRole("example-role1");
+
+// Create a new VPC
+const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
+    enableDnsHostnames: true,
+    cidrBlock: "10.0.0.0/16",
+});
+
+// Create an EKS cluster.
+const cluster = new eks.Cluster("example-managed-nodegroups", {
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    vpcId: eksVpc.vpcId,
+    // Public subnets will be used for load balancers
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    // Private subnets will be used for cluster nodes
+    privateSubnetIds: eksVpc.privateSubnetIds,
+    instanceRoles: [role0, role1],
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+// Managed node group with parameters that cause a custom launch template to be created
+const managedNodeGroup0 = eks.createManagedNodeGroup("example-managed-ng0", {
+    cluster: cluster,
+    nodeRole: role0,
+    kubeletExtraArgs: "--max-pods=500",
+    enableIMDSv2: true,
+    version: cluster.eksCluster.version,
+}, cluster);
+
+// Simple managed node group
+const managedNodeGroup1 = eks.createManagedNodeGroup("example-managed-ng1", {
+    cluster: cluster,
+    nodeGroupName: "aws-managed-ng1",
+    nodeRoleArn: role1.arn,
+    version: cluster.eksCluster.version,
+}, cluster);

--- a/examples/tests/managed-ng-with-version/package.json
+++ b/examples/tests/managed-ng-with-version/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "managed-ng-with-version",
+    "devDependencies": {
+        "typescript": "^4.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/examples/tests/managed-ng-with-version/tsconfig.json
+++ b/examples/tests/managed-ng-with-version/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
Previously the user provided kubernetes version wasn't used when
looking up the AMI for a node group. Instead the cluster version
was used implicitely.
This fixes that and allows users to specify the kubernetes version.
This also allows users now to upgrade their cluster control plane
and node groups in multiple steps.

### Related issues (optional)
Fixes #1283 1283

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
