### PR TITLE
Fix pre-release condition in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,7 +348,8 @@ jobs:
           gradle-version: 7.4.1
   create_docs_build:
     name: Create docs build
-    if: env.IS_PRERELEASE != 'true'
+    # only pre-releases contain a hyphen
+    if: ${{ ! contains(github.ref_name,'-') }}
     needs:
       - prerequisites
       - publish_sdk


### PR DESCRIPTION
It seems that the env cannot be used for controlling whether jobs run. This now uses the underlying expression directly.

This is the error we got:
```
The workflow is not valid. .github/workflows/release.yml (Line: 351, Col: 9): Unrecognized named-value: 'env'. Located at position 1 within expression: env.IS_PRERELEASE != 'true'
```

