### PR TITLE
Deprecate NodeGroup component

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -35,9 +35,11 @@ import { assertCompatibleAWSCLIExists } from "./dependencies";
 import {
     computeWorkerSubnets,
     createNodeGroup,
+    createNodeGroupV2,
     NodeGroup,
     NodeGroupBaseOptions,
     NodeGroupData,
+    NodeGroupV2Data,
 } from "./nodegroup";
 import { createNodeGroupSecurityGroup } from "./securitygroup";
 import { ServiceRole } from "./servicerole";
@@ -1896,7 +1898,7 @@ export class Cluster extends pulumi.ComponentResource {
     /**
      * The default Node Group configuration, or undefined if `skipDefaultNodeGroup` was specified.
      */
-    public readonly defaultNodeGroup: NodeGroupData | undefined;
+    public readonly defaultNodeGroup: NodeGroupV2Data | undefined;
 
     /**
      * The EKS cluster.
@@ -2009,7 +2011,7 @@ export interface ClusterResult {
     instanceRoles: pulumi.Output<aws.iam.Role[]>;
     nodeSecurityGroup: aws.ec2.SecurityGroup;
     eksClusterIngressRule: aws.ec2.SecurityGroupRule;
-    defaultNodeGroup: NodeGroupData | undefined;
+    defaultNodeGroup: NodeGroupV2Data | undefined;
     eksCluster: aws.eks.Cluster;
     core: CoreData;
 }
@@ -2069,10 +2071,9 @@ export function createCluster(
     const skipDefaultNodeGroup = args.skipDefaultNodeGroup || args.fargate;
 
     // Create the default worker node group and grant the workers access to the API server.
-    const configDeps = [core.kubeconfig];
-    let defaultNodeGroup: NodeGroupData | undefined = undefined;
+    let defaultNodeGroup: NodeGroupV2Data | undefined = undefined;
     if (!skipDefaultNodeGroup) {
-        defaultNodeGroup = createNodeGroup(
+        defaultNodeGroup = createNodeGroupV2(
             name,
             {
                 cluster: core,
@@ -2080,15 +2081,9 @@ export function createCluster(
             },
             self,
         );
-        if (defaultNodeGroup.cfnStack) {
-            configDeps.push(defaultNodeGroup.cfnStack.id);
-        }
     }
 
-    // Export the cluster's kubeconfig with a dependency upon the cluster's autoscaling group. This will help
-    // ensure that the cluster's consumers do not attempt to use the cluster until its workers are attached.
-    const kubeconfig = pulumi.all(configDeps).apply(([kc]) => kc);
-    const kubeconfigJson = kubeconfig.apply(JSON.stringify);
+    const kubeconfigJson = pulumi.jsonStringify(core.kubeconfig);
 
     // Export a k8s provider with the above kubeconfig. Note that we do not export the provider we created earlier
     // in order to help ensure that worker nodes are available before the provider can be used.
@@ -2118,7 +2113,7 @@ export function createCluster(
         nodeSecurityGroup,
         eksClusterIngressRule,
         defaultNodeGroup,
-        kubeconfig,
+        kubeconfig: pulumi.output(core.kubeconfig),
         kubeconfigJson,
         provider,
     };
@@ -2138,7 +2133,7 @@ export function createCluster(
 export class ClusterInternal extends pulumi.ComponentResource {
     public readonly clusterSecurityGroup!: pulumi.Output<aws.ec2.SecurityGroup>;
     public readonly core!: pulumi.Output<pulumi.Unwrap<CoreData>>;
-    public readonly defaultNodeGroup!: pulumi.Output<pulumi.Unwrap<NodeGroupData> | undefined>;
+    public readonly defaultNodeGroup!: pulumi.Output<pulumi.Unwrap<NodeGroupV2Data> | undefined>;
     public readonly eksCluster!: pulumi.Output<aws.eks.Cluster>;
     public readonly eksClusterIngressRule!: pulumi.Output<aws.ec2.SecurityGroupRule>;
     public readonly instanceRoles!: pulumi.Output<aws.iam.Role[]>;

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -994,8 +994,9 @@ func generateSchema() schema.PackageSpec {
 						"autoScalingGroupName",
 					},
 				},
-				InputProperties: nodeGroupProperties(true /*cluster*/, false /*NodeGroupV2*/),
-				RequiredInputs:  []string{"cluster"},
+				DeprecationMessage: "NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.",
+				InputProperties:    nodeGroupProperties(true /*cluster*/, false /*NodeGroupV2*/),
+				RequiredInputs:     []string{"cluster"},
 			},
 			"eks:index:NodeGroupV2": {
 				IsComponent: true,
@@ -1371,10 +1372,6 @@ func generateSchema() schema.PackageSpec {
 							},
 							Description: "The additional security groups for the node group that captures user-specific rules.",
 						},
-						"cfnStack": {
-							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:cloudformation%2Fstack:Stack")},
-							Description: "The CloudFormation Stack which defines the Node AutoScalingGroup.",
-						},
 						"autoScalingGroupName": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The AutoScalingGroup name for the node group.",
