### PR TITLE
Add example for EKS feature: Network Policies

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1025,3 +1025,21 @@ func TestAccSkipDefaultSecurityGroups(t *testing.T) {
 
 	programTestWithExtraOptions(t, &test, nil)
 }
+
+func TestAccNetworkPolicies(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "network-policies"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+			},
+		})
+
+	programTestWithExtraOptions(t, &test, nil)
+}

--- a/examples/network-policies/Pulumi.yaml
+++ b/examples/network-policies/Pulumi.yaml
@@ -1,3 +1,3 @@
-name: pod-security-groups
-description: EKS cluster with pod security groups
+name: network-policies
+description: EKS cluster with network policies
 runtime: nodejs

--- a/examples/network-policies/Pulumi.yaml
+++ b/examples/network-policies/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pod-security-groups
+description: EKS cluster with pod security groups
+runtime: nodejs

--- a/examples/network-policies/README.md
+++ b/examples/network-policies/README.md
@@ -1,3 +1,33 @@
 # Network Policies
 
-Demonstrates how to use Kubernetes Network Policies with EKS.
+This example demonstrates how to set up Kubernetes Network Policies in an Amazon EKS cluster using Pulumi.
+
+## Topology
+
+```mermaid
+graph TD
+    caller[caller Job]
+    wrongCaller[wrong-caller Job]
+    nginx[nginx]
+    coredns[corends]
+    caller -- Allow --> nginx
+    caller -- Allow --> coredns
+    wrongCaller -. Deny .-> nginx
+    wrongCaller -- Allow --> coredns
+    nginx -- Allow --> coredns
+```
+
+## Components
+
+1. **caller Job**: A Kubernetes Job that is allowed to communicate with both the nginx pod and CoreDNS.
+2. **wrong-caller Job**: A Kubernetes Job that is allowed to communicate with CoreDNS but denied access to the nginx pod.
+3. **nginx**: A web server pod that can communicate with CoreDNS.
+4. **CoreDNS**: The cluster's DNS service, accessible by all pods.
+
+## Network Policies
+
+This example implements the following network policies:
+
+1. Allow the `caller` Job to access both nginx and CoreDNS.
+2. Deny the `wrong-caller` Job access to nginx, while allowing access to CoreDNS.
+3. Allow nginx to access CoreDNS.

--- a/examples/network-policies/README.md
+++ b/examples/network-policies/README.md
@@ -1,0 +1,3 @@
+# Network Policies
+
+Demonstrates how to use Kubernetes Network Policies with EKS.

