### PR TITLE
Align addon configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROVIDER_VERSION ?= 2.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
-TESTPARALLELISM := 12
+TESTPARALLELISM := 8
 
 PACK            := eks
 PROVIDER        := pulumi-resource-${PACK}

--- a/nodejs/eks/__snapshots__/cni-addon.test.ts.snap
+++ b/nodejs/eks/__snapshots__/cni-addon.test.ts.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`computeEnv should set default values when no arguments are provided 1`] = `
+{
+  "env": {
+    "AWS_VPC_ENI_MTU": "9001",
+    "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG": "false",
+    "AWS_VPC_K8S_CNI_EXTERNALSNAT": "false",
+    "AWS_VPC_K8S_CNI_LOGLEVEL": "DEBUG",
+    "AWS_VPC_K8S_CNI_LOG_FILE": "/host/var/log/aws-routed-eni/ipamd.log",
+    "AWS_VPC_K8S_CNI_VETHPREFIX": "eni",
+    "AWS_VPC_K8S_PLUGIN_LOG_FILE": "/var/log/aws-routed-eni/plugin.log",
+    "AWS_VPC_K8S_PLUGIN_LOG_LEVEL": "DEBUG",
+    "ENABLE_POD_ENI": "false",
+    "WARM_ENI_TARGET": "1",
+  },
+  "initEnv": {
+    "DISABLE_TCP_EARLY_DEMUX": "false",
+  },
+}
+`;
+
+exports[`computeEnv should set provided values correctly 1`] = `
+{
+  "env": {
+    "AWS_VPC_CNI_NODE_PORT_SUPPORT": "true",
+    "AWS_VPC_ENI_MTU": "1500",
+    "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER": "true",
+    "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG": "true",
+    "AWS_VPC_K8S_CNI_EXTERNALSNAT": "true",
+    "AWS_VPC_K8S_CNI_LOGLEVEL": "INFO",
+    "AWS_VPC_K8S_CNI_LOG_FILE": "/custom/log/file",
+    "AWS_VPC_K8S_CNI_VETHPREFIX": "customPrefix",
+    "AWS_VPC_K8S_PLUGIN_LOG_FILE": "/custom/plugin/log/file",
+    "AWS_VPC_K8S_PLUGIN_LOG_LEVEL": "ERROR",
+    "ENABLE_POD_ENI": "true",
+    "ENABLE_PREFIX_DELEGATION": "true",
+    "ENI_CONFIG_LABEL_DEF": "customLabel",
+    "WARM_ENI_TARGET": "2",
+    "WARM_IP_TARGET": "3",
+    "WARM_PREFIX_TARGET": "4",
+  },
+  "initEnv": {
+    "DISABLE_TCP_EARLY_DEMUX": "true",
+  },
+}
+`;

--- a/nodejs/eks/addon.test.ts
+++ b/nodejs/eks/addon.test.ts
@@ -13,59 +13,20 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
-import { createAddonConfiguration, ConfigurationValues } from "./addon";
+import { stringifyAddonConfiguration } from "./addon";
 
