### PR TITLE
Support configuring disk size of self-managed bottlerocket node groups

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -904,7 +904,7 @@ func TestAccSelfManagedNodeGroupOS(t *testing.T) {
 					info.Outputs["kubeconfig"],
 				)
 
-				assert.NoError(t, utils.ValidateNodePodCapacity(t, info.Outputs["kubeconfig"], 4, 100, "increased-storage-capacity"))
+				assert.NoError(t, utils.ValidateNodePodCapacity(t, info.Outputs["kubeconfig"], 4, 100, "increased-pod-capacity"))
 				assert.NoError(t, utils.ValidateNodeStorage(t, info.Outputs["kubeconfig"], 4, 100*1_000_000_000, "increased-storage-capacity"))
 			},
 		})

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -883,6 +883,7 @@ func TestAccManagedNodeGroupOS(t *testing.T) {
 				)
 
 				assert.NoError(t, utils.ValidateNodePodCapacity(t, info.Outputs["kubeconfig"], 4, 100, "increased-pod-capacity"))
+				assert.NoError(t, utils.ValidateNodeStorage(t, info.Outputs["kubeconfig"], 4, 100*1_000_000_000, "increased-storage-capacity"))
 			},
 		})
 
@@ -903,7 +904,8 @@ func TestAccSelfManagedNodeGroupOS(t *testing.T) {
 					info.Outputs["kubeconfig"],
 				)
 
-				assert.NoError(t, utils.ValidateNodePodCapacity(t, info.Outputs["kubeconfig"], 4, 100, "increased-pod-capacity"))
+				assert.NoError(t, utils.ValidateNodePodCapacity(t, info.Outputs["kubeconfig"], 4, 100, "increased-storage-capacity"))
+				assert.NoError(t, utils.ValidateNodeStorage(t, info.Outputs["kubeconfig"], 4, 100*1_000_000_000, "increased-storage-capacity"))
 			},
 		})
 

--- a/examples/tests/managed-ng-os/index.ts
+++ b/examples/tests/managed-ng-os/index.ts
@@ -69,8 +69,10 @@ const managedNodeGroupAL2023UserData = eks.createManagedNodeGroup("al-2023-mng-u
   operatingSystem: eks.OperatingSystem.AL2023,
   instanceTypes: ["t3.medium"],
   nodeRole: role,
+  diskSize: 100,
   labels: {
     "increased-pod-capacity": "true",
+    "increased-storage-capacity": "true",
   },
   kubeletExtraArgs: `--max-pods=${increasedPodCapacity}`,
 });
@@ -82,8 +84,10 @@ const managedNodeGroupAL2023ArmUserData = eks.createManagedNodeGroup("al-2023-ar
   operatingSystem: eks.OperatingSystem.AL2023,
   instanceTypes: ["t4g.medium"],
   nodeRole: role,
+  diskSize: 100,
   labels: {
     "increased-pod-capacity": "true",
+    "increased-storage-capacity": "true",
   },
   kubeletExtraArgs: `--max-pods=${increasedPodCapacity}`,
 });