@@ -1383,7 +1380,6 @@ func generateSchema() schema.PackageSpec {
 					Required: []string{
 						"nodeSecurityGroup",
 						"extraNodeSecurityGroups",
-						"cfnStack",
 						"autoScalingGroupName",
 					},
 				},
@@ -1564,7 +1560,7 @@ func generateSchema() schema.PackageSpec {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Type:        "object",
 					Description: "Describes the configuration options accepted by a cluster to create its own node groups.",
-					Properties:  nodeGroupProperties(false /*cluster*/, false /*NodeGroupV2*/),
+					Properties:  nodeGroupProperties(false /*cluster*/, true /*NodeGroupV2*/),
 				},
 			},
 

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -292,9 +292,20 @@
                     "plain": true,
                     "description": "Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument."
                 },
+                "launchTemplateTagSpecifications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/aws/v6.18.2/schema.json#/types/aws:ec2%2FLaunchTemplateTagSpecification:LaunchTemplateTagSpecification"
+                    },
+                    "description": "The tag specifications to apply to the launch template."
+                },
                 "maxSize": {
                     "type": "integer",
                     "description": "The maximum number of worker nodes running in the cluster. Defaults to 2."
+                },
+                "minRefreshPercentage": {
+                    "type": "integer",
+                    "description": "The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50."
                 },
                 "minSize": {
                     "type": "integer",
@@ -640,10 +651,6 @@
                     "type": "string",
                     "description": "The AutoScalingGroup name for the node group."
                 },
-                "cfnStack": {
-                    "$ref": "/aws/v6.18.2/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
-                    "description": "The CloudFormation Stack which defines the Node AutoScalingGroup."
-                },
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
@@ -660,7 +667,6 @@
             "required": [
                 "nodeSecurityGroup",
                 "extraNodeSecurityGroups",
-                "cfnStack",
                 "autoScalingGroupName"
             ]
         },
@@ -1798,6 +1804,7 @@
             "requiredInputs": [
                 "cluster"
             ],
+            "deprecationMessage": "NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.",
             "isComponent": true
         },
         "eks:index:NodeGroupSecurityGroup": {

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -189,11 +189,29 @@ namespace Pulumi.Eks.Inputs
             set => _labels = value;
         }
 
+        [Input("launchTemplateTagSpecifications")]
+        private InputList<Pulumi.Aws.Ec2.Inputs.LaunchTemplateTagSpecificationArgs>? _launchTemplateTagSpecifications;
+
+        /// <summary>
+        /// The tag specifications to apply to the launch template.
+        /// </summary>
+        public InputList<Pulumi.Aws.Ec2.Inputs.LaunchTemplateTagSpecificationArgs> LaunchTemplateTagSpecifications
+        {
+            get => _launchTemplateTagSpecifications ?? (_launchTemplateTagSpecifications = new InputList<Pulumi.Aws.Ec2.Inputs.LaunchTemplateTagSpecificationArgs>());
+            set => _launchTemplateTagSpecifications = value;
+        }
+
         /// <summary>
         /// The maximum number of worker nodes running in the cluster. Defaults to 2.
         /// </summary>
         [Input("maxSize")]
         public Input<int>? MaxSize { get; set; }
+
+        /// <summary>
+        /// The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+        /// </summary>
+        [Input("minRefreshPercentage")]
+        public Input<int>? MinRefreshPercentage { get; set; }
 
         /// <summary>
         /// The minimum number of worker nodes running in the cluster. Defaults to 1.

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -12,6 +12,7 @@ namespace Pulumi.Eks
     /// <summary>
     /// NodeGroup is a component that wraps the AWS EC2 instances that provide compute capacity for an EKS cluster.
     /// </summary>
