### PR TITLE
Fix go tests only being executed for PRs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -506,7 +506,6 @@ jobs:
       - prerequisites
       - build_sdk
     runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -654,7 +654,6 @@ jobs:
       - prerequisites
       - build_sdk
     runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -675,7 +675,6 @@ jobs:
       - prerequisites
       - build_sdk
     runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       PROVIDER_VERSION: ${{ needs.prerequisites.outputs.version }}
     steps:


### PR DESCRIPTION
While refactoring the GitHub workflows I added the missing golang tests to all workflows. But they were still not executed because of a left-over `if` statement in the workflow defintion.
This change removes the if statements, correctly enabling the go tests for all workflows.
