### PR TITLE
Fix ManagedNodeGroups with custom launch templates always using x86_64 AMI

### DIFF
--- a/examples/managed-nodegroups/index.ts
+++ b/examples/managed-nodegroups/index.ts
@@ -6,6 +6,8 @@ import * as iam from "./iam";
 const role0 = iam.createRole("example-role0");
 const role1 = iam.createRole("example-role1");
 const role2 = iam.createRole("example-role2");
+const role3 = iam.createRole("example-role3");
+const role4 = iam.createRole("example-role4");
 
 // Create a new VPC
 const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
@@ -73,6 +75,15 @@ const managedNodeGroup2 = eks.createManagedNodeGroup(
 // Create a simple AWS managed node group with IMDSv2 enabled
 const managedNodeGroup3 = eks.createManagedNodeGroup("example-managed-ng3", {
   cluster: cluster,
-  nodeRole: role2,
+  nodeRole: role3,
   enableIMDSv2: true,
+});
+
+// Node Group with graviton instances
+const managedNodeGroup4 = eks.createManagedNodeGroup("example-managed-ng4", {
+  cluster: cluster,
+  nodeRole: role4,
+  kubeletExtraArgs: "--max-pods=500",
+  enableIMDSv2: true,
+  instanceTypes: ["t4g.medium"],
 });

--- a/examples/managed-nodegroups/index.ts
+++ b/examples/managed-nodegroups/index.ts
@@ -6,8 +6,6 @@ import * as iam from "./iam";
 const role0 = iam.createRole("example-role0");
 const role1 = iam.createRole("example-role1");
 const role2 = iam.createRole("example-role2");
-const role3 = iam.createRole("example-role3");
-const role4 = iam.createRole("example-role4");
 
 // Create a new VPC
 const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
@@ -75,14 +73,14 @@ const managedNodeGroup2 = eks.createManagedNodeGroup(
 // Create a simple AWS managed node group with IMDSv2 enabled
 const managedNodeGroup3 = eks.createManagedNodeGroup("example-managed-ng3", {
   cluster: cluster,
-  nodeRole: role3,
+  nodeRole: role2,
   enableIMDSv2: true,
 });
 
 // Node Group with graviton instances
 const managedNodeGroup4 = eks.createManagedNodeGroup("example-managed-ng4", {
   cluster: cluster,
-  nodeRole: role4,
+  nodeRole: role0,
   kubeletExtraArgs: "--max-pods=500",
   enableIMDSv2: true,
   instanceTypes: ["t4g.medium"],

--- a/nodejs/eks/nodegroup.test.ts
+++ b/nodejs/eks/nodegroup.test.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { isGravitonInstance } from "./nodegroup";
+import { getArchitecture } from "./nodegroup";
 
 const gravitonInstances = [
     "c6g.12xlarge",
@@ -309,6 +310,34 @@ describe("isGravitonInstance", () => {
     nonGravitonInstances.forEach((instanceType) => {
         test(`${instanceType} should return false for non-Graviton instance`, () => {
             expect(isGravitonInstance(instanceType)).toBe(false);
+        });
+    });
+    describe("getArchitecture", () => {
+        test("should return 'x86_64' when only x86_64 instances are provided", () => {
+            const instanceTypes = ["c5.large", "m5.large", "t3.large"];
+            const architecture = getArchitecture(instanceTypes);
+            expect(architecture).toBe("x86_64");
+        });
+
+        test("should return 'arm64' when only arm64 instances are provided", () => {
+            const instanceTypes = ["c6g.large", "m6g.large", "t4g.large"];
+            const architecture = getArchitecture(instanceTypes);
+            expect(architecture).toBe("arm64");
+        });
+
+        test("should throw an error when both x86_64 and arm64 instances are provided", () => {
+            const instanceTypes = ["c5.large", "c6g.large"];
+            expect(() => {
+                getArchitecture(instanceTypes);
+            }).toThrowError(
+                "Cannot determine architecture of instance types. The provided instance types do not share a common architecture",
+            );
+        });
+
+        test("should return 'x86_64' when no instance types are provided", () => {
+            const instanceTypes: string[] = [];
+            const architecture = getArchitecture(instanceTypes);
+            expect(architecture).toBe("x86_64");
         });
     });
 });

--- a/nodejs/eks/tsconfig.json
+++ b/nodejs/eks/tsconfig.json
@@ -37,6 +37,6 @@
 
         "authenticationMode.test.ts",
         "dependencies.test.ts",
-        "nodegroup.test.ts",
+        "nodegroup.test.ts"
     ]
 }


### PR DESCRIPTION
A custom launch template is created for a Node Group when `kubeletExtraArgs`, `bootstrapExtraArgs` or `enableIMDSv2` is set. In that case, the recommended AMI is retrieved from SSM Parameter Store.

The input property `instanceType` is used to select the right architecture. But `ManagedNodeGroup` doesn't have an `instanceType` input property, it has a list of `instanceTypes`.

This change fixes this by checking the `instanceTypes` property of Managed Node Groups as well.

Fixes #1323