### PR TITLE
Correct parameters for go-test-split-action

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -282,7 +282,7 @@ jobs:
         with:
           working-directory: examples
           flags: -tags=nodejs
-          total: ${{ matrix.parallel }}
+          total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
         run: cd examples && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
@@ -393,7 +393,7 @@ jobs:
         with:
           working-directory: examples
           flags: -tags=python
-          total: ${{ matrix.parallel }}
+          total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
         run: cd examples && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -429,7 +429,7 @@ jobs:
         with:
           working-directory: examples
           flags: -tags=nodejs
-          total: ${{ matrix.parallel }}
+          total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
         run: cd examples && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
@@ -540,7 +540,7 @@ jobs:
         with:
           working-directory: examples
           flags: -tags=python
-          total: ${{ matrix.parallel }}
+          total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
         run: cd examples && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,7 +450,7 @@ jobs:
         with:
           working-directory: examples
           flags: -tags=nodejs
-          total: ${{ matrix.parallel }}
+          total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
         run: cd examples && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
@@ -561,7 +561,7 @@ jobs:
         with:
           working-directory: examples
           flags: -tags=python
-          total: ${{ matrix.parallel }}
+          total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
         run: cd examples && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt


### PR DESCRIPTION
Accidentally copy&pasted the wrong name for one of the parameters in the go-test-split-action. The acceptance test workflow already had the correct one.
