### PR TITLE
Combined GitHub Action dependency upgrades

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,6 +17,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint actions
-        uses: reviewdog/action-actionlint@v1.43.0
+        uses: reviewdog/action-actionlint@v1.54.0
         with:
           actionlint_flags: "-config-file .actionlint.yml"

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Build
-        uses: peter-evans/slash-command-dispatch@v2
+        uses: peter-evans/slash-command-dispatch@v4
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -141,7 +141,7 @@ jobs:
           node-version-file: .node-version
           registry-url: https://registry.npmjs.org
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -147,7 +147,7 @@ jobs:
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v3.5.0
         with:
           gradle-version: "7.6"
       - name: Install Yarn

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -147,7 +147,7 @@ jobs:
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v3.5.0
         with:
           gradle-version: "7.6"
       - name: Install Yarn
@@ -335,7 +335,7 @@ jobs:
       - name: Uncompress Java SDK folder
         run: tar -zxf ${{ github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
       - name: Publish Java SDK
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
           build-root-directory: ./sdk/java

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -141,7 +141,7 @@ jobs:
           node-version-file: .node-version
           registry-url: https://registry.npmjs.org
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin
@@ -322,7 +322,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHONVERSION }}
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin

--- a/.github/workflows/record.yml
+++ b/.github/workflows/record.yml
@@ -104,7 +104,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Setup Java
         if: matrix.language == 'java'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin

--- a/.github/workflows/record.yml
+++ b/.github/workflows/record.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/action-install-pulumi-cli@v2.0.0
       - name: Build provider binary + schema
         run: make schema provider
       - name: Check worktree clean
@@ -88,7 +88,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/action-install-pulumi-cli@v2.0.0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -181,7 +181,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
+        uses: pulumi/action-install-pulumi-cli@v2.0.0
       - name: Install gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
         with:

--- a/.github/workflows/record.yml
+++ b/.github/workflows/record.yml
@@ -111,7 +111,7 @@ jobs:
           java-version: ${{ env.JAVAVERSION }}
       - name: Setup Gradle
         if: matrix.language == 'java'
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v3.5.0
         with:
           gradle-version: "7.6"
       - name: Install Yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           node-version-file: .node-version
           registry-url: https://registry.npmjs.org
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin
@@ -326,7 +326,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHONVERSION }}
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v3.5.0
         with:
           gradle-version: "7.6"
       - name: Install Yarn
@@ -339,7 +339,7 @@ jobs:
       - name: Uncompress Java SDK folder
         run: tar -zxf ${{ github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
       - name: Publish Java SDK
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
           build-root-directory: ./sdk/java

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -267,7 +267,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
+        uses: pulumi/action-install-pulumi-cli@v2.0.0
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -184,7 +184,7 @@ jobs:
           distribution: temurin
           java-version: ${{ env.JAVAVERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v3.5.0
         with:
           gradle-version: "7.6"
       - name: Install Yarn

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -178,7 +178,7 @@ jobs:
           node-version-file: .node-version
           registry-url: https://registry.npmjs.org
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           cache: gradle
           distribution: temurin


### PR DESCRIPTION
- **Bump actions/setup-java from 3 to 4**
- **Bump reviewdog/action-actionlint from 1.43.0 to 1.54.0**
- **Bump pulumi/action-install-pulumi-cli from 1.0.1 to 2.0.0**
- **Bump peter-evans/slash-command-dispatch from 2 to 4**
- **Bump gradle/gradle-build-action from 2.12.0 to 3.5.0**

Combines:
- #1272 
- #1252 
- #1251 
- #1250 
- #1249
