### PR TITLE
Skip upgrade tests until the first v3 alpha is released

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 func TestExamplesUpgrades(t *testing.T) {
-	t.Skip("Skipping for now until EKS v3 alpha is released. Otherwise we cannot re-record.")
+	t.Skip("Temporarily skipping upgrade tests. Needs to be addressed in pulumi/pulumi-eks#1387")
 	t.Run("cluster", func(t *testing.T) {
 		testProviderUpgrade(t, "cluster")
 	})

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -26,6 +26,7 @@ const (
 )
 
 func TestExamplesUpgrades(t *testing.T) {
+	t.Skip("Skipping for now until EKS v3 alpha is released. Otherwise we cannot re-record.")
 	t.Run("cluster", func(t *testing.T) {
 		testProviderUpgrade(t, "cluster")
 	})


### PR DESCRIPTION
The release branch for EKS v3 contains breaking changes now. This causes the upgrade tests to fail. Because of that we disabled the upgrade tests.
Once the first alpha version was released we can re-record and re-enable them.