### PR TITLE
Fix ManagedNodeGroup instances not registering with EKS when using enableIMDSv2

### DIFF
--- a/examples/managed-nodegroups/index.ts
+++ b/examples/managed-nodegroups/index.ts
@@ -6,7 +6,6 @@ import * as iam from "./iam";
 const role0 = iam.createRole("example-role0");
 const role1 = iam.createRole("example-role1");
 const role2 = iam.createRole("example-role2");
-const role3 = iam.createRole("example-role3");
 
 // Create a new VPC
 const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
@@ -23,7 +22,7 @@ const cluster = new eks.Cluster("example-managed-nodegroups", {
   publicSubnetIds: eksVpc.publicSubnetIds,
   // Private subnets will be used for cluster nodes
   privateSubnetIds: eksVpc.privateSubnetIds,
-  instanceRoles: [role0, role1, role2, role3],
+  instanceRoles: [role0, role1, role2],
 });
 
 // Export the cluster's kubeconfig.
@@ -74,6 +73,6 @@ const managedNodeGroup2 = eks.createManagedNodeGroup(
 // Create a simple AWS managed node group with IMDSv2 enabled
 const managedNodeGroup3 = eks.createManagedNodeGroup("example-managed-ng3", {
   cluster: cluster,
-  nodeRole: role3,
+  nodeRole: role2,
   enableIMDSv2: true,
 });

--- a/examples/managed-nodegroups/index.ts
+++ b/examples/managed-nodegroups/index.ts
@@ -6,6 +6,7 @@ import * as iam from "./iam";
 const role0 = iam.createRole("example-role0");
 const role1 = iam.createRole("example-role1");
 const role2 = iam.createRole("example-role2");
+const role3 = iam.createRole("example-role3");
 
 // Create a new VPC
 const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
@@ -22,7 +23,7 @@ const cluster = new eks.Cluster("example-managed-nodegroups", {
   publicSubnetIds: eksVpc.publicSubnetIds,
   // Private subnets will be used for cluster nodes
   privateSubnetIds: eksVpc.privateSubnetIds,
-  instanceRoles: [role0, role1, role2],
+  instanceRoles: [role0, role1, role2, role3],
 });
 
 // Export the cluster's kubeconfig.
@@ -69,3 +70,10 @@ const managedNodeGroup2 = eks.createManagedNodeGroup(
   },
   cluster
 );
+
+// Create a simple AWS managed node group with IMDSv2 enabled
+const managedNodeGroup3 = eks.createManagedNodeGroup("example-managed-ng3", {
+  cluster: cluster,
+  nodeRole: role3,
+  enableIMDSv2: true,
+});

--- a/examples/tests/managed-ng-with-version/index.ts
+++ b/examples/tests/managed-ng-with-version/index.ts
@@ -5,6 +5,7 @@ import * as iam from "./iam";
 // IAM roles for the node groups.
 const role0 = iam.createRole("example-role0");
 const role1 = iam.createRole("example-role1");
+const role2 = iam.createRole("example-role2");
 
 // Create a new VPC
 const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
@@ -21,7 +22,7 @@ const cluster = new eks.Cluster("example-managed-nodegroups", {
     publicSubnetIds: eksVpc.publicSubnetIds,
     // Private subnets will be used for cluster nodes
     privateSubnetIds: eksVpc.privateSubnetIds,
-    instanceRoles: [role0, role1],
+    instanceRoles: [role0, role1, role2],
 });
 
 // Export the cluster's kubeconfig.
@@ -42,4 +43,12 @@ const managedNodeGroup1 = eks.createManagedNodeGroup("example-managed-ng1", {
     nodeGroupName: "aws-managed-ng1",
     nodeRoleArn: role1.arn,
     version: cluster.eksCluster.version,
+}, cluster);
+
+// Managed node group with IMDSv2 enabled
+const managedNodeGroup2 = eks.createManagedNodeGroup("example-managed-ng2", {
+    cluster: cluster,
+    nodeRole: role2,
+    version: cluster.eksCluster.version,
+    enableIMDSv2: true,
 }, cluster);

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1742,7 +1742,10 @@ function createManagedNodeGroupInternal(
     let launchTemplate: aws.ec2.LaunchTemplate | undefined;
     if (args.kubeletExtraArgs || args.bootstrapExtraArgs || args.enableIMDSv2) {
         launchTemplate = createMNGCustomLaunchTemplate(name, args, core, parent, provider);
-        // EKS doesn't allow setting the kubernetes version in the node group if a custom launch template is used.
+    }
+
+    if (launchTemplate?.imageId) {
+        // EKS doesn't allow setting the kubernetes version in the node group if an image id is provided within the launch template.
         delete nodeGroupArgs.version;
     }
 
@@ -1843,9 +1846,9 @@ Content-Type: text/x-shellscript; charset="us-ascii"
         {
             userData,
             metadataOptions,
-            // We need to always supply an imageId, otherwise AWS will attempt to merge the user data which will result in
+            // We need to supply an imageId if userData is set, otherwise AWS will attempt to merge the user data which will result in
             // nodes failing to join the cluster.
-            imageId: getRecommendedAMI(args, core.cluster.version, parent),
+            imageId: userData ? getRecommendedAMI(args, core.cluster.version, parent) : undefined,
         },
         { parent, provider },
     );


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

When creating a `ManagedNodeGroup` with `enableIMDSv2` set to true and no
`kubeletExtraArgs` or `bootstrapExtraArgs` the userdata script is not being created.
This causes the EC2 instances to not register with the EKS cluster.

EKS does not use its default userdata because the Launch Template always specifies
an AMI ID right now ([see AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data) for more details). The userdata script is what actually starts the kubelet and
registers the node with the EKS cluster.

This change fixes it by only setting the AMI ID if a custom userdata script is provided
in the launch template.

### Related issues (optional)
Fixes #1285 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
