### PR TITLE
Update default instance type to t3.medium

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -1358,7 +1358,7 @@ export interface ClusterOptions {
     useDefaultVpcCni?: boolean;
 
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: pulumi.Input<aws.ec2.InstanceType | string>;
 

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -79,7 +79,7 @@ export interface NodeGroupBaseOptions {
     nodeSubnetIds?: pulumi.Input<pulumi.Input<string>[]>;
 
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: pulumi.Input<string | aws.ec2.InstanceType>;
 
@@ -952,7 +952,7 @@ function createNodeGroupInternal(
         {
             associatePublicIpAddress: nodeAssociatePublicIpAddress,
             imageId: amiId,
-            instanceType: args.instanceType || "t2.medium",
+            instanceType: args.instanceType || "t3.medium",
             iamInstanceProfile: instanceProfile,
             keyName: keyName,
             securityGroups: pulumi
@@ -1424,7 +1424,7 @@ function createNodeGroupV2Internal(
         `${name}-launchTemplate`,
         {
             imageId: amiId,
-            instanceType: args.instanceType || "t2.medium",
+            instanceType: args.instanceType || "t3.medium",
             iamInstanceProfile: { arn: instanceProfileArn },
             keyName: keyName,
             instanceMarketOptions: marketOptions,

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -353,7 +353,7 @@ func generateSchema() schema.PackageSpec {
 					},
 					"instanceType": {
 						TypeSpec:    schema.TypeSpec{Type: "string"}, // TODO: aws.ec2.InstanceType is a string enum.
-						Description: "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\".",
+						Description: "The instance type to use for the cluster's nodes. Defaults to \"t3.medium\".",
 					},
 					"instanceRole": {
 						TypeSpec: schema.TypeSpec{Ref: awsRef("#/resources/aws:iam%2Frole:Role")},
@@ -2035,7 +2035,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		},
 		"instanceType": {
 			TypeSpec:    schema.TypeSpec{Type: "string"}, // TODO: aws.ec2.InstanceType is a string enum.
-			Description: "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\".",
+			Description: "The instance type to use for the cluster's nodes. Defaults to \"t3.medium\".",
 		},
 		"spotPrice": {
 			TypeSpec: schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -302,7 +302,7 @@
                 },
                 "instanceType": {
                     "type": "string",
-                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t3.medium\"."
                 },
                 "keyName": {
                     "type": "string",
@@ -1253,7 +1253,7 @@
                 },
                 "instanceType": {
                     "type": "string",
-                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t3.medium\"."
                 },
                 "ipFamily": {
                     "type": "string",
@@ -1732,7 +1732,7 @@
                 },
                 "instanceType": {
                     "type": "string",
-                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t3.medium\"."
                 },
                 "keyName": {
                     "type": "string",
@@ -2000,7 +2000,7 @@
                 },
                 "instanceType": {
                     "type": "string",
-                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t2.medium\"."
+                    "description": "The instance type to use for the cluster's nodes. Defaults to \"t3.medium\"."
                 },
                 "keyName": {
                     "type": "string",

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -336,7 +336,7 @@ namespace Pulumi.Eks
         }
 
         /// <summary>
-        /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        /// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         /// </summary>
         [Input("instanceType")]
         public Input<string>? InstanceType { get; set; }

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -168,7 +168,7 @@ namespace Pulumi.Eks.Inputs
         public Pulumi.Aws.Iam.InstanceProfile? InstanceProfile { get; set; }
 
         /// <summary>
-        /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        /// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         /// </summary>
         [Input("instanceType")]
         public Input<string>? InstanceType { get; set; }

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -219,7 +219,7 @@ namespace Pulumi.Eks
         public Pulumi.Aws.Iam.InstanceProfile? InstanceProfile { get; set; }
 
         /// <summary>
-        /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        /// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         /// </summary>
         [Input("instanceType")]
         public Input<string>? InstanceType { get; set; }

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -220,7 +220,7 @@ namespace Pulumi.Eks
         public Pulumi.Aws.Iam.InstanceProfile? InstanceProfile { get; set; }
 
         /// <summary>
-        /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        /// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         /// </summary>
         [Input("instanceType")]
         public Input<string>? InstanceType { get; set; }

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -117,7 +117,7 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly Pulumi.Aws.Iam.InstanceProfile? InstanceProfile;
         /// <summary>
-        /// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        /// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         /// </summary>
         public readonly string? InstanceType;
         /// <summary>

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -175,7 +175,7 @@ type clusterArgs struct {
 	//
 	// Note: options `instanceRole` and `instanceRoles` are mutually exclusive.
 	InstanceRoles []*iam.Role `pulumi:"instanceRoles"`
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType *string `pulumi:"instanceType"`
 	// The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
 	// You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
@@ -407,7 +407,7 @@ type ClusterArgs struct {
 	//
 	// Note: options `instanceRole` and `instanceRoles` are mutually exclusive.
 	InstanceRoles iam.RoleArrayInput
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType pulumi.StringPtrInput
 	// The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
 	// You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -121,7 +121,7 @@ type nodeGroupArgs struct {
 	Gpu *bool `pulumi:"gpu"`
 	// The ingress rule that gives node group access.
 	InstanceProfile *iam.InstanceProfile `pulumi:"instanceProfile"`
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType *string `pulumi:"instanceType"`
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName *string `pulumi:"keyName"`
@@ -267,7 +267,7 @@ type NodeGroupArgs struct {
 	Gpu pulumi.BoolPtrInput
 	// The ingress rule that gives node group access.
 	InstanceProfile *iam.InstanceProfile
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType pulumi.StringPtrInput
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName pulumi.StringPtrInput

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -121,7 +121,7 @@ type nodeGroupV2Args struct {
 	IgnoreScalingChanges *bool `pulumi:"ignoreScalingChanges"`
 	// The ingress rule that gives node group access.
 	InstanceProfile *iam.InstanceProfile `pulumi:"instanceProfile"`
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType *string `pulumi:"instanceType"`
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName *string `pulumi:"keyName"`
@@ -275,7 +275,7 @@ type NodeGroupV2Args struct {
 	IgnoreScalingChanges *bool
 	// The ingress rule that gives node group access.
 	InstanceProfile *iam.InstanceProfile
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType pulumi.StringPtrInput
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName pulumi.StringPtrInput

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -370,7 +370,7 @@ type ClusterNodeGroupOptions struct {
 	IgnoreScalingChanges *bool `pulumi:"ignoreScalingChanges"`
 	// The ingress rule that gives node group access.
 	InstanceProfile *iam.InstanceProfile `pulumi:"instanceProfile"`
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType *string `pulumi:"instanceType"`
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName *string `pulumi:"keyName"`
@@ -533,7 +533,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	IgnoreScalingChanges *bool `pulumi:"ignoreScalingChanges"`
 	// The ingress rule that gives node group access.
 	InstanceProfile *iam.InstanceProfile `pulumi:"instanceProfile"`
-	// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+	// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 	InstanceType pulumi.StringPtrInput `pulumi:"instanceType"`
 	// Name of the key pair to use for SSH access to worker nodes.
 	KeyName pulumi.StringPtrInput `pulumi:"keyName"`
@@ -803,7 +803,7 @@ func (o ClusterNodeGroupOptionsOutput) InstanceProfile() iam.InstanceProfileOutp
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *iam.InstanceProfile { return v.InstanceProfile }).(iam.InstanceProfileOutput)
 }
 
-// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 func (o ClusterNodeGroupOptionsOutput) InstanceType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *string { return v.InstanceType }).(pulumi.StringPtrOutput)
 }
@@ -1164,7 +1164,7 @@ func (o ClusterNodeGroupOptionsPtrOutput) InstanceProfile() iam.InstanceProfileO
 	}).(iam.InstanceProfileOutput)
 }
 
-// The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+// The instance type to use for the cluster's nodes. Defaults to "t3.medium".
 func (o ClusterNodeGroupOptionsPtrOutput) InstanceType() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *ClusterNodeGroupOptions) *string {
 		if v == nil {

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -409,14 +409,14 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     @Import(name="instanceType")
     private @Nullable Output<String> instanceType;
 
     /**
-     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     public Optional<Output<String>> instanceType() {
@@ -1636,7 +1636,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 
@@ -1647,7 +1647,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -324,14 +324,14 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     @Import(name="instanceType")
     private @Nullable Output<String> instanceType;
 
     /**
-     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     public Optional<Output<String>> instanceType() {
@@ -1171,7 +1171,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 
@@ -1182,7 +1182,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -344,14 +344,14 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     @Import(name="instanceType")
     private @Nullable Output<String> instanceType;
 
     /**
-     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     public Optional<Output<String>> instanceType() {
@@ -1237,7 +1237,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 
@@ -1248,7 +1248,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -330,14 +330,14 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
-     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     @Import(name="instanceType")
     private @Nullable Output<String> instanceType;
 
     /**
-     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     public Optional<Output<String>> instanceType() {
@@ -1181,7 +1181,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 
@@ -1192,7 +1192,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         }
 
         /**
-         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+         * @param instanceType The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -138,7 +138,7 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable InstanceProfile instanceProfile;
     /**
-     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     private @Nullable String instanceType;
@@ -433,7 +433,7 @@ public final class ClusterNodeGroupOptions {
         return Optional.ofNullable(this.instanceProfile);
     }
     /**
-     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t2.medium&#34;.
+     * @return The instance type to use for the cluster&#39;s nodes. Defaults to &#34;t3.medium&#34;.
      * 
      */
     public Optional<String> instanceType() {

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -317,7 +317,7 @@ export interface ClusterArgs {
      */
     instanceRoles?: pulumi.Input<pulumi.Input<pulumiAws.iam.Role>[]>;
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/nodeGroup.ts
+++ b/sdk/nodejs/nodeGroup.ts
@@ -218,7 +218,7 @@ export interface NodeGroupArgs {
      */
     instanceProfile?: pulumiAws.iam.InstanceProfile;
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/nodeGroupV2.ts
+++ b/sdk/nodejs/nodeGroupV2.ts
@@ -217,7 +217,7 @@ export interface NodeGroupV2Args {
      */
     instanceProfile?: pulumiAws.iam.InstanceProfile;
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -168,7 +168,7 @@ export interface ClusterNodeGroupOptionsArgs {
      */
     instanceProfile?: pulumiAws.iam.InstanceProfile;
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -168,7 +168,7 @@ export interface ClusterNodeGroupOptions {
      */
     instanceProfile?: pulumiAws.iam.InstanceProfile;
     /**
-     * The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+     * The instance type to use for the cluster's nodes. Defaults to "t3.medium".
      */
     instanceType?: string;
     /**

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -282,7 +282,7 @@ class ClusterNodeGroupOptionsArgs:
                
                See [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details.
         :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
@@ -629,7 +629,7 @@ class ClusterNodeGroupOptionsArgs:
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[pulumi.Input[str]]:
         """
-        The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         """
         return pulumi.get(self, "instance_type")
 

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -131,7 +131,7 @@ class ClusterArgs:
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.iam.Role']]] instance_roles: This enables the advanced case of registering *many* IAM instance roles with the cluster for per node group IAM, instead of the simpler, shared case of `instanceRole`.
                
                Note: options `instanceRole` and `instanceRoles` are mutually exclusive.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] ip_family: The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
                You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
         :param 'KubeProxyAddonOptionsArgs' kube_proxy_addon_options: Options for managing the `kube-proxy` addon.
@@ -637,7 +637,7 @@ class ClusterArgs:
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[pulumi.Input[str]]:
         """
-        The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         """
         return pulumi.get(self, "instance_type")
 
@@ -1243,7 +1243,7 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.iam.Role']]] instance_roles: This enables the advanced case of registering *many* IAM instance roles with the cluster for per node group IAM, instead of the simpler, shared case of `instanceRole`.
                
                Note: options `instanceRole` and `instanceRoles` are mutually exclusive.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] ip_family: The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
                You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
         :param Union['KubeProxyAddonOptionsArgs', 'KubeProxyAddonOptionsArgsDict'] kube_proxy_addon_options: Options for managing the `kube-proxy` addon.

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -115,7 +115,7 @@ class NodeGroupArgs:
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
         :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
@@ -453,7 +453,7 @@ class NodeGroupArgs:
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[pulumi.Input[str]]:
         """
-        The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         """
         return pulumi.get(self, "instance_type")
 
@@ -861,7 +861,7 @@ class NodeGroup(pulumi.ComponentResource):
                - https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
                - https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html
         :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -121,7 +121,7 @@ class NodeGroupV2Args:
                
                See [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details.
         :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
@@ -481,7 +481,7 @@ class NodeGroupV2Args:
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[pulumi.Input[str]]:
         """
-        The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         """
         return pulumi.get(self, "instance_type")
 
@@ -914,7 +914,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                
                See [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details.
         :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
-        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param pulumi.Input[str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[str] key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -383,7 +383,7 @@ class ClusterNodeGroupOptions(dict):
                
                See [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details.
         :param 'pulumi_aws.iam.InstanceProfile' instance_profile: The ingress rule that gives node group access.
-        :param str instance_type: The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        :param str instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param str key_name: Name of the key pair to use for SSH access to worker nodes.
         :param str kubelet_extra_args: Extra args to pass to the Kubelet. Corresponds to the options passed in the `--kubeletExtraArgs` flag to `/etc/eks/bootstrap.sh`. For example, '--port=10251 --address=0.0.0.0'. Note that the `labels` and `taints` properties will be applied to this list (using `--node-labels` and `--register-with-taints` respectively) after to the explicit `kubeletExtraArgs`.
         :param Mapping[str, str] labels: Custom k8s node labels to be attached to each worker node. Adds the given key/value pairs to the `--node-labels` kubelet argument.
@@ -674,7 +674,7 @@ class ClusterNodeGroupOptions(dict):
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[str]:
         """
-        The instance type to use for the cluster's nodes. Defaults to "t2.medium".
+        The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         """
         return pulumi.get(self, "instance_type")
 


### PR DESCRIPTION
The current default, t2.medium, is an instance type from 2014 that is becoming less common in AWS data centers. This means users will encounter more errors when deploying clusters with the provider when using the default instance type.

This mostly affects beginner users, as more experienced users typically do not rely on the default instance types and instead configure appropriate types for their workloads.

This change replaces the default t2.medium instances with t3.medium. These newer instances offer better performance and are marginally cheaper ($0.0416 vs. $0.0464 per hour).