+    [Obsolete(@"NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.")]
     [EksResourceType("eks:index:NodeGroup")]
     public partial class NodeGroup : global::Pulumi.ComponentResource
     {

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -127,9 +127,17 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly ImmutableDictionary<string, string>? Labels;
         /// <summary>
+        /// The tag specifications to apply to the launch template.
+        /// </summary>
+        public readonly ImmutableArray<Pulumi.Aws.Ec2.Outputs.LaunchTemplateTagSpecification> LaunchTemplateTagSpecifications;
+        /// <summary>
         /// The maximum number of worker nodes running in the cluster. Defaults to 2.
         /// </summary>
         public readonly int? MaxSize;
+        /// <summary>
+        /// The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+        /// </summary>
+        public readonly int? MinRefreshPercentage;
         /// <summary>
         /// The minimum number of worker nodes running in the cluster. Defaults to 1.
         /// </summary>
@@ -265,7 +273,11 @@ namespace Pulumi.Eks.Outputs
 
             ImmutableDictionary<string, string>? labels,
 
+            ImmutableArray<Pulumi.Aws.Ec2.Outputs.LaunchTemplateTagSpecification> launchTemplateTagSpecifications,
+
             int? maxSize,
+
+            int? minRefreshPercentage,
 
             int? minSize,
 
@@ -320,7 +332,9 @@ namespace Pulumi.Eks.Outputs
             KeyName = keyName;
             KubeletExtraArgs = kubeletExtraArgs;
             Labels = labels;
+            LaunchTemplateTagSpecifications = launchTemplateTagSpecifications;
             MaxSize = maxSize;
+            MinRefreshPercentage = minRefreshPercentage;
             MinSize = minSize;
             NodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             NodePublicKey = nodePublicKey;

--- a/sdk/dotnet/Outputs/NodeGroupData.cs
+++ b/sdk/dotnet/Outputs/NodeGroupData.cs
@@ -21,10 +21,6 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly string AutoScalingGroupName;
         /// <summary>
-        /// The CloudFormation Stack which defines the Node AutoScalingGroup.
-        /// </summary>
-        public readonly Pulumi.Aws.CloudFormation.Stack CfnStack;
-        /// <summary>
         /// The additional security groups for the node group that captures user-specific rules.
         /// </summary>
         public readonly ImmutableArray<Pulumi.Aws.Ec2.SecurityGroup> ExtraNodeSecurityGroups;
@@ -37,14 +33,11 @@ namespace Pulumi.Eks.Outputs
         private NodeGroupData(
             string autoScalingGroupName,
 
-            Pulumi.Aws.CloudFormation.Stack cfnStack,
-
             ImmutableArray<Pulumi.Aws.Ec2.SecurityGroup> extraNodeSecurityGroups,
 
             Pulumi.Aws.Ec2.SecurityGroup nodeSecurityGroup)
         {
             AutoScalingGroupName = autoScalingGroupName;
-            CfnStack = cfnStack;
             ExtraNodeSecurityGroups = extraNodeSecurityGroups;
             NodeSecurityGroup = nodeSecurityGroup;
         }

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -16,6 +16,8 @@ import (
 )
 
 // NodeGroup is a component that wraps the AWS EC2 instances that provide compute capacity for an EKS cluster.
+//
+// Deprecated: NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.
 type NodeGroup struct {
 	pulumi.ResourceState
 

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudformation"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
@@ -375,8 +374,12 @@ type ClusterNodeGroupOptions struct {
 	KubeletExtraArgs *string `pulumi:"kubeletExtraArgs"`
 	// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
 	Labels map[string]string `pulumi:"labels"`
+	// The tag specifications to apply to the launch template.
+	LaunchTemplateTagSpecifications []ec2.LaunchTemplateTagSpecification `pulumi:"launchTemplateTagSpecifications"`
 	// The maximum number of worker nodes running in the cluster. Defaults to 2.
 	MaxSize *int `pulumi:"maxSize"`
+	// The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+	MinRefreshPercentage *int `pulumi:"minRefreshPercentage"`
 	// The minimum number of worker nodes running in the cluster. Defaults to 1.
 	MinSize *int `pulumi:"minSize"`
 	// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
@@ -530,8 +533,12 @@ type ClusterNodeGroupOptionsArgs struct {
 	KubeletExtraArgs *string `pulumi:"kubeletExtraArgs"`
 	// Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
 	Labels map[string]string `pulumi:"labels"`
+	// The tag specifications to apply to the launch template.
+	LaunchTemplateTagSpecifications ec2.LaunchTemplateTagSpecificationArrayInput `pulumi:"launchTemplateTagSpecifications"`
 	// The maximum number of worker nodes running in the cluster. Defaults to 2.
 	MaxSize pulumi.IntPtrInput `pulumi:"maxSize"`
+	// The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+	MinRefreshPercentage pulumi.IntPtrInput `pulumi:"minRefreshPercentage"`
 	// The minimum number of worker nodes running in the cluster. Defaults to 1.
 	MinSize pulumi.IntPtrInput `pulumi:"minSize"`
 	// Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
@@ -801,9 +808,21 @@ func (o ClusterNodeGroupOptionsOutput) Labels() pulumi.StringMapOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) map[string]string { return v.Labels }).(pulumi.StringMapOutput)
 }
 
+// The tag specifications to apply to the launch template.
+func (o ClusterNodeGroupOptionsOutput) LaunchTemplateTagSpecifications() ec2.LaunchTemplateTagSpecificationArrayOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) []ec2.LaunchTemplateTagSpecification {
+		return v.LaunchTemplateTagSpecifications
+	}).(ec2.LaunchTemplateTagSpecificationArrayOutput)
+}
+
 // The maximum number of worker nodes running in the cluster. Defaults to 2.
 func (o ClusterNodeGroupOptionsOutput) MaxSize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.MaxSize }).(pulumi.IntPtrOutput)
+}
+
+// The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+func (o ClusterNodeGroupOptionsOutput) MinRefreshPercentage() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.MinRefreshPercentage }).(pulumi.IntPtrOutput)
 }
 
 // The minimum number of worker nodes running in the cluster. Defaults to 1.
@@ -1158,6 +1177,16 @@ func (o ClusterNodeGroupOptionsPtrOutput) Labels() pulumi.StringMapOutput {
 	}).(pulumi.StringMapOutput)
 }
 
