### PR TITLE
Deprecate aws-auth ConfigMap

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -1663,12 +1663,16 @@ export const AuthenticationMode = {
     API: "API",
     /**
      * Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.
+     *
      * @deprecated The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
      * For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
      */
     CONFIG_MAP: "CONFIG_MAP",
     /**
      * Both aws-auth ConfigMap and Access Entries can be used for authenticating to the Kubernetes API.
+     *
+     * @deprecated The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+     * For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
      */
     API_AND_CONFIG_MAP: "API_AND_CONFIG_MAP",
 } as const;

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -1663,6 +1663,8 @@ export const AuthenticationMode = {
     API: "API",
     /**
      * Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.
+     * @deprecated The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+     * For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
      */
     CONFIG_MAP: "CONFIG_MAP",
     /**

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1624,6 +1624,8 @@ func generateSchema() schema.PackageSpec {
 						Name:        "ConfigMap",
 						Value:       "CONFIG_MAP",
 						Description: "Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.",
+						DeprecationMessage: "The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.\n" +
+							"For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.",
 					},
 					{
 						Name:        "Api",
@@ -1634,6 +1636,8 @@ func generateSchema() schema.PackageSpec {
 						Name:        "ApiAndConfigMap",
 						Value:       "API_AND_CONFIG_MAP",
 						Description: "Both aws-auth ConfigMap and Access Entries can be used for authenticating to the Kubernetes API.",
+						DeprecationMessage: "The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.\n" +
+							"For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.",
 					},
 				},
 			},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -143,7 +143,8 @@
                 {
                     "name": "ConfigMap",
                     "description": "Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.",
-                    "value": "CONFIG_MAP"
+                    "value": "CONFIG_MAP",
+                    "deprecationMessage": "The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.\nFor more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html."
                 },
                 {
                     "name": "Api",
@@ -153,7 +154,8 @@
                 {
                     "name": "ApiAndConfigMap",
                     "description": "Both aws-auth ConfigMap and Access Entries can be used for authenticating to the Kubernetes API.",
-                    "value": "API_AND_CONFIG_MAP"
+                    "value": "API_AND_CONFIG_MAP",
+                    "deprecationMessage": "The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.\nFor more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html."
                 }
             ]
         },

--- a/sdk/dotnet/Enums.cs
+++ b/sdk/dotnet/Enums.cs
@@ -72,6 +72,8 @@ namespace Pulumi.Eks
         /// <summary>
         /// Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.
         /// </summary>
+        [Obsolete(@"The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.")]
         public static AuthenticationMode ConfigMap { get; } = new AuthenticationMode("CONFIG_MAP");
         /// <summary>
         /// Only Access Entries will be used for authenticating to the Kubernetes API.
@@ -80,6 +82,8 @@ namespace Pulumi.Eks
         /// <summary>
         /// Both aws-auth ConfigMap and Access Entries can be used for authenticating to the Kubernetes API.
         /// </summary>
+        [Obsolete(@"The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.")]
         public static AuthenticationMode ApiAndConfigMap { get; } = new AuthenticationMode("API_AND_CONFIG_MAP");
 
         public static bool operator ==(AuthenticationMode left, AuthenticationMode right) => left.Equals(right);

--- a/sdk/go/eks/pulumiEnums.go
+++ b/sdk/go/eks/pulumiEnums.go
@@ -193,10 +193,16 @@ type AuthenticationMode string
 
 const (
 	// Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.
+	//
+	// Deprecated: The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+	// For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
 	AuthenticationModeConfigMap = AuthenticationMode("CONFIG_MAP")
 	// Only Access Entries will be used for authenticating to the Kubernetes API.
 	AuthenticationModeApi = AuthenticationMode("API")
 	// Both aws-auth ConfigMap and Access Entries can be used for authenticating to the Kubernetes API.
+	//
+	// Deprecated: The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+	// For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
 	AuthenticationModeApiAndConfigMap = AuthenticationMode("API_AND_CONFIG_MAP")
 )
 

--- a/sdk/java/src/main/java/com/pulumi/eks/enums/AuthenticationMode.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/enums/AuthenticationMode.java
@@ -20,7 +20,12 @@ import java.util.StringJoiner;
         /**
          * Only aws-auth ConfigMap will be used for authenticating to the Kubernetes API.
          * 
+         * @deprecated
+         * The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
          */
+        @Deprecated /* The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html. */
         ConfigMap("CONFIG_MAP"),
         /**
          * Only Access Entries will be used for authenticating to the Kubernetes API.
@@ -30,7 +35,12 @@ import java.util.StringJoiner;
         /**
          * Both aws-auth ConfigMap and Access Entries can be used for authenticating to the Kubernetes API.
          * 
+         * @deprecated
+         * The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html.
          */
+        @Deprecated /* The aws-auth ConfigMap is deprecated. The recommended method to manage access to Kubernetes APIs is Access Entries with the AuthenticationMode API.
+For more information and instructions how to upgrade, see https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html. */
         ApiAndConfigMap("API_AND_CONFIG_MAP");
 
         private final String value;


### PR DESCRIPTION
Following up on AWS' deprecation of the aws-auth ConfigMap.
We're deprecating the enums for the `CONFIG_MAP` and `API_AND_CONFIG_MAP`
AuthenticationModes.
This will steer users into the right direction of using the `API` AuthenticationMode.

Details around the deprecation are here: https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html
This is a good guide for how to migrate away from it: https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html

We have a Pulumi migration guide for this in docs/authentication-mode-migration.md. As a follow up we want
to publish this to the Pulumi Docs as a How-To.

Closes #1213 