--- a/examples/network-policies/application.ts
+++ b/examples/network-policies/application.ts
@@ -1,41 +1,39 @@
-
-import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
 
 export function createApplication(name: string, provider: k8s.Provider): k8s.core.v1.Service {
-    const ns = new k8s.core.v1.Namespace(name, {
-      metadata: { name: name },
-    }, { provider: provider });
-  
-    const deployment = new k8s.apps.v1.Deployment(name, {
-      metadata: {
-        name: name,
-        namespace: ns.metadata.name
-      },
-      spec: {
-        selector: { matchLabels: { app: name } },
-        replicas: 1,
-        template: {
-          metadata: { labels: { app: name } },
-          spec: {
-            containers: [{
-              name: name,
-              image: "nginx",
-              ports: [{ containerPort: 80 }],
-            }],
-          },
+  const ns = new k8s.core.v1.Namespace(name, {
+    metadata: { name: name },
+  }, { provider: provider });
+
+  const deployment = new k8s.apps.v1.Deployment(name, {
+    metadata: {
+      name: name,
+      namespace: ns.metadata.name
+    },
+    spec: {
+      selector: { matchLabels: { app: name } },
+      replicas: 1,
+      template: {
+        metadata: { labels: { app: name } },
+        spec: {
+          containers: [{
+            name: name,
+            image: "nginx",
+            ports: [{ containerPort: 80 }],
+          }],
         },
       },
-    }, { provider: provider });
-  
-    return new k8s.core.v1.Service(name, {
-      metadata: {
-        name: name,
-        namespace: ns.metadata.name
-      },
-      spec: {
-        selector: { app: name },
-        ports: [{ port: 80, targetPort: 80 }],
-      },
-    }, { provider: provider, dependsOn: [deployment] });
-  }
+    },
+  }, { provider: provider });
+
+  return new k8s.core.v1.Service(name, {
+    metadata: {
+      name: name,
+      namespace: ns.metadata.name
+    },
+    spec: {
+      selector: { app: name },
+      ports: [{ port: 80, targetPort: 80 }],
+    },
+  }, { provider: provider, dependsOn: [deployment] });
+}

--- a/examples/network-policies/application.ts
+++ b/examples/network-policies/application.ts
@@ -1,0 +1,41 @@
+
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+export function createApplication(name: string, provider: k8s.Provider): k8s.core.v1.Service {
+    const ns = new k8s.core.v1.Namespace(name, {
+      metadata: { name: name },
+    }, { provider: provider });
+  
+    const deployment = new k8s.apps.v1.Deployment(name, {
+      metadata: {
+        name: name,
+        namespace: ns.metadata.name
+      },
+      spec: {
+        selector: { matchLabels: { app: name } },
+        replicas: 1,
+        template: {
+          metadata: { labels: { app: name } },
+          spec: {
+            containers: [{
+              name: name,
+              image: "nginx",
+              ports: [{ containerPort: 80 }],
+            }],
+          },
+        },
+      },
+    }, { provider: provider });
+  
+    return new k8s.core.v1.Service(name, {
+      metadata: {
+        name: name,
+        namespace: ns.metadata.name
+      },
+      spec: {
+        selector: { app: name },
+        ports: [{ port: 80, targetPort: 80 }],
+      },
+    }, { provider: provider, dependsOn: [deployment] });
+  }

--- a/examples/network-policies/iam.ts
+++ b/examples/network-policies/iam.ts
@@ -1,0 +1,28 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+];
+
+// Creates a role and attches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/examples/network-policies/index.ts
+++ b/examples/network-policies/index.ts
@@ -1,0 +1,171 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as iam from "./iam";
+import * as k8s from "@pulumi/kubernetes";
+import * as app from "./application";
+
+// IAM roles for the node groups.
+const role = iam.createRole("network-policies");
+
+// Create a new VPC
+const eksVpc = new awsx.ec2.Vpc("network-policies", {
+  enableDnsHostnames: true,
+  cidrBlock: "10.0.0.0/16",
+});
+
+// Create an EKS cluster.
+const cluster = new eks.Cluster("network-policies", {
+  skipDefaultNodeGroup: true,
+  vpcId: eksVpc.vpcId,
+  authenticationMode: eks.AuthenticationMode.Api,
+  // Public subnets will be used for load balancers
+  publicSubnetIds: eksVpc.publicSubnetIds,
+  // Private subnets will be used for cluster nodes
+  privateSubnetIds: eksVpc.privateSubnetIds,
+  vpcCniOptions: {
+    enableNetworkPolicy: true,
+    configurationValues: {
+      env: {
+        // pods that use the VPC CNI start with a default deny policy
+        NETWORK_POLICY_ENFORCING_MODE: "strict",
+      }
+    }
+  },
+});
+
+// Export the cluster's kubeconfig.
+export const kubeconfig = cluster.kubeconfig;
+
+const ng = eks.createManagedNodeGroup("network-policies", {
+  scalingConfig: {
+    minSize: 1,
+    maxSize: 2,
+    desiredSize: 1,
+  },
+  cluster: cluster,
+  nodeRole: role,
+});
+
+const kube = cluster.provider;
+
+// Allow DNS traffic to coredns from all pods in the cluster
+const dnsIngressNetworkPolicy = new k8s.networking.v1.NetworkPolicy("dns-ingress", {
+  metadata: {
+    name: "dns-ingress",
+    namespace: "kube-system"
+  },
+  spec: {
+    podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+    ingress: [{
+      from: [{
+        podSelector: {},
+        namespaceSelector: {},
+      }],
+      ports: [{ port: 53, protocol: "UDP" }],
+    }],
+  },
+}, { provider: kube });
+
+const nginx = app.createApplication("nginx", kube);
+
+// allow access to the nginx service from the caller pod in the jobs namespace
+const networkPolicy = new k8s.networking.v1.NetworkPolicy("nginx-ingress", {
+  metadata: {
+    name: "nginx-ingress",
+    namespace: nginx.metadata.namespace
+  },
+  spec: {
+    podSelector: { matchLabels: { app: "nginx" } },
+    ingress: [{
+      from: [{
+        podSelector: { matchLabels: { app: "caller" } },
+        namespaceSelector: { matchLabels: { name: "jobs" } },
+      }],
+      ports: [{ port: 80 }],
+    }],
+  },
+}, { provider: kube });
+
+/*
+ * Verify that the Network Policies are working as expected
+ */
+
+const jobNamespace = new k8s.core.v1.Namespace("jobs", {
+  metadata: {
+    name: "jobs",
+    labels: {
+      name: "jobs",
+    }
+  },
+}, { provider: kube });
+
+// allow all egress traffic for the verification jobs
+const jobEgressNetworkPolicy = new k8s.networking.v1.NetworkPolicy("job-egress", {
+  metadata: {
+    name: "job-egress",
+    namespace: jobNamespace.metadata.name,
+  },
+  spec: {
+    podSelector: {},
+    policyTypes: ["Egress"],
+    egress: [{}],
+  },
+}, { provider: kube });
+
+// Create a job that is allowed to curl the nginx service. The job will fail if it can't reach the service.
+new k8s.batch.v1.Job("caller", {
+  metadata: {
+    namespace: jobNamespace.metadata.name,
+  },
+  spec: {
+    template: {
+      metadata: {
+        name: "caller",
+        namespace: jobNamespace.metadata.name,
+        labels: {
+          app: "caller",
+        },
+      },
+      spec: {
+        containers: [{
+          name: "caller",
+          image: "curlimages/curl",
+          command: ["curl", "--silent", "--show-error", "--fail", pulumi.interpolate`${nginx.metadata.name}.${nginx.metadata.namespace}:80`],
+        }],
+        restartPolicy: "Never",
+      },
+    },
+    backoffLimit: 3,
+  },
+}, { provider: kube, dependsOn: [nginx, networkPolicy] });
+
+// Create a job that is not allowed to curl the nginx service. The job will fail if it can reach the service.
+new k8s.batch.v1.Job("wrong-caller", {
+  metadata: {
+    namespace: jobNamespace.metadata.name,
+  },
+  spec: {
+    template: {
+      metadata: {
+        name: "wrong-caller",
+        namespace: jobNamespace.metadata.name,
+        labels: {
+          app: "wrong-caller",
+        },
+      },
+      spec: {
+        containers: [{
+          name: "caller",
+          image: "curlimages/curl",
+          command: [
+            "sh", "-c",
+            pulumi.interpolate`curl --silent --show-error --fail ${nginx.metadata.name}.${nginx.metadata.namespace}:80 && exit 1 || exit 0`,
+          ],
+        }],
+        restartPolicy: "Never",
+      },
+    },
+    backoffLimit: 3,
+  },
+}, { provider: kube, dependsOn: [nginx] });

--- a/examples/network-policies/package.json
+++ b/examples/network-policies/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "network-policies",
+    "devDependencies": {
+        "@types/node": "latest",
+        "typescript": "^4.0.0"
+    },
+    "dependencies": {
+        "@pulumi/awsx": "^2.0.0",
+        "@pulumi/aws": "^6.50.1",
+        "@pulumi/eks": "latest",
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/examples/network-policies/tsconfig.json
+++ b/examples/network-policies/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts",
+        "iam.ts",
+        "application.ts"
+    ]
+}


### PR DESCRIPTION
This adds an example (and acceptance test) for EKS Network Policies.

The configuration is derived from this AWS example: https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy-configure.html