### PR TITLE
Allow testing release.yml changes on pre-releases before merging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ env:
   DOTNETVERSION: "6.x"
   PYTHONVERSION: "3.8"
   JAVAVERSION: "11"
-  IS_PRERELEASE: ${{ contains(github.ref_name,'-') }}
+  IS_PRERELEASE: ${{ contains(github.ref_name,'-') || github.event_name == 'workflow_dispatch' }}
 jobs:
   lint:
     name: Lint and unit test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -807,3 +807,4 @@ name: release
   push:
     tags:
       - v*.*.*
+  workflow_dispatch: {}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Similar to how master.yml works, this change allows to trigger release.yml manually and point it to a WIP branch. This will help us out to test alpha releases and changes to the release workflow for the 3.x.x series.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
