### PR TITLE
chore: IgnoreDestroyErrors is set for all tests in CI

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -38,7 +38,7 @@ func TestAccClusterCs(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func getCSBaseOptions(t *testing.T) integration.ProgramTestOptions {

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -52,7 +52,7 @@ func TestAccClusterGo(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 	// Ensure that the provider error message is as expected.
 	assert.Contains(t, stdErr.String(), "not supported")
 }
@@ -74,7 +74,7 @@ func TestAccExtraSecurityGroupsGo(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func getGoBaseOptions(t *testing.T) integration.ProgramTestOptions {

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -106,7 +106,7 @@ func TestAccCluster(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccKubernetesServiceIPv4RangeForCluster(t *testing.T) {
@@ -122,7 +122,7 @@ func TestAccKubernetesServiceIPv4RangeForCluster(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccFargate(t *testing.T) {
@@ -143,7 +143,7 @@ func TestAccFargate(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccNodeGroup(t *testing.T) {
@@ -168,7 +168,7 @@ func TestAccNodeGroup(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccManagedNodeGroup(t *testing.T) {
@@ -184,7 +184,7 @@ func TestAccManagedNodeGroup(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccMNG_withMissingRole(t *testing.T) {
@@ -197,7 +197,7 @@ func TestAccMNG_withMissingRole(t *testing.T) {
 			Quick:            true,
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccMNG_withAwsAuth(t *testing.T) {
@@ -224,7 +224,7 @@ func TestAccMNG_withAwsAuth(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccTags(t *testing.T) {
@@ -240,7 +240,7 @@ func TestAccTags(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccStorageClasses(t *testing.T) {
@@ -256,7 +256,7 @@ func TestAccStorageClasses(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccOidcIam(t *testing.T) {
@@ -271,7 +271,7 @@ func TestAccOidcIam(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccScopedKubeconfig(t *testing.T) {
@@ -287,7 +287,7 @@ func TestAccScopedKubeconfig(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccAwsProfile(t *testing.T) {
@@ -309,7 +309,7 @@ func TestAccAwsProfile(t *testing.T) {
 			NoParallel: true,
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccAwsProfileRole(t *testing.T) {
@@ -324,7 +324,7 @@ func TestAccAwsProfileRole(t *testing.T) {
 			},
 			NoParallel: true,
 		})
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccEncryptionProvider(t *testing.T) {
@@ -342,7 +342,7 @@ func TestAccEncryptionProvider(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccExtraSecurityGroups(t *testing.T) {
@@ -360,7 +360,7 @@ func TestAccExtraSecurityGroups(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccReplaceSecGroup(t *testing.T) {
@@ -385,7 +385,7 @@ func TestAccReplaceSecGroup(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccReplaceClusterAddSubnets(t *testing.T) {
@@ -409,7 +409,7 @@ func TestAccReplaceClusterAddSubnets(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccTagInputTypes(t *testing.T) {
@@ -427,7 +427,7 @@ func TestAccTagInputTypes(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccNodegroupOptions(t *testing.T) {
@@ -442,7 +442,7 @@ func TestAccNodegroupOptions(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccImportDefaultEksSecgroup(t *testing.T) {
@@ -472,7 +472,7 @@ func TestAccImportDefaultEksSecgroup(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccVpcSubnetTags(t *testing.T) {
@@ -490,7 +490,7 @@ func TestAccVpcSubnetTags(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccMigrateNodeGroups(t *testing.T) {
@@ -615,7 +615,7 @@ func TestAccMigrateNodeGroups(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
@@ -705,7 +705,7 @@ func TestAccAuthenticationMode(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccMultiRole(t *testing.T) {
@@ -724,7 +724,7 @@ func TestAccMultiRole(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccAuthenticationModeMigration(t *testing.T) {
@@ -778,7 +778,7 @@ func TestAccAuthenticationModeMigration(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccManagedNodeGroupCustom(t *testing.T) {
@@ -809,7 +809,7 @@ func TestAccManagedNodeGroupCustom(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccManagedNodeGroupWithVersion(t *testing.T) {
@@ -827,5 +827,5 @@ func TestAccManagedNodeGroupWithVersion(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -46,7 +46,7 @@ func TestAccAwsProfilePy(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccAwsProfileRolePy(t *testing.T) {
@@ -61,7 +61,7 @@ func TestAccAwsProfileRolePy(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccClusterPy(t *testing.T) {
@@ -96,14 +96,7 @@ func TestAccClusterPy(t *testing.T) {
 			},
 		})
 
-	programTestWithExtraOptions(t, programTestExtraOptions{
-		ProgramTestOptions: test,
-
-		// TODO[pulumi/pulumi-eks#1226]: Deleting an eks.Cluster may fail with DependencyViolation on nodeSecurityGroup
-		// Try destroying the cluster to keep the test account clean but do not fail the test if it fails to destroy.
-		// This weakens the test but makes CI deterministic.
-		IgnoreDestroyErrors: true,
-	})
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccFargatePy(t *testing.T) {
@@ -119,7 +112,7 @@ func TestAccFargatePy(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccNodeGroupPy(t *testing.T) {
@@ -137,7 +130,7 @@ func TestAccNodeGroupPy(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func TestAccManagedNodeGroupPy(t *testing.T) {
@@ -153,7 +146,7 @@ func TestAccManagedNodeGroupPy(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	programTestWithExtraOptions(t, &test, nil)
 }
 
 func getPythonBaseOptions(t *testing.T) integration.ProgramTestOptions {


### PR DESCRIPTION
### Proposed changes

To stabilize CI the IgnoreDestroyErrors option is now set on all the tests, not just the Python Cluster test. This can be removed once the underlying problem with dangling ENIs is fixed and `pulumi destroy` can be relied on for eks.Cluster resources.


### Related issues (optional)

Fixes #1222 
