### PR TITLE
Only create coredns addon in clusters with default node groups 

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -654,12 +654,14 @@ export function createCore(
         );
     }
 
+    const corednsExplicitlyEnabled = args.corednsAddonOptions?.enabled === true;
     // We can only enable the coredns addon if using we have a node group to place it on
     // This means we are either using the default node group or the cluster is a fargate cluster
+    // Also, if the user explicitly enables it then do what they want
     pulumi.output(args.fargate).apply((fargate) => {
         if (
-            (fargate || !args.skipDefaultNodeGroup) &&
-            (args.corednsAddonOptions?.enabled ?? true)
+            corednsExplicitlyEnabled ||
+            ((fargate || !args.skipDefaultNodeGroup) && (args.corednsAddonOptions?.enabled ?? true))
         ) {
             const corednsVersion: pulumi.Output<string> = args.corednsAddonOptions?.version
                 ? pulumi.output(args.corednsAddonOptions.version)

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -656,20 +656,23 @@ export function createCore(
 
     // We can only enable the coredns addon if using we have a node group to place it on
     // This means we are either using the default node group or the cluster is a fargate cluster
-    pulumi.output(args.fargate).apply(fargate => {
-        if ((fargate || !args.skipDefaultNodeGroup) && (args.corednsAddonOptions?.enabled ?? true)) {
+    pulumi.output(args.fargate).apply((fargate) => {
+        if (
+            (fargate || !args.skipDefaultNodeGroup) &&
+            (args.corednsAddonOptions?.enabled ?? true)
+        ) {
             const corednsVersion: pulumi.Output<string> = args.corednsAddonOptions?.version
                 ? pulumi.output(args.corednsAddonOptions.version)
                 : aws.eks
-                    .getAddonVersionOutput(
-                        {
-                            addonName: "coredns",
-                            kubernetesVersion: eksCluster.version,
-                            mostRecent: true, // whether to return the default version or the most recent version for the specified kubernetes version
-                        },
-                        { parent, provider },
-                    )
-                    .apply((addonVersion) => addonVersion.version);
+                      .getAddonVersionOutput(
+                          {
+                              addonName: "coredns",
+                              kubernetesVersion: eksCluster.version,
+                              mostRecent: true, // whether to return the default version or the most recent version for the specified kubernetes version
+                          },
+                          { parent, provider },
+                      )
+                      .apply((addonVersion) => addonVersion.version);
 
             const corednsAddon = new aws.eks.Addon(
                 `${name}-coredns`,
@@ -683,14 +686,16 @@ export function createCore(
                         args.corednsAddonOptions?.resolveConflictsOnCreate ?? "OVERWRITE",
                     resolveConflictsOnUpdate:
                         args.corednsAddonOptions?.resolveConflictsOnUpdate ?? "OVERWRITE",
-                    configurationValues: fargate ? JSON.stringify({
-                        computeType: "Fargate",
-                    }) : undefined,
+                    configurationValues: fargate
+                        ? JSON.stringify({
+                              computeType: "Fargate",
+                          })
+                        : undefined,
                 },
                 { parent, provider },
             );
         }
-    })
+    });
 
     // Instead of using the kubeconfig directly, we also add a wait of up to 5 minutes or until we
     // can reach the API server for the Output that provides access to the kubeconfig string so that

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1857,9 +1857,11 @@ func generateSchema() schema.PackageSpec {
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
 						"enabled": {
-							TypeSpec:    schema.TypeSpec{Type: "boolean", Plain: true},
-							Default:     true,
-							Description: "Whether or not to create the Addon in the cluster",
+							TypeSpec: schema.TypeSpec{Type: "boolean", Plain: true},
+							Default:  true,
+							Description: "Whether or not to create the Addon in the cluster\n\n" +
+								"The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster\n" +
+								"uses the default node group, otherwise the self-managed addon is used.",
 						},
 						"version": {
 							TypeSpec: schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -510,7 +510,7 @@
                 "enabled": {
                     "type": "boolean",
                     "plain": true,
-                    "description": "Whether or not to create the Addon in the cluster",
+                    "description": "Whether or not to create the Addon in the cluster\n\nThe managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster\nuses the default node group, otherwise the self-managed addon is used.",
                     "default": true
                 },
                 "resolveConflictsOnCreate": {

--- a/sdk/dotnet/Inputs/CoreDnsAddonOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/CoreDnsAddonOptionsArgs.cs
@@ -14,6 +14,9 @@ namespace Pulumi.Eks.Inputs
     {
         /// <summary>
         /// Whether or not to create the Addon in the cluster
+        /// 
+        /// The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+        /// uses the default node group, otherwise the self-managed addon is used.
         /// </summary>
         [Input("enabled")]
         public bool? Enabled { get; set; }

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -1599,6 +1599,9 @@ func (o CoreDataOutput) VpcId() pulumi.StringOutput {
 
 type CoreDnsAddonOptions struct {
 	// Whether or not to create the Addon in the cluster
+	//
+	// The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+	// uses the default node group, otherwise the self-managed addon is used.
 	Enabled *bool `pulumi:"enabled"`
 	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
 	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
@@ -1642,6 +1645,9 @@ type CoreDnsAddonOptionsInput interface {
 
 type CoreDnsAddonOptionsArgs struct {
 	// Whether or not to create the Addon in the cluster
+	//
+	// The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+	// uses the default node group, otherwise the self-managed addon is used.
 	Enabled *bool `pulumi:"enabled"`
 	// How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
 	ResolveConflictsOnCreate *ResolveConflictsOnCreate `pulumi:"resolveConflictsOnCreate"`
@@ -1749,6 +1755,9 @@ func (o CoreDnsAddonOptionsOutput) ToCoreDnsAddonOptionsPtrOutputWithContext(ctx
 }
 
 // Whether or not to create the Addon in the cluster
+//
+// The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+// uses the default node group, otherwise the self-managed addon is used.
 func (o CoreDnsAddonOptionsOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v CoreDnsAddonOptions) *bool { return v.Enabled }).(pulumi.BoolPtrOutput)
 }
@@ -1793,6 +1802,9 @@ func (o CoreDnsAddonOptionsPtrOutput) Elem() CoreDnsAddonOptionsOutput {
 }
 
 // Whether or not to create the Addon in the cluster
+//
+// The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+// uses the default node group, otherwise the self-managed addon is used.
 func (o CoreDnsAddonOptionsPtrOutput) Enabled() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *CoreDnsAddonOptions) *bool {
 		if v == nil {

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/CoreDnsAddonOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/CoreDnsAddonOptionsArgs.java
@@ -22,12 +22,18 @@ public final class CoreDnsAddonOptionsArgs extends com.pulumi.resources.Resource
     /**
      * Whether or not to create the Addon in the cluster
      * 
+     * The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+     * uses the default node group, otherwise the self-managed addon is used.
+     * 
      */
     @Import(name="enabled")
     private @Nullable Boolean enabled;
 
     /**
      * @return Whether or not to create the Addon in the cluster
+     * 
+     * The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+     * uses the default node group, otherwise the self-managed addon is used.
      * 
      */
     public Optional<Boolean> enabled() {
@@ -108,6 +114,9 @@ public final class CoreDnsAddonOptionsArgs extends com.pulumi.resources.Resource
 
         /**
          * @param enabled Whether or not to create the Addon in the cluster
+         * 
+         * The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+         * uses the default node group, otherwise the self-managed addon is used.
          * 
          * @return builder
          * 

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -1232,6 +1232,9 @@ class CoreDnsAddonOptionsArgs:
                  version: Optional[pulumi.Input[str]] = None):
         """
         :param bool enabled: Whether or not to create the Addon in the cluster
+               
+               The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+               uses the default node group, otherwise the self-managed addon is used.
         :param 'ResolveConflictsOnCreate' resolve_conflicts_on_create: How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
         :param 'ResolveConflictsOnUpdate' resolve_conflicts_on_update: How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value. Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
         :param pulumi.Input[str] version: The version of the EKS add-on. The version must match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
@@ -1256,6 +1259,9 @@ class CoreDnsAddonOptionsArgs:
     def enabled(self) -> Optional[bool]:
         """
         Whether or not to create the Addon in the cluster
+
+        The managed addon can only be enabled if the cluster is a Fargate cluster or if the cluster
+        uses the default node group, otherwise the self-managed addon is used.
         """
         return pulumi.get(self, "enabled")
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

The coredns managed addon can only be deployed on clusters with default node
groups (which includes Fargate clusters).

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
