### PR TITLE
Udate cron and master github workflows

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -276,36 +276,22 @@ jobs:
         run: |
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
+        with:
+          working-directory: examples
+          flags: -tags=nodejs
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=nodejs
+        run: cd examples && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
-        test-name:
-          - AwsProfile
-          - AuthenticationMode
-          - Cluster
-          - CNIAcrossUpdates
-          - EncryptionProvider
-          - ExtraSecurityGroups
-          - Fargate
-          - ImportDefaultEksSecgroup
-          - KubernetesServiceIPv4RangeForCluster
-          - ManagedNodeGroup
-          - MigrateNodeGroups
-          - MNG_withAwsAuth
-          - MNG_withMissingRole
-          - MultiRole
-          - NodeGroup
-          - NodegroupOptions
-          - OidcIam
-          - ReplaceClusterAddSubnets
-          - ReplaceSecGroup
-          - ScopedKubeconfig
-          - StorageClasses
-          - TagInputTypes
-          - Tags
-          - VpcSubnetTags
+        total: [15]
+        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
   test-python:
     name: Run Python Tests
     needs:
@@ -401,18 +387,21 @@ jobs:
         run: |
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
+        with:
+          working-directory: examples
+          flags: -tags=python
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=python
+        run: cd examples && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
       matrix:
-        test-name:
-          - AwsProfilePy
-          - AwsProfileRolePy
-          - ClusterPy
-          - FargatePy
-          - NodeGroupPy
-          - ManagedNodeGroupPy
+        total: [6]
+        index: [0, 1, 2, 3, 4, 5]
   test-dotnet:
     name: Run DotNet Tests
     needs:
@@ -510,12 +499,103 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=dotnet
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - ClusterCs
+        run: cd examples && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+  test-go:
+    name: Run Go Tests
+    needs:
+      - prerequisites
+      - build_sdk
+    runs-on: ubuntu-latest
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.12.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v5
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNETVERSION }}
+      - name: Download provider binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+          }}/bin
+      - name: Restore binary perms
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+          -exec chmod +x {} \;
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download NodeJS SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: nodejs-sdk.tar.gz
+          path: ${{ github.workspace}}
+      - name: Uncompress NodeJS SDK folder
+        run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
+      - name: Install NodeJS SDK
+        run: make install_nodejs_sdk
+      - name: Install gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
+      - name: Download Go SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: go-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress Go SDK folder
+        run: tar -zxf ${{ github.workspace}}/sdk/go.tar.gz -C ${{github.workspace}}/sdk/go
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 7200
+          role-session-name: ${{ env.PROVIDER }}@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Configure AWS CLI
+        run: |
+          aws configure set default.aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set default.aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set aws_access_key_id ${{ secrets.ALT_AWS_ACCESS_KEY_ID }} --profile ${{ secrets.ALT_AWS_PROFILE }}
+          aws configure set aws_secret_access_key ${{ secrets.ALT_AWS_SECRET_ACCESS_KEY }} --profile ${{ secrets.ALT_AWS_PROFILE }}
+      - name: Link nodejs binary for testing
+        run: |
+          cd ${{ github.workspace }}/bin
+          yarn install && yarn link @pulumi/eks
+      - name: Run tests
+        run: cd examples && go test -tags=go -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 name: cron
 "on":
   schedule:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -201,6 +201,7 @@ jobs:
       - test-nodejs
       - test-python
       - test-dotnet
+      - test-go
     runs-on: ubuntu-latest
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
@@ -422,36 +423,22 @@ jobs:
         run: |
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
+        with:
+          working-directory: examples
+          flags: -tags=nodejs
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=nodejs
+        run: cd examples && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
-        test-name:
-          - AwsProfile
-          - AuthenticationMode
-          - Cluster
-          - CNIAcrossUpdates
-          - EncryptionProvider
-          - ExtraSecurityGroups
-          - Fargate
-          - ImportDefaultEksSecgroup
-          - KubernetesServiceIPv4RangeForCluster
-          - ManagedNodeGroup
-          - MigrateNodeGroups
-          - MNG_withAwsAuth
-          - MNG_withMissingRole
-          - MultiRole
-          - NodeGroup
-          - NodegroupOptions
-          - OidcIam
-          - ReplaceClusterAddSubnets
-          - ReplaceSecGroup
-          - ScopedKubeconfig
-          - StorageClasses
-          - TagInputTypes
-          - Tags
-          - VpcSubnetTags
+        total: [15]
+        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
   test-python:
     name: Run Python Tests
     needs:
@@ -547,18 +534,22 @@ jobs:
         run: |
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
+        with:
+          working-directory: examples
+          flags: -tags=python
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=python
+        run: cd examples && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
-        test-name:
-          - AwsProfilePy
-          - AwsProfileRolePy
-          - ClusterPy
-          - FargatePy
-          - NodeGroupPy
-          - ManagedNodeGroupPy
+        total: [6]
+        index: [0, 1, 2, 3, 4, 5]
   test-dotnet:
     name: Run DotNet Tests
     needs:
@@ -656,12 +647,103 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: make specific_test TestName=${{ matrix.test-name }} LanguageTags=dotnet
-    strategy:
-      fail-fast: false
-      matrix:
-        test-name:
-          - ClusterCs
+        run: cd examples && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+  test-go:
+    name: Run Go Tests
+    needs:
+      - prerequisites
+      - build_sdk
+    runs-on: ubuntu-latest
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.12.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v5
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
+      - name: Install awscli
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli --upgrade
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNETVERSION }}
+      - name: Download provider binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run:
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+          }}/bin
+      - name: Restore binary perms
+        run:
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
+          -exec chmod +x {} \;
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
+      - name: Download NodeJS SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: nodejs-sdk.tar.gz
+          path: ${{ github.workspace}}
+      - name: Uncompress NodeJS SDK folder
+        run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
+      - name: Install NodeJS SDK
+        run: make install_nodejs_sdk
+      - name: Install gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
+      - name: Download Go SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: go-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress Go SDK folder
+        run: tar -zxf ${{ github.workspace}}/sdk/go.tar.gz -C ${{github.workspace}}/sdk/go
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 7200
+          role-session-name: ${{ env.PROVIDER }}@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Configure AWS CLI
+        run: |
+          aws configure set default.aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set default.aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set aws_access_key_id ${{ secrets.ALT_AWS_ACCESS_KEY_ID }} --profile ${{ secrets.ALT_AWS_PROFILE }}
+          aws configure set aws_secret_access_key ${{ secrets.ALT_AWS_SECRET_ACCESS_KEY }} --profile ${{ secrets.ALT_AWS_PROFILE }}
+      - name: Link nodejs binary for testing
+        run: |
+          cd ${{ github.workspace }}/bin
+          yarn install && yarn link @pulumi/eks
+      - name: Run tests
+        run: cd examples && go test -tags=go -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 name: master
 "on":
   push:


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-eks/pull/1312 the GitHub action workflows and acceptance tests were refactored and updated.
The cron and master workflows need the same updates.

In detail this includes:
- Adding go tests, they were missing :(
- introduces go-test-split-action for creating the test matrix instead of manually maintaining a list
- reduces test parallelism to roughly ~2/3 of what we had before (that's required due to EKS cluster account limits).
