### PR TITLE
Add an eks.Cluster option to use an EKS-managed Security Group

### DIFF
--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -95,7 +95,7 @@ export const kubeconfig2: pulumi.Output<any> = cluster2.kubeconfig;
 export const kubeconfig3: pulumi.Output<any> = cluster3.kubeconfig;
 export const kubeconfig4: pulumi.Output<any> = cluster4.kubeconfig;
 export const kubeconfig5: pulumi.Output<any> = cluster5.kubeconfig;
-export const cluster5sg: pulumi.Output<any> = cluster5.clusterSecurityGroup;
+export const cluster5sg: pulumi.Output<any> = cluster5.clusterSecurityGroup.arn;
 
 // export the IAM Role ARN of the cluster
 export const iamRoleArn: pulumi.Output<string> = cluster1.core.clusterIamRole.arn;

--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -58,6 +58,12 @@ const cluster4 = new eks.Cluster(`${projectName}-4`, {
     instanceType: "t4g.small",
 })
 
+// Create an EKS cluster that uses the default EKS-provided security group.
+const cluster5 = new eks.Cluster(`${projectName}-5`, {
+    nodeAmiId: "ami-0384725f0d30527c7",
+    clusterSecurityGroupDefault: true,
+});
+
 //////////////////////////
 ///     EKS Addons     ///
 //////////////////////////
@@ -88,6 +94,8 @@ export const kubeconfig1: pulumi.Output<any> = cluster1.kubeconfig;
 export const kubeconfig2: pulumi.Output<any> = cluster2.kubeconfig;
 export const kubeconfig3: pulumi.Output<any> = cluster3.kubeconfig;
 export const kubeconfig4: pulumi.Output<any> = cluster4.kubeconfig;
+export const kubeconfig5: pulumi.Output<any> = cluster5.kubeconfig;
+export const cluster5sg: pulumi.Output<any> = cluster5.clusterSecurityGroup;
 
 // export the IAM Role ARN of the cluster
 export const iamRoleArn: pulumi.Output<string> = cluster1.core.clusterIamRole.arn;

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -104,7 +104,9 @@ func TestAccCluster(t *testing.T) {
 				}))
 
 				// Ensure that cluster5 exports a security group.
-				assert.NotEmpty(t, info.Outputs["cluster5sg"].(string))
+				// E.g. arn:aws:ec2:us-west-2:616138583583:security-group/sg-0843702f3863a7e61
+				assert.Containsf(t, info.Outputs["cluster5sg"].(string), "arn:aws:ec2")
+				assert.Containsf(t, info.Outputs["cluster5sg"].(string), "security-group/sg")
 			},
 		})
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -101,8 +101,10 @@ func TestAccCluster(t *testing.T) {
 						require.NotNil(t, node.ObjectMeta.Labels)
 						assert.Equal(t, "arm64", node.ObjectMeta.Labels["kubernetes.io/arch"])
 					}
-
 				}))
+
+				// Ensure that cluster5 exports a security group.
+				assert.NotEmpty(t, info.Outputs["cluster5sg"].(string))
 			},
 		})
 

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -618,10 +618,6 @@ export function createCore(
         },
     );
 