-describe("createAddonConfiguration", () => {
-    it("should return undefined if both values and baseSettings are undefined", async () => {
-        const result = createAddonConfiguration(undefined, undefined);
+describe("stringifyAddonConfiguration", () => {
+    it("should return undefined if the configuration values are undefined", async () => {
+        const result = stringifyAddonConfiguration(undefined);
         expect(result).toBeUndefined();
     });
 
-    it("should return JSON stringified values if baseSettings is undefined", async () => {
+    it("should return JSON stringified configuration values", async () => {
         const values = { key1: "value1", key2: 2 };
-        const result = createAddonConfiguration(values, undefined);
+        const result = stringifyAddonConfiguration(values);
         expect(result).toBeDefined();
         await promisify(result).then((r) => {
             expect(JSON.parse(r)).toStrictEqual(values);
-        });
-    });
-
-    it("should return JSON stringified baseSettings if values is undefined", async () => {
-        const baseSettings = { key1: "value1", key2: 2 };
-        const result = createAddonConfiguration(undefined, baseSettings);
-        expect(result).toBeDefined();
-        await promisify(result).then((r) => {
-            expect(JSON.parse(r)).toStrictEqual(baseSettings);
-        });
-    });
-
-    it("should deeply merge values and baseSettings", async () => {
-        const values = { deeply: { nested: { key1: "val1" } }, nested: { key1: "other-val1" } };
-        const baseSettings: ConfigurationValues = {
-            deeply: { nested: { key2: "val2" } },
-            nested: { key2: "other-val2" },
-        };
-        const expectedMerged = {
-            deeply: { nested: { key2: "val2", key1: "val1" } },
-            nested: { key2: "other-val2", key1: "other-val1" },
-        };
-
-        const result = createAddonConfiguration(values, baseSettings);
-        expect(result).toBeDefined();
-        await promisify(result).then((r) => {
-            expect(JSON.parse(r)).toStrictEqual(expectedMerged);
-        });
-    });
-
-    it("should allow overwriting baseSettings", async () => {
-        const values = { key1: "newValue1", key3: true };
-        const baseSettings: ConfigurationValues = { key1: "will be overwritten", key2: 2 };
-        const expectedMerged = { key1: "newValue1", key2: 2, key3: true };
-
-        const result = createAddonConfiguration(values, baseSettings);
-        expect(result).toBeDefined();
-        await promisify(result).then((r) => {
-            expect(JSON.parse(r)).toStrictEqual(expectedMerged);
         });
     });
 
@@ -77,20 +38,13 @@ describe("createAddonConfiguration", () => {
                 deeply: new Promise((resolve) => resolve({ nested: { input: "input1" } })),
             }),
         );
-        const baseSettings: ConfigurationValues = {
-            deeply: new Promise((resolve) =>
-                resolve({ nested: { key1: "val1", input: "will be overwritten" } }),
-            ),
-            nested: new Promise((resolve) => resolve({ key2: "other-val2", key1: "other-val1" })),
-        };
         const expectedMerged = {
             regular: "someVal",
             input: "input1",
-            deeply: { nested: { key1: "val1", input: "input1" } },
-            nested: { key2: "other-val2", key1: "other-val1" },
+            deeply: { nested: { input: "input1" } },
         };
 
-        const result = createAddonConfiguration(values, baseSettings);
+        const result = stringifyAddonConfiguration(values);
         expect(result).toBeDefined();
         await promisify(result).then((r) => {
             expect(JSON.parse(r)).toStrictEqual(expectedMerged);
@@ -111,7 +65,7 @@ describe("createAddonConfiguration", () => {
             nestedInput: { existing: true },
         };
 
-        const result = createAddonConfiguration(values);
+        const result = stringifyAddonConfiguration(values);
         expect(result).toBeDefined();
         await promisify(result).then((r) => {
             expect(JSON.parse(r)).toStrictEqual(expectedMerged);
@@ -134,8 +88,8 @@ describe("createAddonConfiguration", () => {
             a: "aVal",
         };
 
-        const result = createAddonConfiguration(values);
-        const reverseResult = createAddonConfiguration(reverse);
+        const result = stringifyAddonConfiguration(values);
+        const reverseResult = stringifyAddonConfiguration(reverse);
         expect(result).toBeDefined();
         expect(reverseResult).toBeDefined();
         await promisify(pulumi.all([result, reverseResult])).then(([result, reverseResult]) => {
@@ -202,8 +156,8 @@ describe("createAddonConfiguration", () => {
             ),
         };
 
-        const result = createAddonConfiguration(values);
-        const reverseResult = createAddonConfiguration(reverse);
+        const result = stringifyAddonConfiguration(values);
+        const reverseResult = stringifyAddonConfiguration(reverse);
         expect(result).toBeDefined();
         expect(reverseResult).toBeDefined();
         await promisify(pulumi.all([result, reverseResult])).then(([result, reverseResult]) => {

--- a/nodejs/eks/addon.test.ts
+++ b/nodejs/eks/addon.test.ts
@@ -1,0 +1,104 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import { createAddonConfiguration, ConfigurationValues } from "./addon";
+
+describe("createAddonConfiguration", () => {
+    it("should return undefined if both values and baseSettings are undefined", async () => {
+        const result = createAddonConfiguration(undefined, undefined);
+        expect(result).toBeUndefined();
+    });
+
+    it("should return JSON stringified values if baseSettings is undefined", async () => {
+        const values = { key1: "value1", key2: 2 };
+        const result = createAddonConfiguration(values, undefined);
+        expect(result).toBeDefined();
+        await promisify(result).then((r) => {
+            expect(JSON.parse(r)).toStrictEqual(values);
+        });
+    });
+
+    it("should return JSON stringified baseSettings if values is undefined", async () => {
+        const baseSettings = { key1: "value1", key2: 2 };
+        const result = createAddonConfiguration(undefined, baseSettings);
+        expect(result).toBeDefined();
+        await promisify(result).then((r) => {
+            expect(JSON.parse(r)).toStrictEqual(baseSettings);
+        });
+    });
+
+    it("should deeply merge values and baseSettings", async () => {
+        const values = { deeply: { nested: { key1: "val1" } }, nested: { key1: "other-val1" } };
+        const baseSettings: ConfigurationValues = {
+            deeply: { nested: { key2: "val2" } },
+            nested: { key2: "other-val2" },
+        };
+        const expectedMerged = {
+            deeply: { nested: { key2: "val2", key1: "val1" } },
+            nested: { key2: "other-val2", key1: "other-val1" },
+        };
+
+        const result = createAddonConfiguration(values, baseSettings);
+        expect(result).toBeDefined();
+        await promisify(result).then((r) => {
+            expect(JSON.parse(r)).toStrictEqual(expectedMerged);
+        });
+    });
+
+    it("should allow overwriting baseSettings", async () => {
+        const values = { key1: "newValue1", key3: true };
+        const baseSettings: ConfigurationValues = { key1: "will be overwritten", key2: 2 };
+        const expectedMerged = { key1: "newValue1", key2: 2, key3: true };
+
+        const result = createAddonConfiguration(values, baseSettings);
+        expect(result).toBeDefined();
+        await promisify(result!).then((r) => {
+            expect(JSON.parse(r)).toStrictEqual(expectedMerged);
+        });
+    });
+
+    it("should handle pulumi.Input values correctly", async () => {
+        const values = new Promise((resolve) =>
+            resolve({
+                regular: "someVal",
+                input: new Promise((resolve) => resolve("input1")),
+                deeply: new Promise((resolve) => resolve({ nested: { input: "input1" } })),
+            }),
+        );
+        const baseSettings: ConfigurationValues = {
+            deeply: new Promise((resolve) =>
+                resolve({ nested: { key1: "val1", input: "will be overwritten" } }),
+            ),
+            nested: new Promise((resolve) => resolve({ key2: "other-val2", key1: "other-val1" })),
+        };
+        const expectedMerged = {
+            regular: "someVal",
+            input: "input1",
+            deeply: { nested: { key1: "val1", input: "input1" } },
+            nested: { key2: "other-val2", key1: "other-val1" },
+        };
+
+        const result = createAddonConfiguration(values, baseSettings);
+        expect(result).toBeDefined();
+        await promisify(result!).then((r) => {
+            expect(JSON.parse(r)).toStrictEqual(expectedMerged);
+        });
+    });
+});
+
+function promisify<T>(output: pulumi.Output<T> | undefined): Promise<T> {
+    expect(output).toBeDefined();
+    return new Promise((resolve) => output!.apply(resolve));
+}

--- a/nodejs/eks/addon.ts
+++ b/nodejs/eks/addon.ts
@@ -15,7 +15,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { Cluster } from "./cluster";
-import deepmerge from "deepmerge";
+import * as deepmerge from "deepmerge";
 
 /**
  * AddonOptions describes the configuration options available for the Amazon VPC CNI plugin for Kubernetes. This is obtained from

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -31,7 +31,7 @@ import {
 } from "./authenticationMode";
 import { getIssuerCAThumbprint } from "./cert-thumprint";
 import { createDashboard } from "./dashboard";
-import { assertCompatibleAWSCLIExists, assertCompatibleKubectlVersionExists } from "./dependencies";
+import { assertCompatibleAWSCLIExists } from "./dependencies";
 import {
     computeWorkerSubnets,
     createNodeGroup,
@@ -399,9 +399,6 @@ export function createCore(
     // Check to ensure that a compatible version of aws CLI is installed, as we'll need it in order
     // to retrieve a token to login to the EKS cluster later.
     assertCompatibleAWSCLIExists();
-    // Check to ensure that a compatible kubectl is installed, as we'll need it in order to deploy
-    // k8s resources later.
-    assertCompatibleKubectlVersionExists();
 
     const args = validateAuthenticationMode(rawArgs);
 

--- a/nodejs/eks/cni-addon.test.ts
+++ b/nodejs/eks/cni-addon.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as pulumi from "@pulumi/pulumi";
-import { CniEnvVariables, ComputedEnv, computeEnv } from "./cni-addon";
+import { CniEnvVariables, ComputedEnv, computeEnv, mergeConfigurationValues } from "./cni-addon";
 
 describe("computeEnv", () => {
     it("should set default values when no arguments are provided", async () => {
@@ -66,5 +66,102 @@ describe("computeEnv", () => {
         expect(() => computeEnv(args)).toThrow(
             "Please specify one of `cniExternalSnat` or `externalSnat` in your VpcCniOptions",
         );
+    });
+});
+
+describe("mergeConfigurationValues", () => {
+    it("should merge configuration values correctly", () => {
+        const env = { VAR1: "value1", VAR2: "value2" };
+        const initEnv = { INIT_VAR1: "initValue1", INIT_VAR2: "initValue2" };
+        const enableNetworkPolicy = true;
+        const configurationValues = { existingKey: "existingValue" };
+
+        const result = mergeConfigurationValues(
+            env,
+            initEnv,
+            enableNetworkPolicy,
+            configurationValues,
+        );
+
+        expect(result).toEqual({
+            existingKey: "existingValue",
+            enableNetworkPolicy: "true",
+            env: { VAR1: "value1", VAR2: "value2" },
+            init: { env: { INIT_VAR1: "initValue1", INIT_VAR2: "initValue2" } },
+        });
+    });
+
+    it("should handle undefined configurationValues", () => {
+        const env = { VAR1: "value1" };
+        const initEnv = { INIT_VAR1: "initValue1" };
+        const enableNetworkPolicy = false;
+
+        const result = mergeConfigurationValues(env, initEnv, enableNetworkPolicy, undefined);
+
+        expect(result).toEqual({
+            enableNetworkPolicy: "false",
+            env: { VAR1: "value1" },
+            init: { env: { INIT_VAR1: "initValue1" } },
+        });
+    });
+
+    it("should merge env and init.env keys", () => {
+        const env = { VAR1: "value1", EXISTING_ENV_VAR: "will be overwritten" };
+        const initEnv = { INIT_VAR1: "initValue1", EXISTING_INIT_ENV_VAR: "will be overwritten" };
+        const enableNetworkPolicy = true;
+        const configurationValues = {
+            env: { EXISTING_ENV_VAR: "existingEnvValue", VAR2: "value2" },
+            init: {
+                env: { EXISTING_INIT_ENV_VAR: "existingInitEnvValue", INIT_VAR2: "initValue2" },
+            },
+        };
+
+        const result = mergeConfigurationValues(
+            env,
+            initEnv,
+            enableNetworkPolicy,
+            configurationValues,
+        );
+
+        expect(result).toEqual({
+            enableNetworkPolicy: "true",
+            env: { VAR1: "value1", EXISTING_ENV_VAR: "existingEnvValue", VAR2: "value2" },
+            init: {
+                env: {
+                    INIT_VAR1: "initValue1",
+                    EXISTING_INIT_ENV_VAR: "existingInitEnvValue",
+                    INIT_VAR2: "initValue2",
+                },
+            },
+        });
+    });
+
+    it("should handle missing enableNetworkPolicy", () => {
+        const env = { VAR1: "value1" };
+        const initEnv = { INIT_VAR1: "initValue1" };
+        const configurationValues = { existingKey: "existingValue" };
+
+        const result = mergeConfigurationValues(env, initEnv, undefined, configurationValues);
+
+        expect(result).toEqual({
+            existingKey: "existingValue",
+            env: { VAR1: "value1" },
+            init: { env: { INIT_VAR1: "initValue1" } },
+        });
+    });
+
+    it("should allow overwriting enableNetworkPolicy", () => {
+        const env = { VAR1: "value1" };
+        const initEnv = { INIT_VAR1: "initValue1" };
+        const configurationValues = { existingKey: "existingValue", enableNetworkPolicy: "true" };
+
+        const result = mergeConfigurationValues(env, initEnv, false, configurationValues);
+
+        expect(result).toEqual({
+            enableNetworkPolicy: "true",
+            existingKey: "existingValue",
+            env: { VAR1: "value1" },
+            init: { env: { INIT_VAR1: "initValue1" } },
+        });
     });
 });

--- a/nodejs/eks/cni-addon.test.ts
+++ b/nodejs/eks/cni-addon.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import { CniEnvVariables, ComputedEnv, computeEnv } from "./cni-addon";
+
+describe("computeEnv", () => {
+    it("should set default values when no arguments are provided", async () => {
+        const args = {};
+        const result = pulumi.output(computeEnv(args));
+
+        await new Promise<pulumi.UnwrappedObject<ComputedEnv>>((resolve) =>
+            result!.apply(resolve),
+        ).then((result) => {
+            expect(result).toMatchSnapshot();
+        });
+    });
+
+    it("should set provided values correctly", async () => {
+        const args: CniEnvVariables = {
+            nodePortSupport: pulumi.output(true),
+            customNetworkConfig: pulumi.output(true),
+            warmEniTarget: pulumi.output(2),
+            warmIpTarget: pulumi.output(3),
+            warmPrefixTarget: pulumi.output(4),
+            enablePrefixDelegation: pulumi.output(true),
+            logLevel: pulumi.output("INFO"),
+            logFile: pulumi.output("/custom/log/file"),
+            vethPrefix: pulumi.output("customPrefix"),
+            eniMtu: pulumi.output(1500),
+            eniConfigLabelDef: pulumi.output("customLabel"),
+            pluginLogLevel: pulumi.output("ERROR"),
+            pluginLogFile: pulumi.output("/custom/plugin/log/file"),
+            enablePodEni: pulumi.output(true),
+            disableTcpEarlyDemux: pulumi.output(true),
+            cniConfigureRpfilter: pulumi.output(true),
+            cniCustomNetworkCfg: pulumi.output(true),
+            cniExternalSnat: pulumi.output(true),
+        };
+        const result = pulumi.output(computeEnv(args));
+
+        await new Promise<pulumi.UnwrappedObject<ComputedEnv>>((resolve) =>
+            result!.apply(resolve),
+        ).then((result) => {
+            expect(result).toMatchSnapshot();
+        });
+    });
+
+    it("should throw an error if both cniExternalSnat and externalSnat are provided", () => {
+        const args = {
+            cniExternalSnat: pulumi.output(true),
+            externalSnat: pulumi.output(true),
+        };
+
+        expect(() => computeEnv(args)).toThrow(
+            "Please specify one of `cniExternalSnat` or `externalSnat` in your VpcCniOptions",
+        );
+    });
+});

--- a/nodejs/eks/cni-addon.ts
+++ b/nodejs/eks/cni-addon.ts
@@ -15,15 +15,20 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as k8s from "@pulumi/kubernetes";
-import * as deepmerge from "deepmerge";
+import { ConfigurationValues, createAddonConfiguration } from "./addon";
 
-export interface VpcCniAddonOptions {
+export interface VpcCniAddonOptions extends CniEnvVariables {
     clusterName: pulumi.Input<string>;
 
     /**
      * The Kubernetes version of the cluster. This is used to determine the addon version to use if `addonVersion` is not specified.
      */
     clusterVersion?: pulumi.Input<string>;
+
+    /**
+     * The version of the addon to use. If not specified, the latest version of the addon for the cluster's Kubernetes version will be used.
+     */
+    addonVersion?: pulumi.Input<string>;
 
     /**
      * How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
@@ -63,17 +68,21 @@ export interface VpcCniAddonOptions {
     configurationValues?: pulumi.Input<object>;
 
     /**
+     * Pass privilege to containers securityContext
+     * this is required when SELinux is enabled
+     * This value will not be passed to the CNI config by default
+     */
+    securityContextPrivileged?: pulumi.Input<boolean>;
+
+    /**
      * Enables using Kubernetes network policies. In Kubernetes, by default, all pod-to-pod communication is allowed. Communication can be restricted with Kubernetes NetworkPolicy objects.
      *
      * See for more information: [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/).
      */
     enableNetworkPolicy?: pulumi.Input<boolean>;
+}
 
-    /**
-     * The version of the addon to use. If not specified, the latest version of the addon for the cluster's Kubernetes version will be used.
-     */
-    addonVersion?: pulumi.Input<string>;
-
+export interface CniEnvVariables {
     /**
      * Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires
      * additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
@@ -124,14 +133,6 @@ export interface VpcCniAddonOptions {
      * Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md
      */
     enablePrefixDelegation?: pulumi.Input<boolean>;
-
-    /**
-     * VPC CNI can operate in either IPv4 or IPv6 mode. Setting ENABLE_IPv6 to true. will configure it in IPv6 mode.
-     * Note that IPv6 is only supported in Prefix Delegation mode so enablePrefixDelegation must also be set.
-     *
-     * Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md#enable_ipv6-v1100
-     */
-    enableIpv6?: pulumi.Input<boolean>;
 
     /**
      * Specifies the log level used for logs.
@@ -239,13 +240,6 @@ export interface VpcCniAddonOptions {
      * Defaults to "false".
      */
     cniExternalSnat?: pulumi.Input<boolean>;
-
-    /**
-     * Pass privilege to containers securityContext
-     * this is required when SELinux is enabled
-     * This value will not be passed to the CNI config by default
-     */
-    securityContextPrivileged?: pulumi.Input<boolean>;
 }
 
 /**
@@ -302,17 +296,9 @@ export class VpcCniAddon extends pulumi.ComponentResource {
 
         if (args.enableNetworkPolicy) {
             Object.assign(baseSettings, {
-                enableNetworkPolicy: pulumi
-                    .output(args.enableNetworkPolicy)
-                    .apply((val) => (val ? "true" : "false")),
+                enableNetworkPolicy: pulumi.output(args.enableNetworkPolicy).apply(stringifyBool),
             });
         }
-
-        const configurationValues = pulumi
-            .output(args.configurationValues ?? {})
-            .apply((config) => {
-                return deepmerge(baseSettings, config);
-            });
 
         const addon = new aws.eks.Addon(
             name,
@@ -325,7 +311,10 @@ export class VpcCniAddon extends pulumi.ComponentResource {
                 // OVERWRITE makes sure updates to the addon do not fail
                 resolveConflictsOnUpdate: args.resolveConflictsOnUpdate ?? "OVERWRITE",
                 preserve: true,
-                configurationValues: pulumi.jsonStringify(configurationValues),
+                configurationValues: createAddonConfiguration(
+                    args.configurationValues,
+                    baseSettings,
+                ),
                 serviceAccountRoleArn: args.serviceAccountRoleArn,
                 tags: args.tags,
             },
@@ -384,133 +373,141 @@ export class VpcCniAddon extends pulumi.ComponentResource {
     }
 }
 
-function computeEnv(args: VpcCniAddonOptions): {
-    env: { [key: string]: string };
-    initEnv: { [key: string]: string };
-} {
-    const env: { name: string; value: string }[] = [];
-    const initEnv: { name: string; value: string }[] = [];
+export type ComputedEnv = {
+    env: ConfigurationValues;
+    initEnv: ConfigurationValues;
+};
+
+export function computeEnv(args: CniEnvVariables): ComputedEnv {
+    const env: { name: string; value: pulumi.Output<string> }[] = [];
+    const initEnv: { name: string; value: pulumi.Output<string> }[] = [];
     if (args.nodePortSupport) {
         env.push({
             name: "AWS_VPC_CNI_NODE_PORT_SUPPORT",
-            value: args.nodePortSupport ? "true" : "false",
+            value: pulumi.output(args.nodePortSupport).apply(stringifyBool),
         });
     }
     if (args.customNetworkConfig) {
         env.push({
             name: "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG",
-            value: args.customNetworkConfig ? "true" : "false",
+            value: pulumi.output(args.customNetworkConfig).apply(stringifyBool),
         });
     }
-    env.push({ name: "WARM_ENI_TARGET", value: `${args.warmEniTarget ?? 1}` });
+    env.push({
+        name: "WARM_ENI_TARGET",
+        value: pulumi.output(args.warmEniTarget).apply((val) => `${val ?? 1}`),
+    });
     if (args.warmIpTarget) {
         env.push({
             name: "WARM_IP_TARGET",
-            value: args.warmIpTarget.toString(),
+            value: pulumi.output(args.warmIpTarget).apply(stringifyNumber),
         });
     }
     if (args.warmPrefixTarget) {
         env.push({
             name: "WARM_PREFIX_TARGET",
-            value: args.warmPrefixTarget.toString(),
+            value: pulumi.output(args.warmPrefixTarget).apply(stringifyNumber),
         });
     }
 
     if (args.enablePrefixDelegation) {
         env.push({
             name: "ENABLE_PREFIX_DELEGATION",
-            value: args.enablePrefixDelegation ? "true" : "false",
+            value: pulumi.output(args.enablePrefixDelegation).apply(stringifyBool),
         });
     }
     if (args.logLevel) {
         env.push({
             name: "AWS_VPC_K8S_CNI_LOGLEVEL",
-            value: args.logLevel.toString(),
+            value: pulumi.output(args.logLevel),
         });
     } else {
-        env.push({ name: "AWS_VPC_K8S_CNI_LOGLEVEL", value: "DEBUG" });
+        env.push({ name: "AWS_VPC_K8S_CNI_LOGLEVEL", value: pulumi.output("DEBUG") });
     }
     if (args.logFile) {
         env.push({
             name: "AWS_VPC_K8S_CNI_LOG_FILE",
-            value: args.logFile.toString(),
+            value: pulumi.output(args.logFile),
         });
     } else {
         env.push({
             name: "AWS_VPC_K8S_CNI_LOG_FILE",
-            value: "/host/var/log/aws-routed-eni/ipamd.log",
+            value: pulumi.output("/host/var/log/aws-routed-eni/ipamd.log"),
         });
     }
     if (args.vethPrefix) {
         env.push({
             name: "AWS_VPC_K8S_CNI_VETHPREFIX",
-            value: args.vethPrefix.toString(),
+            value: pulumi.output(args.vethPrefix),
         });
     } else {
-        env.push({ name: "AWS_VPC_K8S_CNI_VETHPREFIX", value: "eni" });
+        env.push({ name: "AWS_VPC_K8S_CNI_VETHPREFIX", value: pulumi.output("eni") });
     }
     if (args.eniMtu) {
-        env.push({ name: "AWS_VPC_ENI_MTU", value: args.eniMtu.toString() });
+        env.push({
+            name: "AWS_VPC_ENI_MTU",
+            value: pulumi.output(args.eniMtu).apply(stringifyNumber),
+        });
     } else {
-        env.push({ name: "AWS_VPC_ENI_MTU", value: "9001" });
+        env.push({ name: "AWS_VPC_ENI_MTU", value: pulumi.output("9001") });
     }
 
     if (args.eniConfigLabelDef) {
         env.push({
             name: "ENI_CONFIG_LABEL_DEF",
-            value: args.eniConfigLabelDef.toString(),
+            value: pulumi.output(args.eniConfigLabelDef),
         });
     }
     if (args.pluginLogLevel) {
         env.push({
             name: "AWS_VPC_K8S_PLUGIN_LOG_LEVEL",
-            value: args.pluginLogLevel.toString(),
+            value: pulumi.output(args.pluginLogLevel),
         });
     } else {
-        env.push({ name: "AWS_VPC_K8S_PLUGIN_LOG_LEVEL", value: "DEBUG" });
+        env.push({ name: "AWS_VPC_K8S_PLUGIN_LOG_LEVEL", value: pulumi.output("DEBUG") });
     }
     if (args.pluginLogFile) {
         env.push({
             name: "AWS_VPC_K8S_PLUGIN_LOG_FILE",
-            value: args.pluginLogFile.toString(),
+            value: pulumi.output(args.pluginLogFile),
         });
     } else {
         env.push({
             name: "AWS_VPC_K8S_PLUGIN_LOG_FILE",
-            value: "/var/log/aws-routed-eni/plugin.log",
+            value: pulumi.output("/var/log/aws-routed-eni/plugin.log"),
         });
     }
     if (args.enablePodEni) {
         env.push({
             name: "ENABLE_POD_ENI",
-            value: args.enablePodEni ? "true" : "false",
+            value: pulumi.output(args.enablePodEni).apply(stringifyBool),
         });
     } else {
-        env.push({ name: "ENABLE_POD_ENI", value: "false" });
+        env.push({ name: "ENABLE_POD_ENI", value: pulumi.output("false") });
     }
     if (args.disableTcpEarlyDemux) {
         initEnv.push({
             name: "DISABLE_TCP_EARLY_DEMUX",
-            value: args.disableTcpEarlyDemux ? "true" : "false",
+            value: pulumi.output(args.disableTcpEarlyDemux).apply(stringifyBool),
         });
     } else {
-        initEnv.push({ name: "DISABLE_TCP_EARLY_DEMUX", value: "false" });
+        initEnv.push({ name: "DISABLE_TCP_EARLY_DEMUX", value: pulumi.output("false") });
     }
     if (args.cniConfigureRpfilter) {
         env.push({
             name: "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER",
-            value: args.cniConfigureRpfilter ? "true" : "false",
+            value: pulumi.output(args.cniConfigureRpfilter).apply(stringifyBool),
         });
     }
     if (args.cniCustomNetworkCfg) {
         env.push({
             name: "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG",
-            value: args.cniCustomNetworkCfg ? "true" : "false",
+            value: pulumi.output(args.cniCustomNetworkCfg).apply(stringifyBool),
         });
     } else {
         env.push({
             name: "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG",
-            value: "false",
+            value: pulumi.output("false"),
         });
     }
     // A user would usually specify externalSnat or cniExternalSnat NOT both
@@ -522,15 +519,15 @@ function computeEnv(args: VpcCniAddonOptions): {
     if (args.externalSnat) {
         env.push({
             name: "AWS_VPC_K8S_CNI_EXTERNALSNAT",
-            value: args.externalSnat ? "true" : "false",
+            value: pulumi.output(args.externalSnat).apply(stringifyBool),
         });
     } else if (args.cniExternalSnat) {
         env.push({
             name: "AWS_VPC_K8S_CNI_EXTERNALSNAT",
-            value: args.cniExternalSnat ? "true" : "false",
+            value: pulumi.output(args.cniExternalSnat).apply(stringifyBool),
         });
     } else {
-        env.push({ name: "AWS_VPC_K8S_CNI_EXTERNALSNAT", value: "false" });
+        env.push({ name: "AWS_VPC_K8S_CNI_EXTERNALSNAT", value: pulumi.output("false") });
     }
 
     return {
@@ -543,4 +540,12 @@ function computeEnv(args: VpcCniAddonOptions): {
             return acc;
         }, {}),
     };
+}
+
+function stringifyBool(val: boolean): string {
+    return val ? "true" : "false";
+}
+
+function stringifyNumber(val: number): string {
+    return `${val}`;
 }

--- a/nodejs/eks/dependencies.test.ts
+++ b/nodejs/eks/dependencies.test.ts
@@ -12,98 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { assertCompatibleKubectlVersionExists, assertCompatibleAWSCLIExists } from "./dependencies";
+import { assertCompatibleAWSCLIExists } from "./dependencies";
 import child_process from "child_process";
 import which from "which";
 
 jest.mock("child_process");
 jest.mock("which");
 
-function fakeKubectlVersionJson(v: string): string {
-    return `{"clientVersion": {"gitVersion": "${v}"},"kustomizeVersion": "v5.0.4-0.20230601165947-6ce0bf390ce3"}`;
-}
-
 function fakeAwsVersion(v: string): string {
     return `aws-cli/${v} Python/3.8.8 Darwin/20.5.0 source/x86_64 prompt/off`;
 }
-
-describe("assertCompatibleKubectlVersionExists", () => {
-    beforeEach(() => {
-        (which.sync as jest.Mock).mockImplementation(() => "/fake/path/to/kubectl");
-    });
-
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    it("should throw if kubectl is not installed", () => {
-        (which.sync as jest.Mock).mockImplementation(() => {
-            throw new Error("Not found");
-        });
-
-        expect(() => {
-            assertCompatibleKubectlVersionExists();
-        }).toThrow(
-            "kubectl is missing. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for installation instructions.",
-        );
-
-        expect(which.sync).toHaveBeenCalledWith("kubectl");
-        expect(child_process.execSync).not.toHaveBeenCalled();
-        expect(which.sync).toHaveBeenCalledTimes(1);
-    });
-
-    it("should throw if kubectl version is lower than v1.24.0", () => {
-        (child_process.execSync as jest.Mock).mockImplementation(() =>
-            fakeKubectlVersionJson("v1.23.0"),
-        );
-
-        expect(() => {
-            assertCompatibleKubectlVersionExists();
-        }).toThrow("At least v1.24.0 of kubectl is required.");
-
-        expect(which.sync).toHaveBeenCalledWith("kubectl");
-        expect(child_process.execSync).toHaveBeenCalledTimes(1);
-    });
-
-    it("should throw if kubectl version is invalid", () => {
-        (child_process.execSync as jest.Mock).mockImplementation(() =>
-            fakeKubectlVersionJson("fake-version"),
-        );
-
-        expect(() => {
-            assertCompatibleKubectlVersionExists();
-        }).toThrow("Invalid version");
-
-        expect(which.sync).toHaveBeenCalledWith("kubectl");
-        expect(child_process.execSync).toHaveBeenCalledTimes(1);
-    });
-
-    it("should not error if kubectl is v1.24.0", () => {
-        (child_process.execSync as jest.Mock).mockImplementation(() =>
-            fakeKubectlVersionJson("v1.24.0"),
-        );
-
-        expect(() => {
-            assertCompatibleKubectlVersionExists();
-        }).not.toThrow();
-
-        expect(which.sync).toHaveBeenCalledWith("kubectl");
-        expect(child_process.execSync).toHaveBeenCalledTimes(1);
-    });
-
-    it("should not error if kubectl is greater than v1.24.0", () => {
-        (child_process.execSync as jest.Mock).mockImplementation(() =>
-            fakeKubectlVersionJson("v1.29.6-gke.1400"),
-        );
-
-        expect(() => {
-            assertCompatibleKubectlVersionExists();
-        }).not.toThrow();
-
-        expect(which.sync).toHaveBeenCalledWith("kubectl");
-        expect(child_process.execSync).toHaveBeenCalledTimes(1);
-    });
-});
 
 describe("assertCompatibleAWSCLIExists", () => {
     beforeEach(() => {

--- a/nodejs/eks/dependencies.ts
+++ b/nodejs/eks/dependencies.ts
@@ -16,53 +16,8 @@ import * as childProcess from "child_process";
 import * as semver from "semver";
 import * as which from "which";
 
-const minKubectlVersion = "1.24.0";
 const minAWSCLIV1Version = "1.24.0";
 const minAWSCLIV2Version = "2.7.0";
-
-interface KubectlVersion {
-    clientVersion: {
-        major: string;
-        minor: string;
-        gitVersion: string;
-    };
-}
-
-export function assertCompatibleKubectlVersionExists() {
-    try {
-        which.sync("kubectl");
-    } catch (err) {
-        throw new Error(
-            "kubectl is missing. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for installation instructions.",
-        );
-    }
-
-    const kubectlVersionJson = childProcess.execSync(
-        `kubectl version --client=true --output=json`,
-        {
-            stdio: ["pipe", "pipe", "ignore"],
-            encoding: "utf8",
-        },
-    );
-
-    let kctlVersion: KubectlVersion;
-    try {
-        kctlVersion = JSON.parse(kubectlVersionJson);
-    } catch (err) {
-        throw new Error(
-            `Failed to parse kubectl version JSON output. Received: ${kubectlVersionJson}`,
-        );
-    }
-    const kcVersion = semver.clean(kctlVersion.clientVersion.gitVersion, {
-        loose: true,
-    });
-    if (semver.lt(kcVersion!, minKubectlVersion)) {
-        throw new Error(
-            `At least v${minKubectlVersion} of kubectl is required.` +
-                ` Current version is: ${kcVersion}. See https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl for instructions on installing the latest.`,
-        );
-    }
-}
 
 export function assertCompatibleAWSCLIExists() {
     try {

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -32,8 +32,7 @@
         "semver": "^7.3.7",
         "which": "^1.3.1",
         "@iarna/toml": "^3.0.0",
-        "ipaddr.js": "^2.2.0",
-        "deepmerge": "^4.3.1"
+        "ipaddr.js": "^2.2.0"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.23.9",

--- a/nodejs/eks/userdata.ts
+++ b/nodejs/eks/userdata.ts
@@ -19,6 +19,7 @@ import { NodeadmOptions, Taint } from "./nodegroup";
 import * as jsyaml from "js-yaml";
 import * as toml from "@iarna/toml";
 import * as ipaddr from "ipaddr.js";
+import { isObject } from "./utilities";
 
 // linux is the default user data type for AMIs that use the eks bootstrap script. (e.g. AL2)
 // nodeadm is the user data type for AMIs that use nodeadm to bootstrap the node. (e.g. AL2023)
@@ -543,8 +544,4 @@ export function getClusterDnsIp(serviceCidr: string, parent: pulumi.Resource | u
             parent,
         );
     }
-}
-
-function isObject(obj: any): obj is Record<string, any> {
-    return typeof obj === "object" && !Array.isArray(obj) && obj !== null;
 }

--- a/nodejs/eks/utilities.ts
+++ b/nodejs/eks/utilities.ts
@@ -22,3 +22,7 @@ export function getVersion(): string {
     }
     return version;
 }
+
+export function isObject(obj: any): obj is Record<string, any> {
+    return obj !== null && typeof obj === "object" && !Array.isArray(obj);
+}

--- a/nodejs/eks/yarn.lock
+++ b/nodejs/eks/yarn.lock
@@ -2530,7 +2530,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deepmerge@^4.2.2, deepmerge@^4.3.1:
+deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1859,12 +1859,20 @@ func generateSchema() schema.PackageSpec {
 						"enabled": {
 							TypeSpec:    schema.TypeSpec{Type: "boolean", Plain: true},
 							Default:     true,
-							Description: "Whether or not to create the Addon in the cluster",
+							Description: "Whether or not to create the `coredns` Addon in the cluster",
 						},
 						"version": {
 							TypeSpec: schema.TypeSpec{Type: "string"},
 							Description: "The version of the EKS add-on. The version must " +
 								"match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).",
+						},
+						"configurationValues": {
+							TypeSpec: schema.TypeSpec{
+								Type:                 "object",
+								AdditionalProperties: &schema.TypeSpec{Ref: "pulumi.json#/Any"},
+							},
+							Description: "Custom configuration values for the coredns addon. This object must match the schema derived from " +
+								"[describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).",
 						},
 						"resolveConflictsOnCreate": {
 							TypeSpec: schema.TypeSpec{Plain: true, Type: "string", Ref: "#/types/eks:index:ResolveConflictsOnCreate"},
@@ -1894,6 +1902,14 @@ func generateSchema() schema.PackageSpec {
 							TypeSpec: schema.TypeSpec{Type: "string"},
 							Description: "The version of the EKS add-on. The version must " +
 								"match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).",
+						},
+						"configurationValues": {
+							TypeSpec: schema.TypeSpec{
+								Type:                 "object",
+								AdditionalProperties: &schema.TypeSpec{Ref: "pulumi.json#/Any"},
+							},
+							Description: "Custom configuration values for the kube-proxy addon. This object must match the schema derived from " +
+								"[describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).",
 						},
 						"resolveConflictsOnCreate": {
 							TypeSpec: schema.TypeSpec{Plain: true, Type: "string", Ref: "#/types/eks:index:ResolveConflictsOnCreate"},
@@ -2391,16 +2407,18 @@ func vpcCniProperties(cluster bool) map[string]schema.PropertySpec {
 				"(https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).",
 		},
 		"resolveConflictsOnCreate": {
-			TypeSpec: schema.TypeSpec{Type: "string"},
-			Description: "How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.\n" +
-				"Valid values are NONE and OVERWRITE.\n\nFor more details see the " +
-				"[CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).",
+			TypeSpec: schema.TypeSpec{Plain: true, Type: "string", Ref: "#/types/eks:index:ResolveConflictsOnCreate"},
+			Description: "How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. " +
+				"Valid values are `NONE` and `OVERWRITE`. For more details see the " +
+				"[CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.",
+			Default: "OVERWRITE",
 		},
 		"resolveConflictsOnUpdate": {
-			TypeSpec: schema.TypeSpec{Type: "string"},
-			Description: "How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the" +
-				"Amazon EKS default value.\nValid values are NONE, OVERWRITE, and PRESERVE.\n\nFor more details see the " +
-				"[UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).",
+			TypeSpec: schema.TypeSpec{Plain: true, Type: "string", Ref: "#/types/eks:index:ResolveConflictsOnUpdate"},
+			Description: "How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the " +
+				"Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the " +
+				"[UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.",
+			Default: "OVERWRITE",
 		},
 		"serviceAccountRoleArn": {
 			TypeSpec: schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -507,10 +507,17 @@
         },
         "eks:index:CoreDnsAddonOptions": {
             "properties": {
+                "configurationValues": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html)."
+                },
                 "enabled": {
                     "type": "boolean",
                     "plain": true,
-                    "description": "Whether or not to create the Addon in the cluster",
+                    "description": "Whether or not to create the `coredns` Addon in the cluster",
                     "default": true
                 },
                 "resolveConflictsOnCreate": {
@@ -578,6 +585,13 @@
         },
         "eks:index:KubeProxyAddonOptions": {
             "properties": {
+                "configurationValues": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html)."
+                },
                 "enabled": {
                     "type": "boolean",
                     "plain": true,
@@ -930,11 +944,17 @@
                 },
                 "resolveConflictsOnCreate": {
                     "type": "string",
-                    "description": "How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.\nValid values are NONE and OVERWRITE.\n\nFor more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html)."
+                    "$ref": "#/types/eks:index:ResolveConflictsOnCreate",
+                    "plain": true,
+                    "description": "How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.",
+                    "default": "OVERWRITE"
                 },
                 "resolveConflictsOnUpdate": {
                     "type": "string",
-                    "description": "How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.\nValid values are NONE, OVERWRITE, and PRESERVE.\n\nFor more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html)."
+                    "$ref": "#/types/eks:index:ResolveConflictsOnUpdate",
+                    "plain": true,
+                    "description": "How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.",
+                    "default": "OVERWRITE"
                 },
                 "securityContextPrivileged": {
                     "type": "boolean",
@@ -2133,11 +2153,17 @@
                 },
                 "resolveConflictsOnCreate": {
                     "type": "string",
-                    "description": "How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.\nValid values are NONE and OVERWRITE.\n\nFor more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html)."
+                    "$ref": "#/types/eks:index:ResolveConflictsOnCreate",
+                    "plain": true,
+                    "description": "How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.",
+                    "default": "OVERWRITE"
                 },
                 "resolveConflictsOnUpdate": {
                     "type": "string",
-                    "description": "How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.\nValid values are NONE, OVERWRITE, and PRESERVE.\n\nFor more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html)."
+                    "$ref": "#/types/eks:index:ResolveConflictsOnUpdate",
+                    "plain": true,
+                    "description": "How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.",
+                    "default": "OVERWRITE"
                 },
                 "securityContextPrivileged": {
                     "type": "boolean",

--- a/sdk/dotnet/Inputs/CoreDnsAddonOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/CoreDnsAddonOptionsArgs.cs
@@ -12,8 +12,20 @@ namespace Pulumi.Eks.Inputs
 
     public sealed class CoreDnsAddonOptionsArgs : global::Pulumi.ResourceArgs
     {
+        [Input("configurationValues")]
+        private InputMap<object>? _configurationValues;
+
         /// <summary>
-        /// Whether or not to create the Addon in the cluster
+        /// Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+        /// </summary>
+        public InputMap<object> ConfigurationValues
+        {
+            get => _configurationValues ?? (_configurationValues = new InputMap<object>());
+            set => _configurationValues = value;
+        }
+
+        /// <summary>
+        /// Whether or not to create the `coredns` Addon in the cluster
         /// </summary>
         [Input("enabled")]
         public bool? Enabled { get; set; }

--- a/sdk/dotnet/Inputs/KubeProxyAddonOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/KubeProxyAddonOptionsArgs.cs
@@ -12,6 +12,18 @@ namespace Pulumi.Eks.Inputs
 
     public sealed class KubeProxyAddonOptionsArgs : global::Pulumi.ResourceArgs
     {
+        [Input("configurationValues")]
+        private InputMap<object>? _configurationValues;
+
+        /// <summary>
+        /// Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+        /// </summary>
+        public InputMap<object> ConfigurationValues
+        {
+            get => _configurationValues ?? (_configurationValues = new InputMap<object>());
+            set => _configurationValues = value;
+        }
+
         /// <summary>
         /// Whether or not to create the `kube-proxy` Addon in the cluster
         /// </summary>

--- a/sdk/dotnet/Inputs/VpcCniOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/VpcCniOptionsArgs.cs
@@ -136,22 +136,16 @@ namespace Pulumi.Eks.Inputs
         public Input<bool>? NodePortSupport { get; set; }
 
         /// <summary>
-        /// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-        /// Valid values are NONE and OVERWRITE.
-        /// 
-        /// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+        /// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         /// </summary>
         [Input("resolveConflictsOnCreate")]
-        public Input<string>? ResolveConflictsOnCreate { get; set; }
+        public Pulumi.Eks.ResolveConflictsOnCreate? ResolveConflictsOnCreate { get; set; }
 
         /// <summary>
-        /// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-        /// Valid values are NONE, OVERWRITE, and PRESERVE.
-        /// 
-        /// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        /// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         /// </summary>
         [Input("resolveConflictsOnUpdate")]
-        public Input<string>? ResolveConflictsOnUpdate { get; set; }
+        public Pulumi.Eks.ResolveConflictsOnUpdate? ResolveConflictsOnUpdate { get; set; }
 
         /// <summary>
         /// Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
@@ -201,6 +195,8 @@ namespace Pulumi.Eks.Inputs
 
         public VpcCniOptionsArgs()
         {
+            ResolveConflictsOnCreate = Pulumi.Eks.ResolveConflictsOnCreate.Overwrite;
+            ResolveConflictsOnUpdate = Pulumi.Eks.ResolveConflictsOnUpdate.Overwrite;
         }
         public static new VpcCniOptionsArgs Empty => new VpcCniOptionsArgs();
     }

--- a/sdk/dotnet/VpcCniAddon.cs
+++ b/sdk/dotnet/VpcCniAddon.cs
@@ -193,22 +193,16 @@ namespace Pulumi.Eks
         public Input<bool>? NodePortSupport { get; set; }
 
         /// <summary>
-        /// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-        /// Valid values are NONE and OVERWRITE.
-        /// 
-        /// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+        /// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         /// </summary>
         [Input("resolveConflictsOnCreate")]
-        public Input<string>? ResolveConflictsOnCreate { get; set; }
+        public Pulumi.Eks.ResolveConflictsOnCreate? ResolveConflictsOnCreate { get; set; }
 
         /// <summary>
-        /// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-        /// Valid values are NONE, OVERWRITE, and PRESERVE.
-        /// 
-        /// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        /// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         /// </summary>
         [Input("resolveConflictsOnUpdate")]
-        public Input<string>? ResolveConflictsOnUpdate { get; set; }
+        public Pulumi.Eks.ResolveConflictsOnUpdate? ResolveConflictsOnUpdate { get; set; }
 
         /// <summary>
         /// Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
@@ -270,6 +264,8 @@ namespace Pulumi.Eks
 
         public VpcCniAddonArgs()
         {
+            ResolveConflictsOnCreate = Pulumi.Eks.ResolveConflictsOnCreate.Overwrite;
+            ResolveConflictsOnUpdate = Pulumi.Eks.ResolveConflictsOnUpdate.Overwrite;
         }
         public static new VpcCniAddonArgs Empty => new VpcCniAddonArgs();
     }

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -85,6 +85,9 @@ func NewCluster(ctx *pulumi.Context,
 	if args.KubeProxyAddonOptions != nil {
 		args.KubeProxyAddonOptions = args.KubeProxyAddonOptions.Defaults()
 	}
+	if args.VpcCniOptions != nil {
+		args.VpcCniOptions = args.VpcCniOptions.Defaults()
+	}
 	opts = utilities.PkgResourceDefaultOpts(opts)
 	var resource Cluster
 	err := ctx.RegisterRemoteComponentResource("eks:index:Cluster", name, args, &resource, opts...)

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -1598,7 +1598,9 @@ func (o CoreDataOutput) VpcId() pulumi.StringOutput {
 }
 
 type CoreDnsAddonOptions struct {
-	// Whether or not to create the Addon in the cluster
+	// Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+	ConfigurationValues map[string]interface{} `pulumi:"configurationValues"`
+	// Whether or not to create the `coredns` Addon in the cluster
 	Enabled *bool `pulumi:"enabled"`
 	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
 	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
@@ -1641,7 +1643,9 @@ type CoreDnsAddonOptionsInput interface {
 }
 
 type CoreDnsAddonOptionsArgs struct {
-	// Whether or not to create the Addon in the cluster
+	// Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+	ConfigurationValues pulumi.MapInput `pulumi:"configurationValues"`
+	// Whether or not to create the `coredns` Addon in the cluster
 	Enabled *bool `pulumi:"enabled"`
 	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
 	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
@@ -1748,7 +1752,12 @@ func (o CoreDnsAddonOptionsOutput) ToCoreDnsAddonOptionsPtrOutputWithContext(ctx
 	}).(CoreDnsAddonOptionsPtrOutput)
 }
 
-// Whether or not to create the Addon in the cluster
+// Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+func (o CoreDnsAddonOptionsOutput) ConfigurationValues() pulumi.MapOutput {
+	return o.ApplyT(func(v CoreDnsAddonOptions) map[string]interface{} { return v.ConfigurationValues }).(pulumi.MapOutput)
+}
+
+// Whether or not to create the `coredns` Addon in the cluster
 func (o CoreDnsAddonOptionsOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v CoreDnsAddonOptions) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
 }
@@ -1792,7 +1801,17 @@ func (o CoreDnsAddonOptionsPtrOutput) Elem() CoreDnsAddonOptionsOutput {
 	}).(CoreDnsAddonOptionsOutput)
 }
 
-// Whether or not to create the Addon in the cluster
+// Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+func (o CoreDnsAddonOptionsPtrOutput) ConfigurationValues() pulumi.MapOutput {
+	return o.ApplyT(func(v *CoreDnsAddonOptions) map[string]interface{} {
+		if v == nil {
+			return nil
+		}
+		return v.ConfigurationValues
+	}).(pulumi.MapOutput)
+}
+
+// Whether or not to create the `coredns` Addon in the cluster
 func (o CoreDnsAddonOptionsPtrOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *CoreDnsAddonOptions) *bool {
 		if v == nil {
@@ -2168,6 +2187,8 @@ func (o FargateProfilePtrOutput) SubnetIds() pulumi.StringArrayOutput {
 }
 
 type KubeProxyAddonOptions struct {
+	// Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+	ConfigurationValues map[string]interface{} `pulumi:"configurationValues"`
 	// Whether or not to create the `kube-proxy` Addon in the cluster
 	Enabled *bool `pulumi:"enabled"`
 	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
@@ -2211,6 +2232,8 @@ type KubeProxyAddonOptionsInput interface {
 }
 
 type KubeProxyAddonOptionsArgs struct {
+	// Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+	ConfigurationValues pulumi.MapInput `pulumi:"configurationValues"`
 	// Whether or not to create the `kube-proxy` Addon in the cluster
 	Enabled *bool `pulumi:"enabled"`
 	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
@@ -2318,6 +2341,11 @@ func (o KubeProxyAddonOptionsOutput) ToKubeProxyAddonOptionsPtrOutputWithContext
 	}).(KubeProxyAddonOptionsPtrOutput)
 }
 
+// Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+func (o KubeProxyAddonOptionsOutput) ConfigurationValues() pulumi.MapOutput {
+	return o.ApplyT(func(v KubeProxyAddonOptions) map[string]interface{} { return v.ConfigurationValues }).(pulumi.MapOutput)
+}
+
 // Whether or not to create the `kube-proxy` Addon in the cluster
 func (o KubeProxyAddonOptionsOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v KubeProxyAddonOptions) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
@@ -2360,6 +2388,16 @@ func (o KubeProxyAddonOptionsPtrOutput) Elem() KubeProxyAddonOptionsOutput {
 		var ret KubeProxyAddonOptions
 		return ret
 	}).(KubeProxyAddonOptionsOutput)
+}
+
+// Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+func (o KubeProxyAddonOptionsPtrOutput) ConfigurationValues() pulumi.MapOutput {
+	return o.ApplyT(func(v *KubeProxyAddonOptions) map[string]interface{} {
+		if v == nil {
+			return nil
+		}
+		return v.ConfigurationValues
+	}).(pulumi.MapOutput)
 }
 
 // Whether or not to create the `kube-proxy` Addon in the cluster
@@ -3447,16 +3485,10 @@ type VpcCniOptions struct {
 	//
 	// Defaults to true.
 	NodePortSupport *bool `pulumi:"nodePortSupport"`
-	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-	// Valid values are NONE and OVERWRITE.
-	//
-	// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-	ResolveConflictsOnCreate *string `pulumi:"resolveConflictsOnCreate"`
-	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-	// Valid values are NONE, OVERWRITE, and PRESERVE.
-	//
-	// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-	ResolveConflictsOnUpdate *string `pulumi:"resolveConflictsOnUpdate"`
+	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
+	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+	ResolveConflictsOnUpdate *ResolveConflictsOnUpdate `pulumi:"resolveConflictsOnUpdate"`
 	// Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
 	SecurityContextPrivileged *bool `pulumi:"securityContextPrivileged"`
 	// The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.
@@ -3479,6 +3511,23 @@ type VpcCniOptions struct {
 	WarmIpTarget *int `pulumi:"warmIpTarget"`
 	// WARM_PREFIX_TARGET will allocate one full (/28) prefix even if a single IP  is consumed with the existing prefix. Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md
 	WarmPrefixTarget *int `pulumi:"warmPrefixTarget"`
+}
+
+// Defaults sets the appropriate defaults for VpcCniOptions
+func (val *VpcCniOptions) Defaults() *VpcCniOptions {
+	if val == nil {
+		return nil
+	}
+	tmp := *val
+	if tmp.ResolveConflictsOnCreate == nil {
+		resolveConflictsOnCreate_ := ResolveConflictsOnCreate("OVERWRITE")
+		tmp.ResolveConflictsOnCreate = &resolveConflictsOnCreate_
+	}
+	if tmp.ResolveConflictsOnUpdate == nil {
+		resolveConflictsOnUpdate_ := ResolveConflictsOnUpdate("OVERWRITE")
+		tmp.ResolveConflictsOnUpdate = &resolveConflictsOnUpdate_
+	}
+	return &tmp
 }
 
 // VpcCniOptionsInput is an input type that accepts VpcCniOptionsArgs and VpcCniOptionsOutput values.
@@ -3544,16 +3593,10 @@ type VpcCniOptionsArgs struct {
 	//
 	// Defaults to true.
 	NodePortSupport pulumi.BoolPtrInput `pulumi:"nodePortSupport"`
-	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-	// Valid values are NONE and OVERWRITE.
-	//
-	// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-	ResolveConflictsOnCreate pulumi.StringPtrInput `pulumi:"resolveConflictsOnCreate"`
-	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-	// Valid values are NONE, OVERWRITE, and PRESERVE.
-	//
-	// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-	ResolveConflictsOnUpdate pulumi.StringPtrInput `pulumi:"resolveConflictsOnUpdate"`
+	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
+	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+	ResolveConflictsOnUpdate *ResolveConflictsOnUpdate `pulumi:"resolveConflictsOnUpdate"`
 	// Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
 	SecurityContextPrivileged pulumi.BoolPtrInput `pulumi:"securityContextPrivileged"`
 	// The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.
@@ -3578,6 +3621,22 @@ type VpcCniOptionsArgs struct {
 	WarmPrefixTarget pulumi.IntPtrInput `pulumi:"warmPrefixTarget"`
 }
 
+// Defaults sets the appropriate defaults for VpcCniOptionsArgs
+func (val *VpcCniOptionsArgs) Defaults() *VpcCniOptionsArgs {
+	if val == nil {
+		return nil
+	}
+	tmp := *val
+	if tmp.ResolveConflictsOnCreate == nil {
+		resolveConflictsOnCreate_ := ResolveConflictsOnCreate("OVERWRITE")
+		tmp.ResolveConflictsOnCreate = &resolveConflictsOnCreate_
+	}
+	if tmp.ResolveConflictsOnUpdate == nil {
+		resolveConflictsOnUpdate_ := ResolveConflictsOnUpdate("OVERWRITE")
+		tmp.ResolveConflictsOnUpdate = &resolveConflictsOnUpdate_
+	}
+	return &tmp
+}
 func (VpcCniOptionsArgs) ElementType() reflect.Type {
 	return reflect.TypeOf((*VpcCniOptions)(nil)).Elem()
 }
@@ -3754,20 +3813,14 @@ func (o VpcCniOptionsOutput) NodePortSupport() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v VpcCniOptions) *bool { return v.NodePortSupport }).(pulumi.BoolPtrOutput)
 }
 
-// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-// Valid values are NONE and OVERWRITE.
-//
-// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-func (o VpcCniOptionsOutput) ResolveConflictsOnCreate() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VpcCniOptions) *string { return v.ResolveConflictsOnCreate }).(pulumi.StringPtrOutput)
+// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+func (o VpcCniOptionsOutput) ResolveConflictsOnCreate() ResolveConflictsOnCreatePtrOutput {
+	return o.ApplyT(func(v VpcCniOptions) *ResolveConflictsOnCreate { return v.ResolveConflictsOnCreate }).(ResolveConflictsOnCreatePtrOutput)
 }
 
-// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-// Valid values are NONE, OVERWRITE, and PRESERVE.
-//
-// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-func (o VpcCniOptionsOutput) ResolveConflictsOnUpdate() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v VpcCniOptions) *string { return v.ResolveConflictsOnUpdate }).(pulumi.StringPtrOutput)
+// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+func (o VpcCniOptionsOutput) ResolveConflictsOnUpdate() ResolveConflictsOnUpdatePtrOutput {
+	return o.ApplyT(func(v VpcCniOptions) *ResolveConflictsOnUpdate { return v.ResolveConflictsOnUpdate }).(ResolveConflictsOnUpdatePtrOutput)
 }
 
 // Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
@@ -4012,30 +4065,24 @@ func (o VpcCniOptionsPtrOutput) NodePortSupport() pulumi.BoolPtrOutput {
 	}).(pulumi.BoolPtrOutput)
 }
 
-// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-// Valid values are NONE and OVERWRITE.
-//
-// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-func (o VpcCniOptionsPtrOutput) ResolveConflictsOnCreate() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *VpcCniOptions) *string {
+// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+func (o VpcCniOptionsPtrOutput) ResolveConflictsOnCreate() ResolveConflictsOnCreatePtrOutput {
+	return o.ApplyT(func(v *VpcCniOptions) *ResolveConflictsOnCreate {
 		if v == nil {
 			return nil
 		}
 		return v.ResolveConflictsOnCreate
-	}).(pulumi.StringPtrOutput)
+	}).(ResolveConflictsOnCreatePtrOutput)
 }
 
-// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-// Valid values are NONE, OVERWRITE, and PRESERVE.
-//
-// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-func (o VpcCniOptionsPtrOutput) ResolveConflictsOnUpdate() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *VpcCniOptions) *string {
+// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+func (o VpcCniOptionsPtrOutput) ResolveConflictsOnUpdate() ResolveConflictsOnUpdatePtrOutput {
+	return o.ApplyT(func(v *VpcCniOptions) *ResolveConflictsOnUpdate {
 		if v == nil {
 			return nil
 		}
 		return v.ResolveConflictsOnUpdate
-	}).(pulumi.StringPtrOutput)
+	}).(ResolveConflictsOnUpdatePtrOutput)
 }
 
 // Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default

--- a/sdk/go/eks/vpcCniAddon.go
+++ b/sdk/go/eks/vpcCniAddon.go
@@ -28,6 +28,14 @@ func NewVpcCniAddon(ctx *pulumi.Context,
 	if args.ClusterName == nil {
 		return nil, errors.New("invalid value for required argument 'ClusterName'")
 	}
+	if args.ResolveConflictsOnCreate == nil {
+		resolveConflictsOnCreate_ := ResolveConflictsOnCreate("OVERWRITE")
+		args.ResolveConflictsOnCreate = &resolveConflictsOnCreate_
+	}
+	if args.ResolveConflictsOnUpdate == nil {
+		resolveConflictsOnUpdate_ := ResolveConflictsOnUpdate("OVERWRITE")
+		args.ResolveConflictsOnUpdate = &resolveConflictsOnUpdate_
+	}
 	opts = utilities.PkgResourceDefaultOpts(opts)
 	var resource VpcCniAddon
 	err := ctx.RegisterResource("eks:index:VpcCniAddon", name, args, &resource, opts...)
@@ -115,16 +123,10 @@ type vpcCniAddonArgs struct {
 	//
 	// Defaults to true.
 	NodePortSupport *bool `pulumi:"nodePortSupport"`
-	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-	// Valid values are NONE and OVERWRITE.
-	//
-	// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-	ResolveConflictsOnCreate *string `pulumi:"resolveConflictsOnCreate"`
-	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-	// Valid values are NONE, OVERWRITE, and PRESERVE.
-	//
-	// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-	ResolveConflictsOnUpdate *string `pulumi:"resolveConflictsOnUpdate"`
+	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
+	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+	ResolveConflictsOnUpdate *ResolveConflictsOnUpdate `pulumi:"resolveConflictsOnUpdate"`
 	// Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
 	SecurityContextPrivileged *bool `pulumi:"securityContextPrivileged"`
 	// The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.
@@ -207,16 +209,10 @@ type VpcCniAddonArgs struct {
 	//
 	// Defaults to true.
 	NodePortSupport pulumi.BoolPtrInput
-	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-	// Valid values are NONE and OVERWRITE.
-	//
-	// For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-	ResolveConflictsOnCreate pulumi.StringPtrInput
-	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-	// Valid values are NONE, OVERWRITE, and PRESERVE.
-	//
-	// For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-	ResolveConflictsOnUpdate pulumi.StringPtrInput
+	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+	ResolveConflictsOnCreate *ResolveConflictsOnCreate
+	// How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+	ResolveConflictsOnUpdate *ResolveConflictsOnUpdate
 	// Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
 	SecurityContextPrivileged pulumi.BoolPtrInput
 	// The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.

--- a/sdk/java/src/main/java/com/pulumi/eks/VpcCniAddonArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/VpcCniAddonArgs.java
@@ -5,6 +5,9 @@ package com.pulumi.eks;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
+import com.pulumi.eks.enums.ResolveConflictsOnCreate;
+import com.pulumi.eks.enums.ResolveConflictsOnUpdate;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.Object;
@@ -327,44 +330,32 @@ public final class VpcCniAddonArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-     * Valid values are NONE and OVERWRITE.
-     * 
-     * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+     * How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
      * 
      */
     @Import(name="resolveConflictsOnCreate")
-    private @Nullable Output<String> resolveConflictsOnCreate;
+    private @Nullable ResolveConflictsOnCreate resolveConflictsOnCreate;
 
     /**
-     * @return How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-     * Valid values are NONE and OVERWRITE.
-     * 
-     * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+     * @return How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
      * 
      */
-    public Optional<Output<String>> resolveConflictsOnCreate() {
+    public Optional<ResolveConflictsOnCreate> resolveConflictsOnCreate() {
         return Optional.ofNullable(this.resolveConflictsOnCreate);
     }
 
     /**
-     * How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-     * Valid values are NONE, OVERWRITE, and PRESERVE.
-     * 
-     * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+     * How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
      * 
      */
     @Import(name="resolveConflictsOnUpdate")
-    private @Nullable Output<String> resolveConflictsOnUpdate;
+    private @Nullable ResolveConflictsOnUpdate resolveConflictsOnUpdate;
 
     /**
-     * @return How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-     * Valid values are NONE, OVERWRITE, and PRESERVE.
-     * 
-     * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+     * @return How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
      * 
      */
-    public Optional<Output<String>> resolveConflictsOnUpdate() {
+    public Optional<ResolveConflictsOnUpdate> resolveConflictsOnUpdate() {
         return Optional.ofNullable(this.resolveConflictsOnUpdate);
     }
 
@@ -958,57 +949,25 @@ public final class VpcCniAddonArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param resolveConflictsOnCreate How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-         * Valid values are NONE and OVERWRITE.
-         * 
-         * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+         * @param resolveConflictsOnCreate How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
          * 
          * @return builder
          * 
          */
-        public Builder resolveConflictsOnCreate(@Nullable Output<String> resolveConflictsOnCreate) {
+        public Builder resolveConflictsOnCreate(@Nullable ResolveConflictsOnCreate resolveConflictsOnCreate) {
             $.resolveConflictsOnCreate = resolveConflictsOnCreate;
             return this;
         }
 
         /**
-         * @param resolveConflictsOnCreate How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-         * Valid values are NONE and OVERWRITE.
-         * 
-         * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+         * @param resolveConflictsOnUpdate How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
          * 
          * @return builder
          * 
          */
-        public Builder resolveConflictsOnCreate(String resolveConflictsOnCreate) {
-            return resolveConflictsOnCreate(Output.of(resolveConflictsOnCreate));
-        }
-
-        /**
-         * @param resolveConflictsOnUpdate How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-         * Valid values are NONE, OVERWRITE, and PRESERVE.
-         * 
-         * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-         * 
-         * @return builder
-         * 
-         */
-        public Builder resolveConflictsOnUpdate(@Nullable Output<String> resolveConflictsOnUpdate) {
+        public Builder resolveConflictsOnUpdate(@Nullable ResolveConflictsOnUpdate resolveConflictsOnUpdate) {
             $.resolveConflictsOnUpdate = resolveConflictsOnUpdate;
             return this;
-        }
-
-        /**
-         * @param resolveConflictsOnUpdate How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-         * Valid values are NONE, OVERWRITE, and PRESERVE.
-         * 
-         * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-         * 
-         * @return builder
-         * 
-         */
-        public Builder resolveConflictsOnUpdate(String resolveConflictsOnUpdate) {
-            return resolveConflictsOnUpdate(Output.of(resolveConflictsOnUpdate));
         }
 
         /**
@@ -1190,6 +1149,8 @@ public final class VpcCniAddonArgs extends com.pulumi.resources.ResourceArgs {
 
         public VpcCniAddonArgs build() {
             $.clusterName = Objects.requireNonNull($.clusterName, "expected parameter 'clusterName' to be non-null");
+            $.resolveConflictsOnCreate = Codegen.objectProp("resolveConflictsOnCreate", ResolveConflictsOnCreate.class).arg($.resolveConflictsOnCreate).def(ResolveConflictsOnCreate.Overwrite).getNullable();
+            $.resolveConflictsOnUpdate = Codegen.objectProp("resolveConflictsOnUpdate", ResolveConflictsOnUpdate.class).arg($.resolveConflictsOnUpdate).def(ResolveConflictsOnUpdate.Overwrite).getNullable();
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/CoreDnsAddonOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/CoreDnsAddonOptionsArgs.java
@@ -9,7 +9,9 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.eks.enums.ResolveConflictsOnCreate;
 import com.pulumi.eks.enums.ResolveConflictsOnUpdate;
 import java.lang.Boolean;
+import java.lang.Object;
 import java.lang.String;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -20,14 +22,29 @@ public final class CoreDnsAddonOptionsArgs extends com.pulumi.resources.Resource
     public static final CoreDnsAddonOptionsArgs Empty = new CoreDnsAddonOptionsArgs();
 
     /**
-     * Whether or not to create the Addon in the cluster
+     * Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+     * 
+     */
+    @Import(name="configurationValues")
+    private @Nullable Output<Map<String,Object>> configurationValues;
+
+    /**
+     * @return Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+     * 
+     */
+    public Optional<Output<Map<String,Object>>> configurationValues() {
+        return Optional.ofNullable(this.configurationValues);
+    }
+
+    /**
+     * Whether or not to create the `coredns` Addon in the cluster
      * 
      */
     @Import(name="enabled")
     private @Nullable Boolean enabled;
 
     /**
-     * @return Whether or not to create the Addon in the cluster
+     * @return Whether or not to create the `coredns` Addon in the cluster
      * 
      */
     public Optional<Boolean> enabled() {
@@ -82,6 +99,7 @@ public final class CoreDnsAddonOptionsArgs extends com.pulumi.resources.Resource
     private CoreDnsAddonOptionsArgs() {}
 
     private CoreDnsAddonOptionsArgs(CoreDnsAddonOptionsArgs $) {
+        this.configurationValues = $.configurationValues;
         this.enabled = $.enabled;
         this.resolveConflictsOnCreate = $.resolveConflictsOnCreate;
         this.resolveConflictsOnUpdate = $.resolveConflictsOnUpdate;
@@ -107,7 +125,28 @@ public final class CoreDnsAddonOptionsArgs extends com.pulumi.resources.Resource
         }
 
         /**
-         * @param enabled Whether or not to create the Addon in the cluster
+         * @param configurationValues Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder configurationValues(@Nullable Output<Map<String,Object>> configurationValues) {
+            $.configurationValues = configurationValues;
+            return this;
+        }
+
+        /**
+         * @param configurationValues Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder configurationValues(Map<String,Object> configurationValues) {
+            return configurationValues(Output.of(configurationValues));
+        }
+
+        /**
+         * @param enabled Whether or not to create the `coredns` Addon in the cluster
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/KubeProxyAddonOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/KubeProxyAddonOptionsArgs.java
@@ -9,7 +9,9 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.eks.enums.ResolveConflictsOnCreate;
 import com.pulumi.eks.enums.ResolveConflictsOnUpdate;
 import java.lang.Boolean;
+import java.lang.Object;
 import java.lang.String;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -18,6 +20,21 @@ import javax.annotation.Nullable;
 public final class KubeProxyAddonOptionsArgs extends com.pulumi.resources.ResourceArgs {
 
     public static final KubeProxyAddonOptionsArgs Empty = new KubeProxyAddonOptionsArgs();
+
+    /**
+     * Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+     * 
+     */
+    @Import(name="configurationValues")
+    private @Nullable Output<Map<String,Object>> configurationValues;
+
+    /**
+     * @return Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+     * 
+     */
+    public Optional<Output<Map<String,Object>>> configurationValues() {
+        return Optional.ofNullable(this.configurationValues);
+    }
 
     /**
      * Whether or not to create the `kube-proxy` Addon in the cluster
@@ -82,6 +99,7 @@ public final class KubeProxyAddonOptionsArgs extends com.pulumi.resources.Resour
     private KubeProxyAddonOptionsArgs() {}
 
     private KubeProxyAddonOptionsArgs(KubeProxyAddonOptionsArgs $) {
+        this.configurationValues = $.configurationValues;
         this.enabled = $.enabled;
         this.resolveConflictsOnCreate = $.resolveConflictsOnCreate;
         this.resolveConflictsOnUpdate = $.resolveConflictsOnUpdate;
@@ -104,6 +122,27 @@ public final class KubeProxyAddonOptionsArgs extends com.pulumi.resources.Resour
 
         public Builder(KubeProxyAddonOptionsArgs defaults) {
             $ = new KubeProxyAddonOptionsArgs(Objects.requireNonNull(defaults));
+        }
+
+        /**
+         * @param configurationValues Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder configurationValues(@Nullable Output<Map<String,Object>> configurationValues) {
+            $.configurationValues = configurationValues;
+            return this;
+        }
+
+        /**
+         * @param configurationValues Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+         * 
+         * @return builder
+         * 
+         */
+        public Builder configurationValues(Map<String,Object> configurationValues) {
+            return configurationValues(Output.of(configurationValues));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/VpcCniOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/VpcCniOptionsArgs.java
@@ -5,6 +5,9 @@ package com.pulumi.eks.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
+import com.pulumi.eks.enums.ResolveConflictsOnCreate;
+import com.pulumi.eks.enums.ResolveConflictsOnUpdate;
 import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.Object;
@@ -300,44 +303,32 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-     * Valid values are NONE and OVERWRITE.
-     * 
-     * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+     * How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
      * 
      */
     @Import(name="resolveConflictsOnCreate")
-    private @Nullable Output<String> resolveConflictsOnCreate;
+    private @Nullable ResolveConflictsOnCreate resolveConflictsOnCreate;
 
     /**
-     * @return How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-     * Valid values are NONE and OVERWRITE.
-     * 
-     * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+     * @return How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
      * 
      */
-    public Optional<Output<String>> resolveConflictsOnCreate() {
+    public Optional<ResolveConflictsOnCreate> resolveConflictsOnCreate() {
         return Optional.ofNullable(this.resolveConflictsOnCreate);
     }
 
     /**
-     * How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-     * Valid values are NONE, OVERWRITE, and PRESERVE.
-     * 
-     * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+     * How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
      * 
      */
     @Import(name="resolveConflictsOnUpdate")
-    private @Nullable Output<String> resolveConflictsOnUpdate;
+    private @Nullable ResolveConflictsOnUpdate resolveConflictsOnUpdate;
 
     /**
-     * @return How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-     * Valid values are NONE, OVERWRITE, and PRESERVE.
-     * 
-     * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+     * @return How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
      * 
      */
-    public Optional<Output<String>> resolveConflictsOnUpdate() {
+    public Optional<ResolveConflictsOnUpdate> resolveConflictsOnUpdate() {
         return Optional.ofNullable(this.resolveConflictsOnUpdate);
     }
 
@@ -871,57 +862,25 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param resolveConflictsOnCreate How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-         * Valid values are NONE and OVERWRITE.
-         * 
-         * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+         * @param resolveConflictsOnCreate How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
          * 
          * @return builder
          * 
          */
-        public Builder resolveConflictsOnCreate(@Nullable Output<String> resolveConflictsOnCreate) {
+        public Builder resolveConflictsOnCreate(@Nullable ResolveConflictsOnCreate resolveConflictsOnCreate) {
             $.resolveConflictsOnCreate = resolveConflictsOnCreate;
             return this;
         }
 
         /**
-         * @param resolveConflictsOnCreate How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-         * Valid values are NONE and OVERWRITE.
-         * 
-         * For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+         * @param resolveConflictsOnUpdate How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
          * 
          * @return builder
          * 
          */
-        public Builder resolveConflictsOnCreate(String resolveConflictsOnCreate) {
-            return resolveConflictsOnCreate(Output.of(resolveConflictsOnCreate));
-        }
-
-        /**
-         * @param resolveConflictsOnUpdate How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-         * Valid values are NONE, OVERWRITE, and PRESERVE.
-         * 
-         * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-         * 
-         * @return builder
-         * 
-         */
-        public Builder resolveConflictsOnUpdate(@Nullable Output<String> resolveConflictsOnUpdate) {
+        public Builder resolveConflictsOnUpdate(@Nullable ResolveConflictsOnUpdate resolveConflictsOnUpdate) {
             $.resolveConflictsOnUpdate = resolveConflictsOnUpdate;
             return this;
-        }
-
-        /**
-         * @param resolveConflictsOnUpdate How to resolve field value conflicts for an Amazon EKS add-on if you&#39;ve changed a value from theAmazon EKS default value.
-         * Valid values are NONE, OVERWRITE, and PRESERVE.
-         * 
-         * For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
-         * 
-         * @return builder
-         * 
-         */
-        public Builder resolveConflictsOnUpdate(String resolveConflictsOnUpdate) {
-            return resolveConflictsOnUpdate(Output.of(resolveConflictsOnUpdate));
         }
 
         /**
@@ -1071,6 +1030,8 @@ public final class VpcCniOptionsArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public VpcCniOptionsArgs build() {
+            $.resolveConflictsOnCreate = Codegen.objectProp("resolveConflictsOnCreate", ResolveConflictsOnCreate.class).arg($.resolveConflictsOnCreate).def(ResolveConflictsOnCreate.Overwrite).getNullable();
+            $.resolveConflictsOnUpdate = Codegen.objectProp("resolveConflictsOnUpdate", ResolveConflictsOnUpdate.class).arg($.resolveConflictsOnUpdate).def(ResolveConflictsOnUpdate.Overwrite).getNullable();
             return $;
         }
     }

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -1226,16 +1226,20 @@ class CoreDataArgs:
 @pulumi.input_type
 class CoreDnsAddonOptionsArgs:
     def __init__(__self__, *,
+                 configuration_values: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  enabled: Optional[bool] = None,
                  resolve_conflicts_on_create: Optional['ResolveConflictsOnCreate'] = None,
                  resolve_conflicts_on_update: Optional['ResolveConflictsOnUpdate'] = None,
                  version: Optional[pulumi.Input[str]] = None):
         """
-        :param bool enabled: Whether or not to create the Addon in the cluster
+        :param pulumi.Input[Mapping[str, Any]] configuration_values: Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+        :param bool enabled: Whether or not to create the `coredns` Addon in the cluster
         :param 'ResolveConflictsOnCreate' resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         :param 'ResolveConflictsOnUpdate' resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value. Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         :param pulumi.Input[str] version: The version of the EKS add-on. The version must match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
         """
+        if configuration_values is not None:
+            pulumi.set(__self__, "configuration_values", configuration_values)
         if enabled is None:
             enabled = True
         if enabled is not None:
@@ -1252,10 +1256,22 @@ class CoreDnsAddonOptionsArgs:
             pulumi.set(__self__, "version", version)
 
     @property
+    @pulumi.getter(name="configurationValues")
+    def configuration_values(self) -> Optional[pulumi.Input[Mapping[str, Any]]]:
+        """
+        Custom configuration values for the coredns addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+        """
+        return pulumi.get(self, "configuration_values")
+
+    @configuration_values.setter
+    def configuration_values(self, value: Optional[pulumi.Input[Mapping[str, Any]]]):
+        pulumi.set(self, "configuration_values", value)
+
+    @property
     @pulumi.getter
     def enabled(self) -> Optional[bool]:
         """
-        Whether or not to create the Addon in the cluster
+        Whether or not to create the `coredns` Addon in the cluster
         """
         return pulumi.get(self, "enabled")
 
@@ -1391,16 +1407,20 @@ class FargateProfileArgs:
 @pulumi.input_type
 class KubeProxyAddonOptionsArgs:
     def __init__(__self__, *,
+                 configuration_values: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  enabled: Optional[bool] = None,
                  resolve_conflicts_on_create: Optional['ResolveConflictsOnCreate'] = None,
                  resolve_conflicts_on_update: Optional['ResolveConflictsOnUpdate'] = None,
                  version: Optional[pulumi.Input[str]] = None):
         """
+        :param pulumi.Input[Mapping[str, Any]] configuration_values: Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
         :param bool enabled: Whether or not to create the `kube-proxy` Addon in the cluster
         :param 'ResolveConflictsOnCreate' resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         :param 'ResolveConflictsOnUpdate' resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value. Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         :param pulumi.Input[str] version: The version of the EKS add-on. The version must match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
         """
+        if configuration_values is not None:
+            pulumi.set(__self__, "configuration_values", configuration_values)
         if enabled is None:
             enabled = True
         if enabled is not None:
@@ -1415,6 +1435,18 @@ class KubeProxyAddonOptionsArgs:
             pulumi.set(__self__, "resolve_conflicts_on_update", resolve_conflicts_on_update)
         if version is not None:
             pulumi.set(__self__, "version", version)
+
+    @property
+    @pulumi.getter(name="configurationValues")
+    def configuration_values(self) -> Optional[pulumi.Input[Mapping[str, Any]]]:
+        """
+        Custom configuration values for the kube-proxy addon. This object must match the schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
+        """
+        return pulumi.get(self, "configuration_values")
+
+    @configuration_values.setter
+    def configuration_values(self, value: Optional[pulumi.Input[Mapping[str, Any]]]):
+        pulumi.set(self, "configuration_values", value)
 
     @property
     @pulumi.getter
@@ -1922,8 +1954,8 @@ class VpcCniOptionsArgs:
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
-                 resolve_conflicts_on_create: Optional[pulumi.Input[str]] = None,
-                 resolve_conflicts_on_update: Optional[pulumi.Input[str]] = None,
+                 resolve_conflicts_on_create: Optional['ResolveConflictsOnCreate'] = None,
+                 resolve_conflicts_on_update: Optional['ResolveConflictsOnUpdate'] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  service_account_role_arn: Optional[pulumi.Input[str]] = None,
                  veth_prefix: Optional[pulumi.Input[str]] = None,
@@ -1966,14 +1998,8 @@ class VpcCniOptionsArgs:
         :param pulumi.Input[bool] node_port_support: Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
                
                Defaults to true.
-        :param pulumi.Input[str] resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-               Valid values are NONE and OVERWRITE.
-               
-               For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-        :param pulumi.Input[str] resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-               Valid values are NONE, OVERWRITE, and PRESERVE.
-               
-               For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        :param 'ResolveConflictsOnCreate' resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+        :param 'ResolveConflictsOnUpdate' resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         :param pulumi.Input[bool] security_context_privileged: Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
         :param pulumi.Input[str] service_account_role_arn: The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.
                
@@ -2023,8 +2049,12 @@ class VpcCniOptionsArgs:
             pulumi.set(__self__, "log_level", log_level)
         if node_port_support is not None:
             pulumi.set(__self__, "node_port_support", node_port_support)
+        if resolve_conflicts_on_create is None:
+            resolve_conflicts_on_create = 'OVERWRITE'
         if resolve_conflicts_on_create is not None:
             pulumi.set(__self__, "resolve_conflicts_on_create", resolve_conflicts_on_create)
+        if resolve_conflicts_on_update is None:
+            resolve_conflicts_on_update = 'OVERWRITE'
         if resolve_conflicts_on_update is not None:
             pulumi.set(__self__, "resolve_conflicts_on_update", resolve_conflicts_on_update)
         if security_context_privileged is not None:
@@ -2252,32 +2282,26 @@ class VpcCniOptionsArgs:
 
     @property
     @pulumi.getter(name="resolveConflictsOnCreate")
-    def resolve_conflicts_on_create(self) -> Optional[pulumi.Input[str]]:
+    def resolve_conflicts_on_create(self) -> Optional['ResolveConflictsOnCreate']:
         """
-        How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-        Valid values are NONE and OVERWRITE.
-
-        For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+        How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         """
         return pulumi.get(self, "resolve_conflicts_on_create")
 
     @resolve_conflicts_on_create.setter
-    def resolve_conflicts_on_create(self, value: Optional[pulumi.Input[str]]):
+    def resolve_conflicts_on_create(self, value: Optional['ResolveConflictsOnCreate']):
         pulumi.set(self, "resolve_conflicts_on_create", value)
 
     @property
     @pulumi.getter(name="resolveConflictsOnUpdate")
-    def resolve_conflicts_on_update(self) -> Optional[pulumi.Input[str]]:
+    def resolve_conflicts_on_update(self) -> Optional['ResolveConflictsOnUpdate']:
         """
-        How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-        Valid values are NONE, OVERWRITE, and PRESERVE.
-
-        For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         """
         return pulumi.get(self, "resolve_conflicts_on_update")
 
     @resolve_conflicts_on_update.setter
-    def resolve_conflicts_on_update(self, value: Optional[pulumi.Input[str]]):
+    def resolve_conflicts_on_update(self, value: Optional['ResolveConflictsOnUpdate']):
         pulumi.set(self, "resolve_conflicts_on_update", value)
 
     @property

--- a/sdk/python/pulumi_eks/vpc_cni_addon.py
+++ b/sdk/python/pulumi_eks/vpc_cni_addon.py
@@ -8,6 +8,7 @@ import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
 from . import _utilities
+from ._enums import *
 
 __all__ = ['VpcCniAddonArgs', 'VpcCniAddon']
 
@@ -32,8 +33,8 @@ class VpcCniAddonArgs:
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
-                 resolve_conflicts_on_create: Optional[pulumi.Input[str]] = None,
-                 resolve_conflicts_on_update: Optional[pulumi.Input[str]] = None,
+                 resolve_conflicts_on_create: Optional['ResolveConflictsOnCreate'] = None,
+                 resolve_conflicts_on_update: Optional['ResolveConflictsOnUpdate'] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  service_account_role_arn: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
@@ -79,14 +80,8 @@ class VpcCniAddonArgs:
         :param pulumi.Input[bool] node_port_support: Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
                
                Defaults to true.
-        :param pulumi.Input[str] resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-               Valid values are NONE and OVERWRITE.
-               
-               For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-        :param pulumi.Input[str] resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-               Valid values are NONE, OVERWRITE, and PRESERVE.
-               
-               For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        :param 'ResolveConflictsOnCreate' resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+        :param 'ResolveConflictsOnUpdate' resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         :param pulumi.Input[bool] security_context_privileged: Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
         :param pulumi.Input[str] service_account_role_arn: The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.
                
@@ -140,8 +135,12 @@ class VpcCniAddonArgs:
             pulumi.set(__self__, "log_level", log_level)
         if node_port_support is not None:
             pulumi.set(__self__, "node_port_support", node_port_support)
+        if resolve_conflicts_on_create is None:
+            resolve_conflicts_on_create = 'OVERWRITE'
         if resolve_conflicts_on_create is not None:
             pulumi.set(__self__, "resolve_conflicts_on_create", resolve_conflicts_on_create)
+        if resolve_conflicts_on_update is None:
+            resolve_conflicts_on_update = 'OVERWRITE'
         if resolve_conflicts_on_update is not None:
             pulumi.set(__self__, "resolve_conflicts_on_update", resolve_conflicts_on_update)
         if security_context_privileged is not None:
@@ -395,32 +394,26 @@ class VpcCniAddonArgs:
 
     @property
     @pulumi.getter(name="resolveConflictsOnCreate")
-    def resolve_conflicts_on_create(self) -> Optional[pulumi.Input[str]]:
+    def resolve_conflicts_on_create(self) -> Optional['ResolveConflictsOnCreate']:
         """
-        How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-        Valid values are NONE and OVERWRITE.
-
-        For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
+        How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         """
         return pulumi.get(self, "resolve_conflicts_on_create")
 
     @resolve_conflicts_on_create.setter
-    def resolve_conflicts_on_create(self, value: Optional[pulumi.Input[str]]):
+    def resolve_conflicts_on_create(self, value: Optional['ResolveConflictsOnCreate']):
         pulumi.set(self, "resolve_conflicts_on_create", value)
 
     @property
     @pulumi.getter(name="resolveConflictsOnUpdate")
-    def resolve_conflicts_on_update(self) -> Optional[pulumi.Input[str]]:
+    def resolve_conflicts_on_update(self) -> Optional['ResolveConflictsOnUpdate']:
         """
-        How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-        Valid values are NONE, OVERWRITE, and PRESERVE.
-
-        For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         """
         return pulumi.get(self, "resolve_conflicts_on_update")
 
     @resolve_conflicts_on_update.setter
-    def resolve_conflicts_on_update(self, value: Optional[pulumi.Input[str]]):
+    def resolve_conflicts_on_update(self, value: Optional['ResolveConflictsOnUpdate']):
         pulumi.set(self, "resolve_conflicts_on_update", value)
 
     @property
@@ -541,8 +534,8 @@ class VpcCniAddon(pulumi.CustomResource):
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
-                 resolve_conflicts_on_create: Optional[pulumi.Input[str]] = None,
-                 resolve_conflicts_on_update: Optional[pulumi.Input[str]] = None,
+                 resolve_conflicts_on_create: Optional['ResolveConflictsOnCreate'] = None,
+                 resolve_conflicts_on_update: Optional['ResolveConflictsOnUpdate'] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  service_account_role_arn: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
@@ -593,14 +586,8 @@ class VpcCniAddon(pulumi.CustomResource):
         :param pulumi.Input[bool] node_port_support: Specifies whether NodePort services are enabled on a worker node's primary network interface. This requires additional iptables rules and that the kernel's reverse path filter on the primary interface is set to loose.
                
                Defaults to true.
-        :param pulumi.Input[str] resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on.
-               Valid values are NONE and OVERWRITE.
-               
-               For more details see the [CreateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html).
-        :param pulumi.Input[str] resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from theAmazon EKS default value.
-               Valid values are NONE, OVERWRITE, and PRESERVE.
-               
-               For more details see the [UpdateAddon API Docs](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html).
+        :param 'ResolveConflictsOnCreate' resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
+        :param 'ResolveConflictsOnUpdate' resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value.  Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         :param pulumi.Input[bool] security_context_privileged: Pass privilege to containers securityContext. This is required when SELinux is enabled. This value will not be passed to the CNI config by default
         :param pulumi.Input[str] service_account_role_arn: The Amazon Resource Name (ARN) of an existing IAM role to bind to the add-on's service account. The role must be assigned the IAM permissions required by the add-on. If you don't specify an existing IAM role, then the add-on uses the permissions assigned to the node IAM role.
                
@@ -662,8 +649,8 @@ class VpcCniAddon(pulumi.CustomResource):
                  log_file: Optional[pulumi.Input[str]] = None,
                  log_level: Optional[pulumi.Input[str]] = None,
                  node_port_support: Optional[pulumi.Input[bool]] = None,
-                 resolve_conflicts_on_create: Optional[pulumi.Input[str]] = None,
-                 resolve_conflicts_on_update: Optional[pulumi.Input[str]] = None,
+                 resolve_conflicts_on_create: Optional['ResolveConflictsOnCreate'] = None,
+                 resolve_conflicts_on_update: Optional['ResolveConflictsOnUpdate'] = None,
                  security_context_privileged: Optional[pulumi.Input[bool]] = None,
                  service_account_role_arn: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
@@ -700,7 +687,11 @@ class VpcCniAddon(pulumi.CustomResource):
             __props__.__dict__["log_file"] = log_file
             __props__.__dict__["log_level"] = log_level
             __props__.__dict__["node_port_support"] = node_port_support
+            if resolve_conflicts_on_create is None:
+                resolve_conflicts_on_create = 'OVERWRITE'
             __props__.__dict__["resolve_conflicts_on_create"] = resolve_conflicts_on_create
+            if resolve_conflicts_on_update is None:
+                resolve_conflicts_on_update = 'OVERWRITE'
             __props__.__dict__["resolve_conflicts_on_update"] = resolve_conflicts_on_update
             __props__.__dict__["security_context_privileged"] = security_context_privileged
             __props__.__dict__["service_account_role_arn"] = service_account_role_arn


### PR DESCRIPTION
Now that the EKS addons are added we need to align them and do some cleanup. This involves:
- adding the enums introduced in https://github.com/pulumi/pulumi-eks/pull/1357 to the VPC CNI
- exposing configurationValues for coredns and kube-proxy
- removing kubectl from the provider
- deeply sort addon configuration keys to guarantee stable json serialization
- remove deepmerge again. It caused issues during unit tests (https://github.com/voodoocreation/ts-deepmerge/issues/22) and when used on outputs.

Additionally I discovered and fixed an old bug that luckily never surfaced. The VPC CNI configuration did incorrectly handle outputs and called `toString` on them in a couple of places. The increased type safety and tests around addon configuration uncovered this.

Closes #1369