+// The tag specifications to apply to the launch template.
+func (o ClusterNodeGroupOptionsPtrOutput) LaunchTemplateTagSpecifications() ec2.LaunchTemplateTagSpecificationArrayOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) []ec2.LaunchTemplateTagSpecification {
+		if v == nil {
+			return nil
+		}
+		return v.LaunchTemplateTagSpecifications
+	}).(ec2.LaunchTemplateTagSpecificationArrayOutput)
+}
+
 // The maximum number of worker nodes running in the cluster. Defaults to 2.
 func (o ClusterNodeGroupOptionsPtrOutput) MaxSize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *ClusterNodeGroupOptions) *int {
@@ -1165,6 +1194,16 @@ func (o ClusterNodeGroupOptionsPtrOutput) MaxSize() pulumi.IntPtrOutput {
 			return nil
 		}
 		return v.MaxSize
+	}).(pulumi.IntPtrOutput)
+}
+
+// The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+func (o ClusterNodeGroupOptionsPtrOutput) MinRefreshPercentage() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *int {
+		if v == nil {
+			return nil
+		}
+		return v.MinRefreshPercentage
 	}).(pulumi.IntPtrOutput)
 }
 
@@ -2676,8 +2715,6 @@ func (o KubeconfigOptionsPtrOutput) RoleArn() pulumi.StringPtrOutput {
 type NodeGroupData struct {
 	// The AutoScalingGroup name for the node group.
 	AutoScalingGroupName string `pulumi:"autoScalingGroupName"`
-	// The CloudFormation Stack which defines the Node AutoScalingGroup.
-	CfnStack *cloudformation.Stack `pulumi:"cfnStack"`
 	// The additional security groups for the node group that captures user-specific rules.
 	ExtraNodeSecurityGroups []*ec2.SecurityGroup `pulumi:"extraNodeSecurityGroups"`
 	// The security group for the node group to communicate with the cluster.
@@ -2702,11 +2739,6 @@ func (o NodeGroupDataOutput) ToNodeGroupDataOutputWithContext(ctx context.Contex
 // The AutoScalingGroup name for the node group.
 func (o NodeGroupDataOutput) AutoScalingGroupName() pulumi.StringOutput {
 	return o.ApplyT(func(v NodeGroupData) string { return v.AutoScalingGroupName }).(pulumi.StringOutput)
-}
-
-// The CloudFormation Stack which defines the Node AutoScalingGroup.
-func (o NodeGroupDataOutput) CfnStack() cloudformation.StackOutput {
-	return o.ApplyT(func(v NodeGroupData) *cloudformation.Stack { return v.CfnStack }).(cloudformation.StackOutput)
 }
 
 // The additional security groups for the node group that captures user-specific rules.
@@ -2751,16 +2783,6 @@ func (o NodeGroupDataPtrOutput) AutoScalingGroupName() pulumi.StringPtrOutput {
 		}
 		return &v.AutoScalingGroupName
 	}).(pulumi.StringPtrOutput)
-}
-
-// The CloudFormation Stack which defines the Node AutoScalingGroup.
-func (o NodeGroupDataPtrOutput) CfnStack() cloudformation.StackOutput {
-	return o.ApplyT(func(v *NodeGroupData) *cloudformation.Stack {
-		if v == nil {
-			return nil
-		}
-		return v.CfnStack
-	}).(cloudformation.StackOutput)
 }
 
 // The additional security groups for the node group that captures user-specific rules.

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroup.java
@@ -18,7 +18,11 @@ import javax.annotation.Nullable;
 /**
  * NodeGroup is a component that wraps the AWS EC2 instances that provide compute capacity for an EKS cluster.
  * 
+ * @deprecated
+ * NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn&#39;t support the newest instance types. Please use NodeGroupV2 instead.
+ * 
  */
