### PR TITLE
Fix environment variable syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ env:
   DOTNETVERSION: "6.x"
   PYTHONVERSION: "3.8"
   JAVAVERSION: "11"
-  IS_PRERELEASE: ${{ contains(github.ref_name,'-') || github.event_name == 'workflow_dispatch' }}
 jobs:
   lint:
     name: Lint and unit test
@@ -191,7 +190,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.prerequisites.outputs.version }}
-      isPrerelease: ${{ env.IS_PRERELEASE }}
+      isPrerelease: ${{ contains(github.ref_name,'-') || github.event_name == 'workflow_dispatch' }}
 
   test-nodejs:
     name: Run NodeJS Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ env:
   DOTNETVERSION: "6.x"
   PYTHONVERSION: "3.8"
   JAVAVERSION: "11"
-  IS_PRERELEASE: ${{ contains(github.ref_name,'-') }}
+  IS_PRERELEASE: ${{ contains(github.ref_name,'-') || github.event_name == 'workflow_dispatch' }}
 jobs:
   lint:
     name: Lint and unit test
@@ -600,3 +600,4 @@ name: release
   push:
     tags:
       - v*.*.*
+  workflow_dispatch: {}


### PR DESCRIPTION
On master this works:

      - name: Create GH Release
        uses: softprops/action-gh-release@v2
        with:
          generate_release_notes: true
          files: |
            dist/*.tar.gz
          prerelease: ${{ env.IS_PRERELEASE }}
        env:
          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

On release-3.x.x this fails:

```
  publish:
    name: publish
    needs:
      - prerequisites
      - test-nodejs
      - test-python
      - test-dotnet
      - test-go
    uses: ./.github/workflows/publish.yml
    secrets: inherit
    with:
      version: ${{ needs.prerequisites.outputs.version }}
      isPrerelease: ${{ env.IS_PRERELEASE }}
```

With:

```
 Invalid workflow file: .github/workflows/release.yml#L194
 The workflow is not valid. .github/workflows/release.yml (ine: 194, Col: 21):
 Unrecognized named-value: 'env'.
 Located at position 1 within expression: env.IS_PRERELEASE
```

Possibly related https://github.com/actions/runner/issues/1189

Working around by in-lining the ENV var.