### PR TITLE
Add enum changes to migration guide

### DIFF
--- a/docs/eks-v3-migration.md
+++ b/docs/eks-v3-migration.md
@@ -148,6 +148,7 @@ The Nodejs SDK is updated to use state of the art Pulumi tooling, improving stab
   - `clusterOidcProvider` is an output now. `getKubeConfig` returns an output now  
 - The deprecated input property `deployDashboard` of the `Cluster` component has been removed from the Nodejs SDK. This has already been removed from the other SDKs in the past. If you’d like to continue using it, you can adopt the existing code into your own program from [here](https://github.com/pulumi/pulumi-eks/blob/bcc170e72b802a78e7f0a99bc92316a5f8a62b0e/nodejs/eks/dashboard.ts).
 - The `createManagedNodeGroup` function will now create an Pulumi EKS `ManagedNodeGroup` instead of creating the underlying `aws.eks.NodeGroup` resource directly. During the upgrade to Pulumi EKS v3 you'll see the additional wrapper component being created.
+- The capitalization of the `AuthenticationMode` and `AccessEntryType` enum values has been aligned with other providers (e.g. `AuthenticationMode.API` => `AuthenticationMode.Api`). The previous values have been marked as deprecated and now point to their new counterparts.
 
 ## Miscellaneous changes
 


### PR DESCRIPTION
This adds a sentence about the enum changes to the migration guide. Those changes are caused by auto-generating the node sdk now.