-    if (args.clusterSecurityGroupDefault) {
-        createEksClusterInternetEgressRule(name, eksCluster.vpcConfig.clusterSecurityGroupId, { parent, provider });
-    }
-
     // Instead of using the kubeconfig directly, we also add a wait of up to 5 minutes or until we
     // can reach the API server for the Output that provides access to the kubeconfig string so that
     // there is time for the cluster API server to become completely available.  Ideally we

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -579,7 +579,9 @@ export function createCore(
             name: args.name,
             roleArn: eksRole.apply((r) => r.arn),
             vpcConfig: {
-                securityGroupIds: eksClusterSecurityGroup ? [eksClusterSecurityGroup.id] : undefined,
+                securityGroupIds: eksClusterSecurityGroup
+                    ? [eksClusterSecurityGroup.id]
+                    : undefined,
                 subnetIds: clusterSubnetIds,
                 endpointPrivateAccess: args.endpointPrivateAccess,
                 endpointPublicAccess: args.endpointPublicAccess,
@@ -1044,7 +1046,8 @@ export function createCore(
         subnetIds: args.subnetIds ? pulumi.output(args.subnetIds) : pulumi.output(clusterSubnetIds),
         publicSubnetIds: args.publicSubnetIds ? pulumi.output(args.publicSubnetIds) : undefined,
         privateSubnetIds: args.privateSubnetIds ? pulumi.output(args.privateSubnetIds) : undefined,
-        clusterSecurityGroup: eksClusterSecurityGroup ||
+        clusterSecurityGroup:
+            eksClusterSecurityGroup ||
             aws.ec2.SecurityGroup.get("eks-sg", eksCluster.vpcConfig.clusterSecurityGroupId),
         cluster: eksCluster,
         endpoint: endpoint,
@@ -1071,7 +1074,7 @@ function createEksClusterInternetEgressRule(
     eksClusterSecurityGroupId: pulumi.Output<string>,
     opts: pulumi.ResourceOptions,
 ) {
-    new aws.ec2.SecurityGroupRule(
+    const sgr = new aws.ec2.SecurityGroupRule(
         `${name}-eksClusterInternetEgressRule`,
         {
             description: "Allow internet access.",

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -419,7 +419,16 @@ func generateSchema() schema.PackageSpec {
 						},
 						Description: "The security group to use for the cluster API endpoint. If not provided, a new " +
 							"security group will be created with full internet egress and ingress from node groups.\n\n" +
+							"See clusterSecurityGroupDefault for using the EKS-created security group instead.\n\n" +
 							"Note: The security group resource should not contain any inline ingress or egress rules.",
+					},
+					"clusterSecurityGroupDefault": {
+						TypeSpec: schema.TypeSpec{
+							Plain: true,
+							Type:  "boolean",
+						},
+						Description: "Use the default security group created by EKS instead of creating one.\n\n" +
+							"Add full internet ingress and egress rules from node groups to this security group.\n",
 					},
 					"clusterSecurityGroupTags": {
 						TypeSpec: schema.TypeSpec{

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -888,7 +888,12 @@
                 },
                 "clusterSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.\n\nNote: The security group resource should not contain any inline ingress or egress rules."
+                    "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.\n\nSee clusterSecurityGroupDefault for using the EKS-created security group instead.\n\nNote: The security group resource should not contain any inline ingress or egress rules."
+                },
+                "clusterSecurityGroupDefault": {
+                    "type": "boolean",
+                    "plain": true,
+                    "description": "Use the default security group created by EKS instead of creating one.\n\nAdd full internet ingress and egress rules from node groups to this security group.\n"
                 },
                 "clusterSecurityGroupTags": {
                     "type": "object",

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -169,10 +169,20 @@ namespace Pulumi.Eks
         /// <summary>
         /// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
         /// 
+        /// See clusterSecurityGroupDefault for using the EKS-created security group instead.
+        /// 
         /// Note: The security group resource should not contain any inline ingress or egress rules.
         /// </summary>
         [Input("clusterSecurityGroup")]
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? ClusterSecurityGroup { get; set; }
+
+        /// <summary>
+        /// Use the default security group created by EKS instead of creating one.
+        /// 
+        /// Add full internet ingress and egress rules from node groups to this security group.
+        /// </summary>
+        [Input("clusterSecurityGroupDefault")]
+        public bool? ClusterSecurityGroupDefault { get; set; }
 
         [Input("clusterSecurityGroupTags")]
         private InputMap<string>? _clusterSecurityGroupTags;

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -101,8 +101,14 @@ type clusterArgs struct {
 	AuthenticationMode *AuthenticationMode `pulumi:"authenticationMode"`
 	// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
 	//
+	// See clusterSecurityGroupDefault for using the EKS-created security group instead.
+	//
 	// Note: The security group resource should not contain any inline ingress or egress rules.
 	ClusterSecurityGroup *ec2.SecurityGroup `pulumi:"clusterSecurityGroup"`
+	// Use the default security group created by EKS instead of creating one.
+	//
+	// Add full internet ingress and egress rules from node groups to this security group.
+	ClusterSecurityGroupDefault *bool `pulumi:"clusterSecurityGroupDefault"`
 	// The tags to apply to the cluster security group.
 	ClusterSecurityGroupTags map[string]string `pulumi:"clusterSecurityGroupTags"`
 	// The tags to apply to the EKS cluster.
@@ -329,8 +335,14 @@ type ClusterArgs struct {
 	AuthenticationMode *AuthenticationMode
 	// The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
 	//
+	// See clusterSecurityGroupDefault for using the EKS-created security group instead.
+	//
 	// Note: The security group resource should not contain any inline ingress or egress rules.
 	ClusterSecurityGroup ec2.SecurityGroupInput
+	// Use the default security group created by EKS instead of creating one.
+	//
+	// Add full internet ingress and egress rules from node groups to this security group.
+	ClusterSecurityGroupDefault *bool
 	// The tags to apply to the cluster security group.
 	ClusterSecurityGroupTags pulumi.StringMapInput
 	// The tags to apply to the EKS cluster.

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -77,6 +77,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
      * 
+     * See clusterSecurityGroupDefault for using the EKS-created security group instead.
+     * 
      * Note: The security group resource should not contain any inline ingress or egress rules.
      * 
      */
@@ -86,11 +88,32 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     /**
      * @return The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
      * 
+     * See clusterSecurityGroupDefault for using the EKS-created security group instead.
+     * 
      * Note: The security group resource should not contain any inline ingress or egress rules.
      * 
      */
     public Optional<Output<SecurityGroup>> clusterSecurityGroup() {
         return Optional.ofNullable(this.clusterSecurityGroup);
+    }
+
+    /**
+     * Use the default security group created by EKS instead of creating one.
+     * 
+     * Add full internet ingress and egress rules from node groups to this security group.
+     * 
+     */
+    @Import(name="clusterSecurityGroupDefault")
+    private @Nullable Boolean clusterSecurityGroupDefault;
+
+    /**
+     * @return Use the default security group created by EKS instead of creating one.
+     * 
+     * Add full internet ingress and egress rules from node groups to this security group.
+     * 
+     */
+    public Optional<Boolean> clusterSecurityGroupDefault() {
+        return Optional.ofNullable(this.clusterSecurityGroupDefault);
     }
 
     /**
@@ -1036,6 +1059,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         this.accessEntries = $.accessEntries;
         this.authenticationMode = $.authenticationMode;
         this.clusterSecurityGroup = $.clusterSecurityGroup;
+        this.clusterSecurityGroupDefault = $.clusterSecurityGroupDefault;
         this.clusterSecurityGroupTags = $.clusterSecurityGroupTags;
         this.clusterTags = $.clusterTags;
         this.createOidcProvider = $.createOidcProvider;
@@ -1134,6 +1158,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         /**
          * @param clusterSecurityGroup The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
          * 
+         * See clusterSecurityGroupDefault for using the EKS-created security group instead.
+         * 
          * Note: The security group resource should not contain any inline ingress or egress rules.
          * 
          * @return builder
@@ -1147,6 +1173,8 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         /**
          * @param clusterSecurityGroup The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
          * 
+         * See clusterSecurityGroupDefault for using the EKS-created security group instead.
+         * 
          * Note: The security group resource should not contain any inline ingress or egress rules.
          * 
          * @return builder
@@ -1154,6 +1182,19 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder clusterSecurityGroup(SecurityGroup clusterSecurityGroup) {
             return clusterSecurityGroup(Output.of(clusterSecurityGroup));
+        }
+
+        /**
+         * @param clusterSecurityGroupDefault Use the default security group created by EKS instead of creating one.
+         * 
+         * Add full internet ingress and egress rules from node groups to this security group.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterSecurityGroupDefault(@Nullable Boolean clusterSecurityGroupDefault) {
+            $.clusterSecurityGroupDefault = clusterSecurityGroupDefault;
+            return this;
         }
 
         /**

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -23,6 +23,7 @@ class ClusterArgs:
                  access_entries: Optional[Mapping[str, 'AccessEntryArgs']] = None,
                  authentication_mode: Optional['AuthenticationMode'] = None,
                  cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 cluster_security_group_default: Optional[bool] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
@@ -82,7 +83,12 @@ class ClusterArgs:
                https://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html#set-cam
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
                
+               See clusterSecurityGroupDefault for using the EKS-created security group instead.
+               
                Note: The security group resource should not contain any inline ingress or egress rules.
+        :param bool cluster_security_group_default: Use the default security group created by EKS instead of creating one.
+               
+               Add full internet ingress and egress rules from node groups to this security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
@@ -253,6 +259,8 @@ class ClusterArgs:
             pulumi.set(__self__, "authentication_mode", authentication_mode)
         if cluster_security_group is not None:
             pulumi.set(__self__, "cluster_security_group", cluster_security_group)
+        if cluster_security_group_default is not None:
+            pulumi.set(__self__, "cluster_security_group_default", cluster_security_group_default)
         if cluster_security_group_tags is not None:
             pulumi.set(__self__, "cluster_security_group_tags", cluster_security_group_tags)
         if cluster_tags is not None:
@@ -384,6 +392,8 @@ class ClusterArgs:
         """
         The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
 
+        See clusterSecurityGroupDefault for using the EKS-created security group instead.
+
         Note: The security group resource should not contain any inline ingress or egress rules.
         """
         return pulumi.get(self, "cluster_security_group")
@@ -391,6 +401,20 @@ class ClusterArgs:
     @cluster_security_group.setter
     def cluster_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "cluster_security_group", value)
+
+    @property
+    @pulumi.getter(name="clusterSecurityGroupDefault")
+    def cluster_security_group_default(self) -> Optional[bool]:
+        """
+        Use the default security group created by EKS instead of creating one.
+
+        Add full internet ingress and egress rules from node groups to this security group.
+        """
+        return pulumi.get(self, "cluster_security_group_default")
+
+    @cluster_security_group_default.setter
+    def cluster_security_group_default(self, value: Optional[bool]):
+        pulumi.set(self, "cluster_security_group_default", value)
 
     @property
     @pulumi.getter(name="clusterSecurityGroupTags")
@@ -1081,6 +1105,7 @@ class Cluster(pulumi.ComponentResource):
                  access_entries: Optional[Mapping[str, Union['AccessEntryArgs', 'AccessEntryArgsDict']]] = None,
                  authentication_mode: Optional['AuthenticationMode'] = None,
                  cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 cluster_security_group_default: Optional[bool] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
@@ -1162,7 +1187,12 @@ class Cluster(pulumi.ComponentResource):
                https://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html#set-cam
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroup'] cluster_security_group: The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.
                
+               See clusterSecurityGroupDefault for using the EKS-created security group instead.
+               
                Note: The security group resource should not contain any inline ingress or egress rules.
+        :param bool cluster_security_group_default: Use the default security group created by EKS instead of creating one.
+               
+               Add full internet ingress and egress rules from node groups to this security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
@@ -1372,6 +1402,7 @@ class Cluster(pulumi.ComponentResource):
                  access_entries: Optional[Mapping[str, Union['AccessEntryArgs', 'AccessEntryArgsDict']]] = None,
                  authentication_mode: Optional['AuthenticationMode'] = None,
                  cluster_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 cluster_security_group_default: Optional[bool] = None,
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
@@ -1433,6 +1464,7 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["access_entries"] = access_entries
             __props__.__dict__["authentication_mode"] = authentication_mode
             __props__.__dict__["cluster_security_group"] = cluster_security_group
+            __props__.__dict__["cluster_security_group_default"] = cluster_security_group_default
             __props__.__dict__["cluster_security_group_tags"] = cluster_security_group_tags
             __props__.__dict__["cluster_tags"] = cluster_tags
             __props__.__dict__["create_oidc_provider"] = create_oidc_provider


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Currently by default eks.Cluster can utilize a user-provided Security Group or it can create one in the Pulumi layer. After this change users may opt into letting EKS create the security group. It still can be referenced in Pulumi via SecurityGroup.get machinery under the hood but this is transparent to users.

Example usage:

```typescript
const cluster = new eks.Cluster(`my-cluster`, {
    nodeAmiId: "ami-0384725f0d30527c7",
    clusterSecurityGroupDefault: true,
});
```

### Related issues (optional)

Relates: #747 

To fully close the above issue another PR is needed for the node group.

Design note: currently we think that using a Pulumi-provisioned SG is the right default, but the switch is added for users that require it. 

### Reference

#### Official details on the default SG

https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html

