### PR TITLE
Mark AL2 ami types deprecated

### DIFF
--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1753,14 +1753,20 @@ func generateSchema() schema.PackageSpec {
 					{
 						Name:  "AL2X86_64",
 						Value: "AL2_x86_64",
+						DeprecationMessage: "Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.\n" +
+							"See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html",
 					},
 					{
 						Name:  "AL2X86_64GPU",
 						Value: "AL2_x86_64_GPU",
+						DeprecationMessage: "Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.\n" +
+							"See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html",
 					},
 					{
 						Name:  "AL2Arm64",
 						Value: "AL2_ARM_64",
+						DeprecationMessage: "Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.\n" +
+							"See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html",
 					},
 
 					{

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -142,15 +142,18 @@
             "enum": [
                 {
                     "name": "AL2X86_64",
-                    "value": "AL2_x86_64"
+                    "value": "AL2_x86_64",
+                    "deprecationMessage": "Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html"
                 },
                 {
                     "name": "AL2X86_64GPU",
-                    "value": "AL2_x86_64_GPU"
+                    "value": "AL2_x86_64_GPU",
+                    "deprecationMessage": "Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html"
                 },
                 {
                     "name": "AL2Arm64",
-                    "value": "AL2_ARM_64"
+                    "value": "AL2_ARM_64",
+                    "deprecationMessage": "Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.\nSee for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html"
                 },
                 {
                     "name": "AL2023X86_64Standard",

--- a/sdk/dotnet/Enums.cs
+++ b/sdk/dotnet/Enums.cs
@@ -66,8 +66,14 @@ namespace Pulumi.Eks
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        [Obsolete(@"Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html")]
         public static AmiType AL2X86_64 { get; } = new AmiType("AL2_x86_64");
+        [Obsolete(@"Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html")]
         public static AmiType AL2X86_64GPU { get; } = new AmiType("AL2_x86_64_GPU");
+        [Obsolete(@"Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html")]
         public static AmiType AL2Arm64 { get; } = new AmiType("AL2_ARM_64");
         public static AmiType AL2023X86_64Standard { get; } = new AmiType("AL2023_x86_64_STANDARD");
         public static AmiType AL2023Arm64Standard { get; } = new AmiType("AL2023_ARM_64_STANDARD");

--- a/sdk/go/eks/pulumiEnums.go
+++ b/sdk/go/eks/pulumiEnums.go
@@ -189,8 +189,14 @@ func (in *accessEntryTypePtr) ToAccessEntryTypePtrOutputWithContext(ctx context.
 type AmiType string
 
 const (
-	AmiType_AL2X86_64                = AmiType("AL2_x86_64")
-	AmiType_AL2X86_64GPU             = AmiType("AL2_x86_64_GPU")
+	// Deprecated: Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+	// See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html
+	AmiType_AL2X86_64 = AmiType("AL2_x86_64")
+	// Deprecated: Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+	// See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html
+	AmiType_AL2X86_64GPU = AmiType("AL2_x86_64_GPU")
+	// Deprecated: Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+	// See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html
 	AmiTypeAL2Arm64                  = AmiType("AL2_ARM_64")
 	AmiType_AL2023X86_64Standard     = AmiType("AL2023_x86_64_STANDARD")
 	AmiTypeAL2023Arm64Standard       = AmiType("AL2023_ARM_64_STANDARD")

--- a/sdk/java/src/main/java/com/pulumi/eks/enums/AmiType.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/enums/AmiType.java
@@ -14,8 +14,29 @@ import java.util.StringJoiner;
      */
     @EnumType
     public enum AmiType {
+        /**
+         * @deprecated
+         * Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html
+         */
+        @Deprecated /* Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html */
         AL2X86_64("AL2_x86_64"),
+        /**
+         * @deprecated
+         * Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html
+         */
+        @Deprecated /* Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html */
         AL2X86_64GPU("AL2_x86_64_GPU"),
+        /**
+         * @deprecated
+         * Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html
+         */
+        @Deprecated /* Amazon Linux 2 is deprecated. Please use Amazon Linux 2023 instead.
+See for more details: https://docs.aws.amazon.com/eks/latest/userguide/al2023.html */
         AL2Arm64("AL2_ARM_64"),
         AL2023X86_64Standard("AL2023_x86_64_STANDARD"),
         AL2023Arm64Standard("AL2023_ARM_64_STANDARD"),


### PR DESCRIPTION
AWS deprecated AL2 and it will be EOL'ed in June 2025. This change marks the AL2 related ami types as deprecated so users are aware of this deprecation.

The type `AmiTypes` is not released yet, so this is not a user facing change.

As a follow up task we want to publish a migration guide: https://github.com/pulumi/home/issues/3626

Closes #1351 