+@Deprecated /* NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead. */
 @ResourceType(type="eks:index:NodeGroup")
 public class NodeGroup extends com.pulumi.resources.ComponentResource {
     /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.eks.inputs;
 
 import com.pulumi.aws.ec2.SecurityGroup;
 import com.pulumi.aws.ec2.SecurityGroupRule;
+import com.pulumi.aws.ec2.inputs.LaunchTemplateTagSpecificationArgs;
 import com.pulumi.aws.iam.InstanceProfile;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
@@ -370,6 +371,21 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
+     * The tag specifications to apply to the launch template.
+     * 
+     */
+    @Import(name="launchTemplateTagSpecifications")
+    private @Nullable Output<List<LaunchTemplateTagSpecificationArgs>> launchTemplateTagSpecifications;
+
+    /**
+     * @return The tag specifications to apply to the launch template.
+     * 
+     */
+    public Optional<Output<List<LaunchTemplateTagSpecificationArgs>>> launchTemplateTagSpecifications() {
+        return Optional.ofNullable(this.launchTemplateTagSpecifications);
+    }
+
+    /**
      * The maximum number of worker nodes running in the cluster. Defaults to 2.
      * 
      */
@@ -382,6 +398,21 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
      */
     public Optional<Output<Integer>> maxSize() {
         return Optional.ofNullable(this.maxSize);
+    }
+
+    /**
+     * The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+     * 
+     */
+    @Import(name="minRefreshPercentage")
+    private @Nullable Output<Integer> minRefreshPercentage;
+
+    /**
+     * @return The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+     * 
+     */
+    public Optional<Output<Integer>> minRefreshPercentage() {
+        return Optional.ofNullable(this.minRefreshPercentage);
     }
 
     /**
@@ -726,7 +757,9 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         this.keyName = $.keyName;
         this.kubeletExtraArgs = $.kubeletExtraArgs;
         this.labels = $.labels;
+        this.launchTemplateTagSpecifications = $.launchTemplateTagSpecifications;
         this.maxSize = $.maxSize;
+        this.minRefreshPercentage = $.minRefreshPercentage;
         this.minSize = $.minSize;
         this.nodeAssociatePublicIpAddress = $.nodeAssociatePublicIpAddress;
         this.nodePublicKey = $.nodePublicKey;
@@ -1179,6 +1212,37 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         }
 
         /**
+         * @param launchTemplateTagSpecifications The tag specifications to apply to the launch template.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder launchTemplateTagSpecifications(@Nullable Output<List<LaunchTemplateTagSpecificationArgs>> launchTemplateTagSpecifications) {
+            $.launchTemplateTagSpecifications = launchTemplateTagSpecifications;
+            return this;
+        }
+
+        /**
+         * @param launchTemplateTagSpecifications The tag specifications to apply to the launch template.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder launchTemplateTagSpecifications(List<LaunchTemplateTagSpecificationArgs> launchTemplateTagSpecifications) {
+            return launchTemplateTagSpecifications(Output.of(launchTemplateTagSpecifications));
+        }
+
+        /**
+         * @param launchTemplateTagSpecifications The tag specifications to apply to the launch template.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder launchTemplateTagSpecifications(LaunchTemplateTagSpecificationArgs... launchTemplateTagSpecifications) {
+            return launchTemplateTagSpecifications(List.of(launchTemplateTagSpecifications));
+        }
+
+        /**
          * @param maxSize The maximum number of worker nodes running in the cluster. Defaults to 2.
          * 
          * @return builder
@@ -1197,6 +1261,27 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          */
         public Builder maxSize(Integer maxSize) {
             return maxSize(Output.of(maxSize));
+        }
+
+        /**
+         * @param minRefreshPercentage The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder minRefreshPercentage(@Nullable Output<Integer> minRefreshPercentage) {
+            $.minRefreshPercentage = minRefreshPercentage;
+            return this;
+        }
+
+        /**
+         * @param minRefreshPercentage The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder minRefreshPercentage(Integer minRefreshPercentage) {
+            return minRefreshPercentage(Output.of(minRefreshPercentage));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -5,6 +5,7 @@ package com.pulumi.eks.outputs;
 
 import com.pulumi.aws.ec2.SecurityGroup;
 import com.pulumi.aws.ec2.SecurityGroupRule;
+import com.pulumi.aws.ec2.outputs.LaunchTemplateTagSpecification;
 import com.pulumi.aws.iam.InstanceProfile;
 import com.pulumi.core.annotations.CustomType;
 import com.pulumi.eks.enums.OperatingSystem;
@@ -150,10 +151,20 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable Map<String,String> labels;
     /**
+     * @return The tag specifications to apply to the launch template.
+     * 
+     */
+    private @Nullable List<LaunchTemplateTagSpecification> launchTemplateTagSpecifications;
+    /**
      * @return The maximum number of worker nodes running in the cluster. Defaults to 2.
      * 
      */
     private @Nullable Integer maxSize;
+    /**
+     * @return The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+     * 
+     */
+    private @Nullable Integer minRefreshPercentage;
     /**
      * @return The minimum number of worker nodes running in the cluster. Defaults to 1.
      * 
@@ -434,11 +445,25 @@ public final class ClusterNodeGroupOptions {
         return this.labels == null ? Map.of() : this.labels;
     }
     /**
+     * @return The tag specifications to apply to the launch template.
+     * 
+     */
+    public List<LaunchTemplateTagSpecification> launchTemplateTagSpecifications() {
+        return this.launchTemplateTagSpecifications == null ? List.of() : this.launchTemplateTagSpecifications;
+    }
+    /**
      * @return The maximum number of worker nodes running in the cluster. Defaults to 2.
      * 
      */
     public Optional<Integer> maxSize() {
         return Optional.ofNullable(this.maxSize);
+    }
+    /**
+     * @return The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+     * 
+     */
+    public Optional<Integer> minRefreshPercentage() {
+        return Optional.ofNullable(this.minRefreshPercentage);
     }
     /**
      * @return The minimum number of worker nodes running in the cluster. Defaults to 1.
@@ -619,7 +644,9 @@ public final class ClusterNodeGroupOptions {
         private @Nullable String keyName;
         private @Nullable String kubeletExtraArgs;
         private @Nullable Map<String,String> labels;
+        private @Nullable List<LaunchTemplateTagSpecification> launchTemplateTagSpecifications;
         private @Nullable Integer maxSize;
+        private @Nullable Integer minRefreshPercentage;
         private @Nullable Integer minSize;
         private @Nullable Boolean nodeAssociatePublicIpAddress;
         private @Nullable String nodePublicKey;
@@ -658,7 +685,9 @@ public final class ClusterNodeGroupOptions {
     	      this.keyName = defaults.keyName;
     	      this.kubeletExtraArgs = defaults.kubeletExtraArgs;
     	      this.labels = defaults.labels;
+    	      this.launchTemplateTagSpecifications = defaults.launchTemplateTagSpecifications;
     	      this.maxSize = defaults.maxSize;
+    	      this.minRefreshPercentage = defaults.minRefreshPercentage;
     	      this.minSize = defaults.minSize;
     	      this.nodeAssociatePublicIpAddress = defaults.nodeAssociatePublicIpAddress;
     	      this.nodePublicKey = defaults.nodePublicKey;
@@ -768,8 +797,21 @@ public final class ClusterNodeGroupOptions {
             return this;
         }
         @CustomType.Setter
+        public Builder launchTemplateTagSpecifications(@Nullable List<LaunchTemplateTagSpecification> launchTemplateTagSpecifications) {
+            this.launchTemplateTagSpecifications = launchTemplateTagSpecifications;
+            return this;
+        }
+        public Builder launchTemplateTagSpecifications(LaunchTemplateTagSpecification... launchTemplateTagSpecifications) {
+            return launchTemplateTagSpecifications(List.of(launchTemplateTagSpecifications));
+        }
+        @CustomType.Setter
         public Builder maxSize(@Nullable Integer maxSize) {
             this.maxSize = maxSize;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder minRefreshPercentage(@Nullable Integer minRefreshPercentage) {
+            this.minRefreshPercentage = minRefreshPercentage;
             return this;
         }
         @CustomType.Setter
@@ -887,7 +929,9 @@ public final class ClusterNodeGroupOptions {
             _resultValue.keyName = keyName;
             _resultValue.kubeletExtraArgs = kubeletExtraArgs;
             _resultValue.labels = labels;
+            _resultValue.launchTemplateTagSpecifications = launchTemplateTagSpecifications;
             _resultValue.maxSize = maxSize;
+            _resultValue.minRefreshPercentage = minRefreshPercentage;
             _resultValue.minSize = minSize;
             _resultValue.nodeAssociatePublicIpAddress = nodeAssociatePublicIpAddress;
             _resultValue.nodePublicKey = nodePublicKey;

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/NodeGroupData.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/NodeGroupData.java
@@ -3,7 +3,6 @@
 
 package com.pulumi.eks.outputs;
 
-import com.pulumi.aws.cloudformation.Stack;
 import com.pulumi.aws.ec2.SecurityGroup;
 import com.pulumi.core.annotations.CustomType;
 import java.lang.String;
@@ -17,11 +16,6 @@ public final class NodeGroupData {
      * 
      */
     private String autoScalingGroupName;
-    /**
-     * @return The CloudFormation Stack which defines the Node AutoScalingGroup.
-     * 
-     */
-    private Stack cfnStack;
     /**
      * @return The additional security groups for the node group that captures user-specific rules.
      * 
@@ -40,13 +34,6 @@ public final class NodeGroupData {
      */
     public String autoScalingGroupName() {
         return this.autoScalingGroupName;
-    }
-    /**
-     * @return The CloudFormation Stack which defines the Node AutoScalingGroup.
-     * 
-     */
-    public Stack cfnStack() {
-        return this.cfnStack;
     }
     /**
      * @return The additional security groups for the node group that captures user-specific rules.
@@ -73,14 +60,12 @@ public final class NodeGroupData {
     @CustomType.Builder
     public static final class Builder {
         private String autoScalingGroupName;
-        private Stack cfnStack;
         private List<SecurityGroup> extraNodeSecurityGroups;
         private SecurityGroup nodeSecurityGroup;
         public Builder() {}
         public Builder(NodeGroupData defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.autoScalingGroupName = defaults.autoScalingGroupName;
-    	      this.cfnStack = defaults.cfnStack;
     	      this.extraNodeSecurityGroups = defaults.extraNodeSecurityGroups;
     	      this.nodeSecurityGroup = defaults.nodeSecurityGroup;
         }
@@ -88,11 +73,6 @@ public final class NodeGroupData {
         @CustomType.Setter
         public Builder autoScalingGroupName(String autoScalingGroupName) {
             this.autoScalingGroupName = Objects.requireNonNull(autoScalingGroupName);
-            return this;
-        }
-        @CustomType.Setter
-        public Builder cfnStack(Stack cfnStack) {
-            this.cfnStack = Objects.requireNonNull(cfnStack);
             return this;
         }
         @CustomType.Setter
@@ -111,7 +91,6 @@ public final class NodeGroupData {
         public NodeGroupData build() {
             final var _resultValue = new NodeGroupData();
             _resultValue.autoScalingGroupName = autoScalingGroupName;
-            _resultValue.cfnStack = cfnStack;
             _resultValue.extraNodeSecurityGroups = extraNodeSecurityGroups;
             _resultValue.nodeSecurityGroup = nodeSecurityGroup;
             return _resultValue;

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -200,7 +200,9 @@ class ClusterNodeGroupOptionsArgs:
                  key_name: Optional[pulumi.Input[str]] = None,
                  kubelet_extra_args: Optional[str] = None,
                  labels: Optional[Mapping[str, str]] = None,
+                 launch_template_tag_specifications: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]] = None,
                  max_size: Optional[pulumi.Input[int]] = None,
+                 min_refresh_percentage: Optional[pulumi.Input[int]] = None,
                  min_size: Optional[pulumi.Input[int]] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[pulumi.Input[str]] = None,
@@ -280,7 +282,9 @@ class ClusterNodeGroupOptionsArgs:
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]] launch_template_tag_specifications: The tag specifications to apply to the launch template.
         :param pulumi.Input[int] max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
+        :param pulumi.Input[int] min_refresh_percentage: The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
         :param pulumi.Input[int] min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
         :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param pulumi.Input[str] node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
@@ -360,8 +364,12 @@ class ClusterNodeGroupOptionsArgs:
             pulumi.set(__self__, "kubelet_extra_args", kubelet_extra_args)
         if labels is not None:
             pulumi.set(__self__, "labels", labels)
+        if launch_template_tag_specifications is not None:
+            pulumi.set(__self__, "launch_template_tag_specifications", launch_template_tag_specifications)
         if max_size is not None:
             pulumi.set(__self__, "max_size", max_size)
+        if min_refresh_percentage is not None:
+            pulumi.set(__self__, "min_refresh_percentage", min_refresh_percentage)
         if min_size is not None:
             pulumi.set(__self__, "min_size", min_size)
         if node_associate_public_ip_address is not None:
@@ -646,6 +654,18 @@ class ClusterNodeGroupOptionsArgs:
         pulumi.set(self, "labels", value)
 
     @property
+    @pulumi.getter(name="launchTemplateTagSpecifications")
+    def launch_template_tag_specifications(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]]:
+        """
+        The tag specifications to apply to the launch template.
+        """
+        return pulumi.get(self, "launch_template_tag_specifications")
+
+    @launch_template_tag_specifications.setter
+    def launch_template_tag_specifications(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs']]]]):
+        pulumi.set(self, "launch_template_tag_specifications", value)
+
+    @property
     @pulumi.getter(name="maxSize")
     def max_size(self) -> Optional[pulumi.Input[int]]:
         """
@@ -656,6 +676,18 @@ class ClusterNodeGroupOptionsArgs:
     @max_size.setter
     def max_size(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "max_size", value)
+
+    @property
+    @pulumi.getter(name="minRefreshPercentage")
+    def min_refresh_percentage(self) -> Optional[pulumi.Input[int]]:
+        """
+        The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+        """
+        return pulumi.get(self, "min_refresh_percentage")
+
+    @min_refresh_percentage.setter
+    def min_refresh_percentage(self, value: Optional[pulumi.Input[int]]):
+        pulumi.set(self, "min_refresh_percentage", value)
 
     @property
     @pulumi.getter(name="minSize")

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -752,7 +752,12 @@ class NodeGroupArgs:
         pulumi.set(self, "version", value)
 
 
+warnings.warn("""NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.""", DeprecationWarning)
+
+
 class NodeGroup(pulumi.ComponentResource):
+    warnings.warn("""NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.""", DeprecationWarning)
+
     @overload
     def __init__(__self__,
                  resource_name: str,
@@ -968,6 +973,7 @@ class NodeGroup(pulumi.ComponentResource):
                  taints: Optional[Mapping[str, Union['TaintArgs', 'TaintArgsDict']]] = None,
                  version: Optional[pulumi.Input[str]] = None,
                  __props__=None):
+        pulumi.log.warn("""NodeGroup is deprecated: NodeGroup uses AWS EC2 LaunchConfiguration which has been deprecated by AWS and doesn't support the newest instance types. Please use NodeGroupV2 instead.""")
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -231,8 +231,12 @@ class ClusterNodeGroupOptions(dict):
             suggest = "key_name"
         elif key == "kubeletExtraArgs":
             suggest = "kubelet_extra_args"
+        elif key == "launchTemplateTagSpecifications":
+            suggest = "launch_template_tag_specifications"
         elif key == "maxSize":
             suggest = "max_size"
+        elif key == "minRefreshPercentage":
+            suggest = "min_refresh_percentage"
         elif key == "minSize":
             suggest = "min_size"
         elif key == "nodeAssociatePublicIpAddress":
@@ -295,7 +299,9 @@ class ClusterNodeGroupOptions(dict):
                  key_name: Optional[str] = None,
                  kubelet_extra_args: Optional[str] = None,
                  labels: Optional[Mapping[str, str]] = None,
+                 launch_template_tag_specifications: Optional[Sequence['pulumi_aws.ec2.outputs.LaunchTemplateTagSpecification']] = None,
                  max_size: Optional[int] = None,
+                 min_refresh_percentage: Optional[int] = None,
                  min_size: Optional[int] = None,
                  node_associate_public_ip_address: Optional[bool] = None,
                  node_public_key: Optional[str] = None,
@@ -375,7 +381,9 @@ class ClusterNodeGroupOptions(dict):
         :param str key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
+        :param Sequence['pulumi_aws.ec2.LaunchTemplateTagSpecificationArgs'] launch_template_tag_specifications: The tag specifications to apply to the launch template.
         :param int max_size: The maximum number of worker nodes running in the cluster. Defaults to 2.
+        :param int min_refresh_percentage: The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
         :param int min_size: The minimum number of worker nodes running in the cluster. Defaults to 1.
         :param bool node_associate_public_ip_address: Whether or not to auto-assign public IP addresses on the EKS worker nodes. If this toggle is set to true, the EKS workers will be auto-assigned public IPs. If false, they will not be auto-assigned public IPs.
         :param str node_public_key: Public key material for SSH access to worker nodes. See allowed formats at:
@@ -455,8 +463,12 @@ class ClusterNodeGroupOptions(dict):
             pulumi.set(__self__, "kubelet_extra_args", kubelet_extra_args)
         if labels is not None:
             pulumi.set(__self__, "labels", labels)
+        if launch_template_tag_specifications is not None:
+            pulumi.set(__self__, "launch_template_tag_specifications", launch_template_tag_specifications)
         if max_size is not None:
             pulumi.set(__self__, "max_size", max_size)
+        if min_refresh_percentage is not None:
+            pulumi.set(__self__, "min_refresh_percentage", min_refresh_percentage)
         if min_size is not None:
             pulumi.set(__self__, "min_size", min_size)
         if node_associate_public_ip_address is not None:
@@ -673,12 +685,28 @@ class ClusterNodeGroupOptions(dict):
         return pulumi.get(self, "labels")
 
     @property
+    @pulumi.getter(name="launchTemplateTagSpecifications")
+    def launch_template_tag_specifications(self) -> Optional[Sequence['pulumi_aws.ec2.outputs.LaunchTemplateTagSpecification']]:
+        """
+        The tag specifications to apply to the launch template.
+        """
+        return pulumi.get(self, "launch_template_tag_specifications")
+
+    @property
     @pulumi.getter(name="maxSize")
     def max_size(self) -> Optional[int]:
         """
         The maximum number of worker nodes running in the cluster. Defaults to 2.
         """
         return pulumi.get(self, "max_size")
+
+    @property
+    @pulumi.getter(name="minRefreshPercentage")
+    def min_refresh_percentage(self) -> Optional[int]:
+        """
+        The minimum amount of instances that should remain available during an instance refresh, expressed as a percentage. Defaults to 50.
+        """
+        return pulumi.get(self, "min_refresh_percentage")
 
     @property
     @pulumi.getter(name="minSize")
@@ -1148,8 +1176,6 @@ class NodeGroupData(dict):
         suggest = None
         if key == "autoScalingGroupName":
             suggest = "auto_scaling_group_name"
-        elif key == "cfnStack":
-            suggest = "cfn_stack"
         elif key == "extraNodeSecurityGroups":
             suggest = "extra_node_security_groups"
         elif key == "nodeSecurityGroup":
@@ -1168,18 +1194,15 @@ class NodeGroupData(dict):
 
     def __init__(__self__, *,
                  auto_scaling_group_name: str,
-                 cfn_stack: 'pulumi_aws.cloudformation.Stack',
                  extra_node_security_groups: Sequence['pulumi_aws.ec2.SecurityGroup'],
                  node_security_group: 'pulumi_aws.ec2.SecurityGroup'):
         """
         NodeGroupData describes the resources created for the given NodeGroup.
         :param str auto_scaling_group_name: The AutoScalingGroup name for the node group.
-        :param 'pulumi_aws.cloudformation.Stack' cfn_stack: The CloudFormation Stack which defines the Node AutoScalingGroup.
         :param Sequence['pulumi_aws.ec2.SecurityGroup'] extra_node_security_groups: The additional security groups for the node group that captures user-specific rules.
         :param 'pulumi_aws.ec2.SecurityGroup' node_security_group: The security group for the node group to communicate with the cluster.
         """
         pulumi.set(__self__, "auto_scaling_group_name", auto_scaling_group_name)
-        pulumi.set(__self__, "cfn_stack", cfn_stack)
         pulumi.set(__self__, "extra_node_security_groups", extra_node_security_groups)
         pulumi.set(__self__, "node_security_group", node_security_group)
 
@@ -1190,14 +1213,6 @@ class NodeGroupData(dict):
         The AutoScalingGroup name for the node group.
         """
         return pulumi.get(self, "auto_scaling_group_name")
-
-    @property
-    @pulumi.getter(name="cfnStack")
-    def cfn_stack(self) -> 'pulumi_aws.cloudformation.Stack':
-        """
-        The CloudFormation Stack which defines the Node AutoScalingGroup.
-        """
-        return pulumi.get(self, "cfn_stack")
 
     @property
     @pulumi.getter(name="extraNodeSecurityGroups")


### PR DESCRIPTION
The `NodeGroup` component uses the deprecated AWS Launch Configuration ([see](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html))

This marks the legacy CloudFormation based self-managed NodeGroup (also referred to as NodeGroupV1) as deprecated. The Pulumi native NodeGroupV2 is functionally equivalent (same inputs) but doesn't suffer from problems like [pulumi-eks#535](https://github.com/pulumi/pulumi-eks/issues/535). Users will need to replace their self managed node groups anyway to migrate away from AL2 in a safe way (see [What does a node group update look like for users?](https://docs.google.com/document/d/1XyLq_EyAziCp3f6rQ_8qfcUk0RMl8AgUq1mqpqsQcHM/edit#bookmark=id.l6qozya46ay3)).

This also switches the default node group of the cluster component to use NodeGroupV2 instead.

Closes #1353 
Closes #1352