@@ -113,8 +117,10 @@ const managedNodeGroupBottlerocketUserData = eks.createManagedNodeGroup("bottler
   operatingSystem: eks.OperatingSystem.Bottlerocket,
   instanceTypes: ["t3.medium"],
   nodeRole: role,
+  diskSize: 100,
   labels: {
     "increased-pod-capacity": "true",
+    "increased-storage-capacity": "true",
   },
   bottlerocketSettings: {
     settings: {
@@ -132,8 +138,10 @@ const managedNodeGroupBottlerocketArmUserData = eks.createManagedNodeGroup("bott
   operatingSystem: eks.OperatingSystem.Bottlerocket,
   instanceTypes: ["t4g.medium"],
   nodeRole: role,
+  diskSize: 100,
   labels: {
     "increased-pod-capacity": "true",
+    "increased-storage-capacity": "true",
   },
   bottlerocketSettings: {
     settings: {

--- a/examples/tests/self-managed-ng-os/index.ts
+++ b/examples/tests/self-managed-ng-os/index.ts
@@ -51,6 +51,16 @@ const nodeGroupAL2023V1 = new eks.NodeGroup("al-2023-v1-ng", {
   instanceProfile: instanceProfile,
 });
 
+const nodeGroupAL2023V1Storage = new eks.NodeGroup("al-2023-v1-storage-ng", {
+  ...capacity,
+  cluster: cluster,
+  instanceType: "t3.medium",
+  operatingSystem: eks.OperatingSystem.AL2023,
+  instanceProfile: instanceProfile,
+  labels: {"increased-storage-capacity": "true"},
+  nodeRootVolumeSize: 100,
+});
+
 const nodeGroupAL2023V1Userdata = new eks.NodeGroup("al-2023-v1-userdata-ng", {
   ...capacity,
   cluster: cluster,
@@ -67,6 +77,16 @@ const nodeGroupBottlerocketV1 = new eks.NodeGroup("bottlerocket-v1-ng", {
   instanceType: "t3.medium",
   operatingSystem: eks.OperatingSystem.Bottlerocket,
   instanceProfile: instanceProfile,
+});
+
+const nodeGroupBottlerocketV1Storage = new eks.NodeGroup("bottlerocket-v1-storage-ng", {
+  ...capacity,
+  cluster: cluster,
+  instanceType: "t3.medium",
+  operatingSystem: eks.OperatingSystem.Bottlerocket,
+  instanceProfile: instanceProfile,
+  labels: {"increased-storage-capacity": "true"},
+  nodeRootVolumeSize: 100,
 });
 
 const nodeGroupBottlerocketV1Userdata = new eks.NodeGroup("bottlerocket-v1-userdata-ng", {
@@ -91,6 +111,16 @@ const nodeGroupAL2023 = new eks.NodeGroupV2("al-2023-ng", {
   instanceType: "t3.medium",
   operatingSystem: eks.OperatingSystem.AL2023,
   labels: {"ondemand": "true"},
+  instanceProfile: instanceProfile,
+});
+
+const nodeGroupAL2023Storage = new eks.NodeGroupV2("al-2023-storage-ng", {
+  ...capacity,
+  cluster: cluster,
+  instanceType: "t3.medium",
+  operatingSystem: eks.OperatingSystem.AL2023,
+  nodeRootVolumeSize: 100,
+  labels: {"increased-storage-capacity": "true"},
   instanceProfile: instanceProfile,
 });
 
@@ -119,6 +149,16 @@ const nodeGroupBottlerocket = new eks.NodeGroupV2("bottlerocket-ng", {
   instanceType: "t3.medium",
   operatingSystem: eks.OperatingSystem.Bottlerocket,
   labels: {"ondemand": "true"},
+  instanceProfile: instanceProfile,
+});
+
+const nodeGroupBottlerocketStorage = new eks.NodeGroupV2("bottlerocket-storage-ng", {
+  ...capacity,
+  cluster: cluster,
+  instanceType: "t3.medium",
+  operatingSystem: eks.OperatingSystem.Bottlerocket,
+  labels: {"increased-storage-capacity": "true"},
+  nodeRootVolumeSize: 100,
   instanceProfile: instanceProfile,
 });
 

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1322,7 +1322,7 @@ function createNodeGroupV2Internal(
                     ebs: {
                         encrypted: pulumi
                             .output(args.nodeRootVolumeEncrypted)
-                            .apply((val) => (val === true ?? false ? "true" : "false")),
+                            .apply((val) => (val ? "true" : "false")),
                         volumeSize: args.nodeRootVolumeSize ?? 20, // GiB
                         volumeType: args.nodeRootVolumeType ?? "gp2",
                         iops: args.nodeRootVolumeIops,

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -894,6 +894,17 @@ function createNodeGroupInternal(
                     },
                 ],
             };
+        })
+        .apply(({ rootBlockDevice, ebsBlockDevices }) => {
+            // if no ebs settings are specified, we cannot set the blockDevice props because that would end up as a validation error
+            return {
+                rootBlockDevice: Object.values(rootBlockDevice).every((v) => v === undefined)
+                    ? {}
+                    : rootBlockDevice,
+                ebsBlockDevices: ebsBlockDevices.filter((bd) =>
+                    Object.values(bd).some((v) => v !== undefined),
+                ),
+            };
         });
 
     const nodeLaunchConfiguration = new aws.ec2.LaunchConfiguration(
@@ -1353,12 +1364,15 @@ function createNodeGroupV2Internal(
             iamInstanceProfile: { arn: instanceProfileArn },
             keyName: keyName,
             instanceMarketOptions: marketOptions,
-            blockDeviceMappings: [
-                {
-                    deviceName: deviceName,
-                    ebs: ebsSettings,
-                },
-            ],
+            // if no ebs settings are specified, we cannot set the blockDeviceMappings because that would end up as a validation error
+            blockDeviceMappings: Object.values(ebsSettings).every((v) => v === undefined)
+                ? undefined
+                : [
+                      {
+                          deviceName: deviceName,
+                          ebs: ebsSettings,
+                      },
+                  ],
             networkInterfaces: [
                 {
                     associatePublicIpAddress: String(nodeAssociatePublicIpAddress),


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

The provider wrongly assumed that an AMI only has a single block device. But Bottlerocket has two.
Bottlerocket has two block devices, the root device stores the OS itself and the other is for data like images, logs, persistent storage. We need to allow users to configure the block device for data.

With this change, the provider will choose the block device that gets modified depending on the OS. If the OS is bottlerocket, the data device gets modified.
This also adds E2E tests verifying that the node storage capacity correctly reflects user settings.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
- This builds on top of #1334
