### PR TITLE
eks.NodeGroupV2 will now autoname the autoscaling group

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -269,6 +269,12 @@ func TestAccTags(t *testing.T) {
 					info.Outputs["kubeconfig1"],
 					info.Outputs["kubeconfig2"],
 				)
+				for _, r := range info.Deployment.Resources {
+					if r.Type == "aws:autoscaling/group:Group" {
+						assert.NotEqualf(t, "example-ng-tags-ng2", string(r.ID),
+							"aws.autoscaling.Group should have an autonamed random suffix")
+					}
+				}
 			},
 		})
 

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -1298,7 +1298,6 @@ ${customUserData}
     const asGroup = new aws.autoscaling.Group(
         name,
         {
-            name: name,
             minSize: args?.minSize ?? 1,
             maxSize: args?.maxSize ?? 2,
             desiredCapacity: args?.desiredCapacity ?? 2,


### PR DESCRIPTION
### Proposed changes

Before this change, eks.NodeGroupV2 would create an aws.autoscaling.Group resource with a fixed name, and the users
would need to make sure the name does not conflict with any unrelated resources in their AWS account. After the change,
the name automatically receives a randomized suffix, making eks.NodeGroupV2 easier to use correctly.

Users with existing eks.NodeGroupV2 instances will not be affected by this change as the new provider version will
respect the names allocated by the previous version.

### Related issues


Fixes #1335
Fixes #1336