### PR TITLE
Add formatting check to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,15 @@ build_dotnet:: schema
 		echo "${VERSION_GENERIC}" >version.txt && \
 		dotnet build
 
+lint_fix:
+	cd nodejs/eks && \
+		yarn install && \
+		yarn lint
+
 lint:
 	cd nodejs/eks && \
 		yarn install && \
-		yarn format && \
-		yarn run tslint -c ../tslint.json -p tsconfig.json
+		yarn lint-check
 
 lint_provider::
 	cd provider && golangci-lint run -c ../.golangci.yml

--- a/nodejs/eks/authenticationMode.test.ts
+++ b/nodejs/eks/authenticationMode.test.ts
@@ -18,15 +18,12 @@ import {
     validateAuthenticationMode,
 } from "./authenticationMode";
 
-import {
-    ClusterOptions, AuthenticationMode
-} from "./cluster";
+import { ClusterOptions, AuthenticationMode } from "./cluster";
 
 import * as aws from "@pulumi/aws";
 
 describe("validateAuthenticationMode", () => {
-
-    const testRole: aws.iam.Role = (<any>{"arn": "testRole"});
+    const testRole: aws.iam.Role = <any>{ arn: "testRole" };
 
     it("should throw an error for invalid authentication mode", () => {
         const invalidMode: any = "INVALID_MODE";
@@ -99,7 +96,7 @@ describe("validateAuthenticationMode", () => {
         const args: ClusterOptions = {
             authenticationMode: "CONFIG_MAP",
             accessEntries: {
-                "entry1": {
+                entry1: {
                     principalArn: "roleArn",
                 },
             },
@@ -113,7 +110,7 @@ describe("validateAuthenticationMode", () => {
     it("should throw an error for accessEntries when authentication mode is not set", () => {
         const args = {
             accessEntries: {
-                "entry1": {
+                entry1: {
                     principalArn: "roleArn",
                 },
             },
@@ -164,7 +161,7 @@ describe("validateAuthenticationMode", () => {
                 ],
                 instanceRoles: [testRole],
                 accessEntries: {
-                    "entry1": {
+                    entry1: {
                         principalArn: "roleArn",
                     },
                 },
@@ -174,7 +171,7 @@ describe("validateAuthenticationMode", () => {
             {
                 authenticationMode: "API",
                 accessEntries: {
-                    "entry1": {
+                    entry1: {
                         principalArn: "roleArn",
                     },
                 },
@@ -197,9 +194,12 @@ describe("validateAuthenticationMode", () => {
         ],
     ];
 
-    test.each(cases)("should not throw an error for valid authentication mode and properties", (args) => {
-        expect(() => validateAuthenticationMode(args)).not.toThrow();
-    });
+    test.each(cases)(
+        "should not throw an error for valid authentication mode and properties",
+        (args) => {
+            expect(() => validateAuthenticationMode(args)).not.toThrow();
+        },
+    );
 });
 
 describe("supportsConfigMap", () => {

--- a/nodejs/eks/authenticationMode.ts
+++ b/nodejs/eks/authenticationMode.ts
@@ -36,14 +36,15 @@ export function validateAuthenticationMode(rawArgs: ClusterOptions): ClusterOpti
     }
 
     if (!supportsConfigMap(args.authenticationMode)) {
-        const checkNonEmpty: (prop: keyof ClusterOptions) => (_: any|undefined) => void = (prop) => (pv) => {
-            if (pv !== undefined && pv.length !== 0) {
-                throw new Error(
-                    `The '${prop}' property does not support non-empty values when 'authenticationMode' is set to `+
-                        `'${args.authenticationMode}'.`,
-                );
-            }
-        };
+        const checkNonEmpty: (prop: keyof ClusterOptions) => (_: any | undefined) => void =
+            (prop) => (pv) => {
+                if (pv !== undefined && pv.length !== 0) {
+                    throw new Error(
+                        `The '${prop}' property does not support non-empty values when 'authenticationMode' is set to ` +
+                            `'${args.authenticationMode}'.`,
+                    );
+                }
+            };
 
         args.roleMappings = validatedInput(args.roleMappings, checkNonEmpty("roleMappings"));
         args.userMappings = validatedInput(args.userMappings, checkNonEmpty("userMappings"));
@@ -71,16 +72,16 @@ export function validateAuthenticationMode(rawArgs: ClusterOptions): ClusterOpti
 // input is gated on the validation. Unfortunately since apply always unwraps, the validate function required here needs
 // to be able to handle both unwrapped and normal forms.
 function validatedInput<T>(
-    i: pulumi.Input<T>|undefined,
-    validate: (value: T|pulumi.Unwrap<T>|undefined) => void
-): pulumi.Input<T>|undefined {
+    i: pulumi.Input<T> | undefined,
+    validate: (value: T | pulumi.Unwrap<T> | undefined) => void,
+): pulumi.Input<T> | undefined {
     if (i instanceof Promise) {
-        return pulumi.output(i).apply(value => {
+        return pulumi.output(i).apply((value) => {
             validate(value);
             return i;
         });
     } else if (pulumi.Output.isInstance(i)) {
-        return i.apply(value => {
+        return i.apply((value) => {
             validate(value);
             return i;
         });

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -9,7 +9,10 @@
         "eks"
     ],
     "scripts": {
+        "format-check": "prettier --list-different .",
         "format": "prettier --list-different --write .",
+        "lint-check": "yarn run format-check && tslint -c ../tslint.json -p tsconfig.json",
+        "lint": "yarn run format && tslint -c ../tslint.json -p tsconfig.json --fix",
         "test": "jest"
     },
     "homepage": "https://pulumi.com",


### PR DESCRIPTION
Previously CI was running the nodejs formatter in `--fix` mode, which silently corrected formatting issues. But those changes were never surfaced or made their way into the repo.

This changes first reformats the code (first commit) and then corrects the `lint` make target to check for formatting issues instead.
An additional make target for fixing up issues was added as well.

I thought about making this a pre-commit hook, but first want to check what other tools are used for managing hooks across our repos.
