### PR TITLE
Add scalar types for most commonly used resource outputs

### DIFF
--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -19,7 +19,7 @@ const cluster1 = new eks.Cluster(`${projectName}-1`, {
     nodeAmiId: "ami-066e69f6f03b5383e",
 });
 
-export const defaultAsgArn: pulumi.Output<string> = cluster1.defaultNodeGroup.apply(ng => ng?.autoScalingGroup.arn ?? pulumi.output(""));
+export const defaultAsgName: pulumi.Output<string> = cluster1.defaultNodeGroupAsgName;
 
 const cluster2 = new eks.Cluster(`${projectName}-2`, {
     vpcId: vpc.vpcId,

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -57,7 +57,7 @@ func TestAccCluster(t *testing.T) {
 					info.Outputs["kubeconfig4"],
 				)
 
-				assert.NotEmpty(t, info.Outputs["defaultAsgArn"], "should have a default ASG")
+				assert.NotEmpty(t, info.Outputs["defaultAsgName"], "should have a default ASG")
 
 				// let's test there's a iamRoleArn specified for the cluster
 				assert.NotEmpty(t, info.Outputs["iamRoleArn"])

--- a/examples/extra-sg/index.ts
+++ b/examples/extra-sg/index.ts
@@ -61,7 +61,7 @@ const nodeIngressRule = new aws.ec2.SecurityGroupRule("nodeIngressRule", {
   fromPort: 0,
   toPort: 65535,
   protocol: "tcp",
-  securityGroupId: cluster.nodeSecurityGroup.apply((sg) => sg!.id),
+  securityGroupId: cluster.nodeSecurityGroupId,
   sourceSecurityGroupId: customSecurityGroup.id,
 });
 
@@ -108,6 +108,6 @@ const ng = new eks.NodeGroupV2("example-mng", {
   amiId: "ami-066e69f6f03b5383e",
   extraNodeSecurityGroups: [
     customSecurityGroup, // Plain type
-    cluster.nodeSecurityGroup.apply(sg => sg!), // Input type
+    cluster.nodeSecurityGroupId, // Input type
   ],
 });

--- a/examples/extra-sg/index.ts
+++ b/examples/extra-sg/index.ts
@@ -108,6 +108,6 @@ const ng = new eks.NodeGroupV2("example-mng", {
   amiId: "ami-066e69f6f03b5383e",
   extraNodeSecurityGroups: [
     customSecurityGroup, // Plain type
-    cluster.nodeSecurityGroupId, // Input type
+    cluster.nodeSecurityGroup.apply(sg => sg!), // Input type
   ],
 });

--- a/examples/oidc-iam-sa/index.ts
+++ b/examples/oidc-iam-sa/index.ts
@@ -19,8 +19,6 @@ export const kubeconfig = cluster.kubeconfig;
 if (!cluster?.core?.oidcProvider) {
     throw new Error("Invalid cluster OIDC provider URL");
 }
-const clusterOidcProvider = cluster.core.oidcProvider;
-export const clusterOidcProviderUrl = clusterOidcProvider.apply(u => u!.url);
 
 // Setup Pulumi Kubernetes provider.
 const provider = new k8s.Provider("eks-k8s", {
@@ -34,22 +32,21 @@ export const appsNamespaceName = appsNamespace.metadata.name;
 // Create the new IAM policy for the Service Account using the
 // AssumeRoleWebWebIdentity action.
 const saName = "s3";
-const oidcProviderArn = clusterOidcProvider.apply(o => o!.arn);
-const saAssumeRolePolicy = pulumi.all([clusterOidcProviderUrl, oidcProviderArn, appsNamespaceName]).apply(([url, arn, namespace]) => aws.iam.getPolicyDocument({
+const saAssumeRolePolicy = aws.iam.getPolicyDocument({
     statements: [{
         actions: ["sts:AssumeRoleWithWebIdentity"],
         conditions: [{
             test: "StringEquals",
-            values: [`system:serviceaccount:${namespace}:${saName}`],
-            variable: `${url.replace("https://", "")}:sub`,
+            values: [pulumi.interpolate`system:serviceaccount:${appsNamespaceName}:${saName}`],
+            variable: pulumi.interpolate`${cluster.oidcIssuer}:sub`,
         }],
         effect: "Allow",
         principals: [{
-            identifiers: [arn],
+            identifiers: [cluster.oidcProviderArn],
             type: "Federated",
         }],
     }],
-}));
+});
 
 const saRole = new aws.iam.Role(saName, {
     assumeRolePolicy: saAssumeRolePolicy.json,

--- a/examples/oidc-iam-sa/index.ts
+++ b/examples/oidc-iam-sa/index.ts
@@ -32,7 +32,7 @@ export const appsNamespaceName = appsNamespace.metadata.name;
 // Create the new IAM policy for the Service Account using the
 // AssumeRoleWebWebIdentity action.
 const saName = "s3";
-const saAssumeRolePolicy = aws.iam.getPolicyDocument({
+const saAssumeRolePolicy = aws.iam.getPolicyDocumentOutput({
     statements: [{
         actions: ["sts:AssumeRoleWithWebIdentity"],
         conditions: [{

--- a/examples/tests/scalar-types/Pulumi.yaml
+++ b/examples/tests/scalar-types/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: scalar-types
+description: Tests retrieving the scalar properties of EKS clusters
+runtime: nodejs

--- a/examples/tests/scalar-types/iam.ts
+++ b/examples/tests/scalar-types/iam.ts
@@ -1,0 +1,28 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+];
+
+// Creates a role and attches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/examples/tests/scalar-types/index.ts
+++ b/examples/tests/scalar-types/index.ts
@@ -1,0 +1,37 @@
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as iam from "./iam";
+
+const role1 = iam.createRole("scalar-types-1");
+const role2 = iam.createRole("scalar-types-2");
+
+const eksVpc = new awsx.ec2.Vpc("scalar-types", {
+  enableDnsHostnames: true,
+  cidrBlock: "10.0.0.0/16",
+});
+
+export const cluster1 = new eks.Cluster("scalar-types-1", {
+  vpcId: eksVpc.vpcId,
+  authenticationMode: eks.AuthenticationMode.Api,
+  publicSubnetIds: eksVpc.publicSubnetIds,
+  privateSubnetIds: eksVpc.privateSubnetIds,
+  createOidcProvider: true,
+});
+
+export const kubeconfig1 = cluster1.kubeconfig;
+
+export const cluster2 = new eks.Cluster("scalar-types-2", {
+  vpcId: eksVpc.vpcId,
+  authenticationMode: eks.AuthenticationMode.Api,
+  fargate: {
+    selectors: [{ namespace: "kube-system" }],
+  },
+  skipDefaultSecurityGroups: true,
+  publicSubnetIds: eksVpc.publicSubnetIds,
+  privateSubnetIds: eksVpc.privateSubnetIds,
+});
+
+export const kubeconfig2 = cluster2.kubeconfig;

--- a/examples/tests/scalar-types/package.json
+++ b/examples/tests/scalar-types/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "scalar-types",
+    "devDependencies": {
+        "@types/node": "latest",
+        "typescript": "^4.0.0"
+    },
+    "dependencies": {
+        "@pulumi/awsx": "^2.0.0",
+        "@pulumi/aws": "^6.50.1",
+        "@pulumi/eks": "latest",
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/examples/tests/scalar-types/tsconfig.json
+++ b/examples/tests/scalar-types/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -1009,7 +1009,8 @@ export function createCore(
             return result;
         });
 
-    const corednsExplicitlyEnabled = args.corednsAddonOptions?.enabled === true || args.corednsAddonOptions?.configurationValues;
+    const corednsExplicitlyEnabled =
+        args.corednsAddonOptions?.enabled === true || args.corednsAddonOptions?.configurationValues;
     // We can only enable the coredns addon if we have a node group to place it on
     // This means we are either using the default node group or the cluster is a fargate cluster
     // Also, if the user explicitly enables it then do what they want
@@ -1058,17 +1059,21 @@ export function createCore(
                         args.corednsAddonOptions?.resolveConflictsOnUpdate ?? "OVERWRITE",
                     configurationValues: stringifyAddonConfiguration(configurationValues),
                 },
-                { parent, provider, dependsOn: fargateProfile.apply(profile => {
-                    // The coredns addon needs a dependency on the fargate profile because
-                    // if there's no profile at the time of deployment, the pods of the
-                    // addon will be assigned to the default-scheduler and not the
-                    // fargate scheduler.
-                    if (profile) {
-                        return [profile];
-                    } else {
-                        return [];
-                    }
-                }) },
+                {
+                    parent,
+                    provider,
+                    dependsOn: fargateProfile.apply((profile) => {
+                        // The coredns addon needs a dependency on the fargate profile because
+                        // if there's no profile at the time of deployment, the pods of the
+                        // addon will be assigned to the default-scheduler and not the
+                        // fargate scheduler.
+                        if (profile) {
+                            return [profile];
+                        } else {
+                            return [];
+                        }
+                    }),
+                },
             );
         }
     });
@@ -2092,11 +2097,16 @@ export function createCluster(
 
     const kubeconfigJson = pulumi.jsonStringify(core.kubeconfig);
 
-    const oidcIssuerUrl = core.cluster.identities.apply(identities => {
+    const oidcIssuerUrl = core.cluster.identities.apply((identities) => {
         // this is nowadays guaranteed to be present, but we still check for it to be safe
         // this was not set for cluster version 1.14 and below. Those versions are not available anymore
         // since 2020-12-08 and clusters were force upgraded
-        if (identities && identities.length > 0 && identities[0].oidcs && identities[0].oidcs.length > 0) {
+        if (
+            identities &&
+            identities.length > 0 &&
+            identities[0].oidcs &&
+            identities[0].oidcs.length > 0
+        ) {
             return identities[0].oidcs[0].issuer;
         }
         return "";
@@ -2115,17 +2125,22 @@ export function createCluster(
         kubeconfigJson,
         // If the cluster is created without default security groups, we're returning the EKS created security group
         // see: https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#security-group-default-rules
-        clusterSecurityGroupId: core.clusterSecurityGroup?.id ?? core.cluster.vpcConfig.clusterSecurityGroupId,
+        clusterSecurityGroupId:
+            core.clusterSecurityGroup?.id ?? core.cluster.vpcConfig.clusterSecurityGroupId,
         nodeSecurityGroupId: nodeSecurityGroup?.id ?? core.cluster.vpcConfig.clusterSecurityGroupId,
 
         clusterIngressRuleId: eksClusterIngressRule?.securityGroupRuleId ?? pulumi.output(""),
         defaultNodeGroupAsgName: defaultNodeGroup?.autoScalingGroup.name ?? pulumi.output(""),
-        fargateProfileId: core.fargateProfile.apply(fargateProfile => fargateProfile?.id ?? pulumi.output("")),
-        fargateProfileStatus: core.fargateProfile.apply(fargateProfile => fargateProfile?.status ?? pulumi.output("")),
+        fargateProfileId: core.fargateProfile.apply(
+            (fargateProfile) => fargateProfile?.id ?? pulumi.output(""),
+        ),
+        fargateProfileStatus: core.fargateProfile.apply(
+            (fargateProfile) => fargateProfile?.status ?? pulumi.output(""),
+        ),
         oidcProviderArn: core.oidcProvider?.arn ?? pulumi.output(""),
         oidcProviderUrl: oidcIssuerUrl,
         // The issuer is the issuer URL without the protocol part
-        oidcIssuer: oidcIssuerUrl.apply(url => url.replace("https://", "")),
+        oidcIssuer: oidcIssuerUrl.apply((url) => url.replace("https://", "")),
     };
 }
 

--- a/nodejs/eks/cmd/provider/cluster.ts
+++ b/nodejs/eks/cmd/provider/cluster.ts
@@ -36,6 +36,15 @@ const clusterProvider: pulumi.provider.Provider = {
                     defaultNodeGroup: cluster.defaultNodeGroup,
                     eksCluster: cluster.eksCluster,
                     core: cluster.core,
+                    clusterSecurityGroupId: cluster.clusterSecurityGroupId,
+                    nodeSecurityGroupId: cluster.nodeSecurityGroupId,
+                    clusterIngressRuleId: cluster.clusterIngressRuleId,
+                    defaultNodeGroupAsgName: cluster.defaultNodeGroupAsgName,
+                    fargateProfileId: cluster.fargateProfileId,
+                    fargateProfileStatus: cluster.fargateProfileStatus,
+                    oidcProviderArn: cluster.oidcProviderArn,
+                    oidcProviderUrl: cluster.oidcProviderUrl,
+                    oidcIssuer: cluster.oidcIssuer,
                 },
             });
         } catch (e) {

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1103,6 +1103,7 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 				},
 			},
 			"eks:index:VpcCniAddon": {
+				IsComponent: true,
 				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Description: "VpcCniAddon manages the configuration of the Amazon VPC CNI plugin for Kubernetes by leveraging the EKS managed add-on.\n" +
 						"For more information see: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html",

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -264,7 +264,7 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 							Description: "Issuer URL for the OpenID Connect identity provider of the EKS cluster.",
 						},
 						"oidcIssuer": {
-							TypeSpec:    schema.TypeSpec{Type: "string"},
+							TypeSpec: schema.TypeSpec{Type: "string"},
 							Description: "The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).\n\n" +
 								"This value can be used to associate kubernetes service accounts with IAM roles. For more information, see " +
 								"https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.",

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -199,10 +199,6 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/provider")},
 							Description: "The AWS resource provider.",
 						},
-						// "provider": {
-						// 	TypeSpec:    schema.TypeSpec{Ref: k8sRef("#/provider")},
-						// 	Description: "A Kubernetes resource provider that can be used to deploy into this cluster.",
-						// },
 						"clusterSecurityGroup": {
 							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup")},
 							Description: "The security group for the EKS cluster.",
@@ -235,15 +231,61 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 							TypeSpec:    schema.TypeSpec{Ref: "#/types/eks:index:CoreData"},
 							Description: "The EKS cluster and its dependencies.",
 						},
+						"clusterSecurityGroupId": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.",
+						},
+						"nodeSecurityGroupId": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.",
+						},
+						"clusterIngressRuleId": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.",
+						},
+						"defaultNodeGroupAsgName": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.",
+						},
+						"fargateProfileId": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.",
+						},
+						"fargateProfileStatus": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.",
+						},
+						"oidcProviderArn": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.",
+						},
+						"oidcProviderUrl": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "Issuer URL for the OpenID Connect identity provider of the EKS cluster.",
+						},
+						"oidcIssuer": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).\n\n" +
+								"This value can be used to associate kubernetes service accounts with IAM roles. For more information, see " +
+								"https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.",
+						},
 					},
 					Required: []string{
 						"kubeconfig",
 						"kubeconfigJson",
 						"awsProvider",
-						// "provider",
 						"instanceRoles",
 						"eksCluster",
 						"core",
+						"clusterSecurityGroupId",
+						"nodeSecurityGroupId",
+						"clusterIngressRuleId",
+						"defaultNodeGroupAsgName",
+						"fargateProfileId",
+						"fargateProfileStatus",
+						"oidcProviderArn",
+						"oidcProviderUrl",
+						"oidcIssuer",
 					},
 				},
 				InputProperties: map[string]schema.PropertySpec{

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -1077,9 +1077,17 @@
                     "$ref": "/aws/v6.18.2/schema.json#/provider",
                     "description": "The AWS resource provider."
                 },
+                "clusterIngressRuleId": {
+                    "type": "string",
+                    "description": "The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true."
+                },
                 "clusterSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the EKS cluster."
+                },
+                "clusterSecurityGroupId": {
+                    "type": "string",
+                    "description": "The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true."
                 },
                 "core": {
                     "$ref": "#/types/eks:index:CoreData",
@@ -1089,6 +1097,10 @@
                     "$ref": "#/types/eks:index:NodeGroupData",
                     "description": "The default Node Group configuration, or undefined if `skipDefaultNodeGroup` was specified."
                 },
+                "defaultNodeGroupAsgName": {
+                    "type": "string",
+                    "description": "The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true."
+                },
                 "eksCluster": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:eks%2Fcluster:Cluster",
                     "description": "The EKS cluster."
@@ -1096,6 +1108,14 @@
                 "eksClusterIngressRule": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access to cluster API server."
+                },
+                "fargateProfileId": {
+                    "type": "string",
+                    "description": "The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured."
+                },
+                "fargateProfileStatus": {
+                    "type": "string",
+                    "description": "The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured."
                 },
                 "instanceRoles": {
                     "type": "array",
@@ -1115,6 +1135,22 @@
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the cluster's nodes."
+                },
+                "nodeSecurityGroupId": {
+                    "type": "string",
+                    "description": "The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true."
+                },
+                "oidcIssuer": {
+                    "type": "string",
+                    "description": "The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).\n\nThis value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html."
+                },
+                "oidcProviderArn": {
+                    "type": "string",
+                    "description": "The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured."
+                },
+                "oidcProviderUrl": {
+                    "type": "string",
+                    "description": "Issuer URL for the OpenID Connect identity provider of the EKS cluster."
                 }
             },
             "required": [
@@ -1123,7 +1159,16 @@
                 "awsProvider",
                 "instanceRoles",
                 "eksCluster",
-                "core"
+                "core",
+                "clusterSecurityGroupId",
+                "nodeSecurityGroupId",
+                "clusterIngressRuleId",
+                "defaultNodeGroupAsgName",
+                "fargateProfileId",
+                "fargateProfileStatus",
+                "oidcProviderArn",
+                "oidcProviderUrl",
+                "oidcIssuer"
             ],
             "inputProperties": {
                 "accessEntries": {
@@ -2235,7 +2280,8 @@
                 {
                     "type": "eks:index:VpcCni"
                 }
-            ]
+            ],
+            "isComponent": true
         }
     },
     "functions": {

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -48,10 +48,22 @@ namespace Pulumi.Eks
         public Output<Pulumi.Aws.Provider> AwsProvider { get; private set; } = null!;
 
         /// <summary>
+        /// The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+        /// </summary>
+        [Output("clusterIngressRuleId")]
+        public Output<string> ClusterIngressRuleId { get; private set; } = null!;
+
+        /// <summary>
         /// The security group for the EKS cluster.
         /// </summary>
         [Output("clusterSecurityGroup")]
         public Output<Pulumi.Aws.Ec2.SecurityGroup?> ClusterSecurityGroup { get; private set; } = null!;
+
+        /// <summary>
+        /// The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+        /// </summary>
+        [Output("clusterSecurityGroupId")]
+        public Output<string> ClusterSecurityGroupId { get; private set; } = null!;
 
         /// <summary>
         /// The EKS cluster and its dependencies.
@@ -66,6 +78,12 @@ namespace Pulumi.Eks
         public Output<Outputs.NodeGroupData?> DefaultNodeGroup { get; private set; } = null!;
 
         /// <summary>
+        /// The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+        /// </summary>
+        [Output("defaultNodeGroupAsgName")]
+        public Output<string> DefaultNodeGroupAsgName { get; private set; } = null!;
+
+        /// <summary>
         /// The EKS cluster.
         /// </summary>
         [Output("eksCluster")]
@@ -76,6 +94,18 @@ namespace Pulumi.Eks
         /// </summary>
         [Output("eksClusterIngressRule")]
         public Output<Pulumi.Aws.Ec2.SecurityGroupRule?> EksClusterIngressRule { get; private set; } = null!;
+
+        /// <summary>
+        /// The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+        /// </summary>
+        [Output("fargateProfileId")]
+        public Output<string> FargateProfileId { get; private set; } = null!;
+
+        /// <summary>
+        /// The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+        /// </summary>
+        [Output("fargateProfileStatus")]
+        public Output<string> FargateProfileStatus { get; private set; } = null!;
 
         /// <summary>
         /// The service roles used by the EKS cluster. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`.
@@ -100,6 +130,32 @@ namespace Pulumi.Eks
         /// </summary>
         [Output("nodeSecurityGroup")]
         public Output<Pulumi.Aws.Ec2.SecurityGroup?> NodeSecurityGroup { get; private set; } = null!;
+
+        /// <summary>
+        /// The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+        /// </summary>
+        [Output("nodeSecurityGroupId")]
+        public Output<string> NodeSecurityGroupId { get; private set; } = null!;
+
+        /// <summary>
+        /// The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+        /// 
+        /// This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+        /// </summary>
+        [Output("oidcIssuer")]
+        public Output<string> OidcIssuer { get; private set; } = null!;
+
+        /// <summary>
+        /// The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+        /// </summary>
+        [Output("oidcProviderArn")]
+        public Output<string> OidcProviderArn { get; private set; } = null!;
+
+        /// <summary>
+        /// Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+        /// </summary>
+        [Output("oidcProviderUrl")]
+        public Output<string> OidcProviderUrl { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/dotnet/VpcCniAddon.cs
+++ b/sdk/dotnet/VpcCniAddon.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Eks
     /// For more information see: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
     /// </summary>
     [EksResourceType("eks:index:VpcCniAddon")]
-    public partial class VpcCniAddon : global::Pulumi.CustomResource
+    public partial class VpcCniAddon : global::Pulumi.ComponentResource
     {
         /// <summary>
         /// Create a VpcCniAddon resource with the given unique name, arguments, and options.
@@ -23,19 +23,14 @@ namespace Pulumi.Eks
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public VpcCniAddon(string name, VpcCniAddonArgs args, CustomResourceOptions? options = null)
-            : base("eks:index:VpcCniAddon", name, args ?? new VpcCniAddonArgs(), MakeResourceOptions(options, ""))
+        public VpcCniAddon(string name, VpcCniAddonArgs args, ComponentResourceOptions? options = null)
+            : base("eks:index:VpcCniAddon", name, args ?? new VpcCniAddonArgs(), MakeResourceOptions(options, ""), remote: true)
         {
         }
 
-        private VpcCniAddon(string name, Input<string> id, CustomResourceOptions? options = null)
-            : base("eks:index:VpcCniAddon", name, null, MakeResourceOptions(options, id))
+        private static ComponentResourceOptions MakeResourceOptions(ComponentResourceOptions? options, Input<string>? id)
         {
-        }
-
-        private static CustomResourceOptions MakeResourceOptions(CustomResourceOptions? options, Input<string>? id)
-        {
-            var defaultOptions = new CustomResourceOptions
+            var defaultOptions = new ComponentResourceOptions
             {
                 Version = Utilities.Version,
                 Aliases =
@@ -43,22 +38,10 @@ namespace Pulumi.Eks
                     new global::Pulumi.Alias { Type = "eks:index:VpcCni" },
                 },
             };
-            var merged = CustomResourceOptions.Merge(defaultOptions, options);
+            var merged = ComponentResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
             merged.Id = id ?? merged.Id;
             return merged;
-        }
-        /// <summary>
-        /// Get an existing VpcCniAddon resource's state with the given name, ID, and optional extra
-        /// properties used to qualify the lookup.
-        /// </summary>
-        ///
-        /// <param name="name">The unique name of the resulting resource.</param>
-        /// <param name="id">The unique provider ID of the resource to lookup.</param>
-        /// <param name="options">A bag of options that control this resource's behavior</param>
-        public static VpcCniAddon Get(string name, Input<string> id, CustomResourceOptions? options = null)
-        {
-            return new VpcCniAddon(name, id, options);
         }
     }
 

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -52,16 +52,26 @@ type Cluster struct {
 
 	// The AWS resource provider.
 	AwsProvider aws.ProviderOutput `pulumi:"awsProvider"`
+	// The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+	ClusterIngressRuleId pulumi.StringOutput `pulumi:"clusterIngressRuleId"`
 	// The security group for the EKS cluster.
 	ClusterSecurityGroup ec2.SecurityGroupOutput `pulumi:"clusterSecurityGroup"`
+	// The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+	ClusterSecurityGroupId pulumi.StringOutput `pulumi:"clusterSecurityGroupId"`
 	// The EKS cluster and its dependencies.
 	Core CoreDataOutput `pulumi:"core"`
 	// The default Node Group configuration, or undefined if `skipDefaultNodeGroup` was specified.
 	DefaultNodeGroup NodeGroupDataPtrOutput `pulumi:"defaultNodeGroup"`
+	// The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+	DefaultNodeGroupAsgName pulumi.StringOutput `pulumi:"defaultNodeGroupAsgName"`
 	// The EKS cluster.
 	EksCluster eks.ClusterOutput `pulumi:"eksCluster"`
 	// The ingress rule that gives node group access to cluster API server.
 	EksClusterIngressRule ec2.SecurityGroupRuleOutput `pulumi:"eksClusterIngressRule"`
+	// The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+	FargateProfileId pulumi.StringOutput `pulumi:"fargateProfileId"`
+	// The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+	FargateProfileStatus pulumi.StringOutput `pulumi:"fargateProfileStatus"`
 	// The service roles used by the EKS cluster. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`.
 	InstanceRoles iam.RoleArrayOutput `pulumi:"instanceRoles"`
 	// A kubeconfig that can be used to connect to the EKS cluster.
@@ -70,6 +80,16 @@ type Cluster struct {
 	KubeconfigJson pulumi.StringOutput `pulumi:"kubeconfigJson"`
 	// The security group for the cluster's nodes.
 	NodeSecurityGroup ec2.SecurityGroupOutput `pulumi:"nodeSecurityGroup"`
+	// The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+	NodeSecurityGroupId pulumi.StringOutput `pulumi:"nodeSecurityGroupId"`
+	// The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+	//
+	// This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+	OidcIssuer pulumi.StringOutput `pulumi:"oidcIssuer"`
+	// The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+	OidcProviderArn pulumi.StringOutput `pulumi:"oidcProviderArn"`
+	// Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+	OidcProviderUrl pulumi.StringOutput `pulumi:"oidcProviderUrl"`
 }
 
 // NewCluster registers a new resource with the given unique name, arguments, and options.
@@ -719,9 +739,19 @@ func (o ClusterOutput) AwsProvider() aws.ProviderOutput {
 	return o.ApplyT(func(v *Cluster) aws.ProviderOutput { return v.AwsProvider }).(aws.ProviderOutput)
 }
 
+// The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+func (o ClusterOutput) ClusterIngressRuleId() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.ClusterIngressRuleId }).(pulumi.StringOutput)
+}
+
 // The security group for the EKS cluster.
 func (o ClusterOutput) ClusterSecurityGroup() ec2.SecurityGroupOutput {
 	return o.ApplyT(func(v *Cluster) ec2.SecurityGroupOutput { return v.ClusterSecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+// The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+func (o ClusterOutput) ClusterSecurityGroupId() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.ClusterSecurityGroupId }).(pulumi.StringOutput)
 }
 
 // The EKS cluster and its dependencies.
@@ -734,6 +764,11 @@ func (o ClusterOutput) DefaultNodeGroup() NodeGroupDataPtrOutput {
 	return o.ApplyT(func(v *Cluster) NodeGroupDataPtrOutput { return v.DefaultNodeGroup }).(NodeGroupDataPtrOutput)
 }
 
+// The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+func (o ClusterOutput) DefaultNodeGroupAsgName() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.DefaultNodeGroupAsgName }).(pulumi.StringOutput)
+}
+
 // The EKS cluster.
 func (o ClusterOutput) EksCluster() eks.ClusterOutput {
 	return o.ApplyT(func(v *Cluster) eks.ClusterOutput { return v.EksCluster }).(eks.ClusterOutput)
@@ -742,6 +777,16 @@ func (o ClusterOutput) EksCluster() eks.ClusterOutput {
 // The ingress rule that gives node group access to cluster API server.
 func (o ClusterOutput) EksClusterIngressRule() ec2.SecurityGroupRuleOutput {
 	return o.ApplyT(func(v *Cluster) ec2.SecurityGroupRuleOutput { return v.EksClusterIngressRule }).(ec2.SecurityGroupRuleOutput)
+}
+
+// The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+func (o ClusterOutput) FargateProfileId() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.FargateProfileId }).(pulumi.StringOutput)
+}
+
+// The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+func (o ClusterOutput) FargateProfileStatus() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.FargateProfileStatus }).(pulumi.StringOutput)
 }
 
 // The service roles used by the EKS cluster. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`.
@@ -762,6 +807,28 @@ func (o ClusterOutput) KubeconfigJson() pulumi.StringOutput {
 // The security group for the cluster's nodes.
 func (o ClusterOutput) NodeSecurityGroup() ec2.SecurityGroupOutput {
 	return o.ApplyT(func(v *Cluster) ec2.SecurityGroupOutput { return v.NodeSecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+// The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+func (o ClusterOutput) NodeSecurityGroupId() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.NodeSecurityGroupId }).(pulumi.StringOutput)
+}
+
+// The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+//
+// This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+func (o ClusterOutput) OidcIssuer() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.OidcIssuer }).(pulumi.StringOutput)
+}
+
+// The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+func (o ClusterOutput) OidcProviderArn() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.OidcProviderArn }).(pulumi.StringOutput)
+}
+
+// Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+func (o ClusterOutput) OidcProviderUrl() pulumi.StringOutput {
+	return o.ApplyT(func(v *Cluster) pulumi.StringOutput { return v.OidcProviderUrl }).(pulumi.StringOutput)
 }
 
 type ClusterArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/eks/vpcCniAddon.go
+++ b/sdk/go/eks/vpcCniAddon.go
@@ -15,7 +15,7 @@ import (
 // VpcCniAddon manages the configuration of the Amazon VPC CNI plugin for Kubernetes by leveraging the EKS managed add-on.
 // For more information see: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
 type VpcCniAddon struct {
-	pulumi.CustomResourceState
+	pulumi.ResourceState
 }
 
 // NewVpcCniAddon registers a new resource with the given unique name, arguments, and options.
@@ -44,34 +44,11 @@ func NewVpcCniAddon(ctx *pulumi.Context,
 	opts = append(opts, aliases)
 	opts = utilities.PkgResourceDefaultOpts(opts)
 	var resource VpcCniAddon
-	err := ctx.RegisterResource("eks:index:VpcCniAddon", name, args, &resource, opts...)
+	err := ctx.RegisterRemoteComponentResource("eks:index:VpcCniAddon", name, args, &resource, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return &resource, nil
-}
-
-// GetVpcCniAddon gets an existing VpcCniAddon resource's state with the given name, ID, and optional
-// state properties that are used to uniquely qualify the lookup (nil if not required).
-func GetVpcCniAddon(ctx *pulumi.Context,
-	name string, id pulumi.IDInput, state *VpcCniAddonState, opts ...pulumi.ResourceOption) (*VpcCniAddon, error) {
-	var resource VpcCniAddon
-	err := ctx.ReadResource("eks:index:VpcCniAddon", name, id, state, &resource, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &resource, nil
-}
-
-// Input properties used for looking up and filtering VpcCniAddon resources.
-type vpcCniAddonState struct {
-}
-
-type VpcCniAddonState struct {
-}
-
-func (VpcCniAddonState) ElementType() reflect.Type {
-	return reflect.TypeOf((*vpcCniAddonState)(nil)).Elem()
 }
 
 type vpcCniAddonArgs struct {

--- a/sdk/java/src/main/java/com/pulumi/eks/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/Cluster.java
@@ -78,6 +78,20 @@ public class Cluster extends com.pulumi.resources.ComponentResource {
         return this.awsProvider;
     }
     /**
+     * The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+     * 
+     */
+    @Export(name="clusterIngressRuleId", refs={String.class}, tree="[0]")
+    private Output<String> clusterIngressRuleId;
+
+    /**
+     * @return The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+     * 
+     */
+    public Output<String> clusterIngressRuleId() {
+        return this.clusterIngressRuleId;
+    }
+    /**
      * The security group for the EKS cluster.
      * 
      */
@@ -90,6 +104,20 @@ public class Cluster extends com.pulumi.resources.ComponentResource {
      */
     public Output<Optional<SecurityGroup>> clusterSecurityGroup() {
         return Codegen.optional(this.clusterSecurityGroup);
+    }
+    /**
+     * The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+     * 
+     */
+    @Export(name="clusterSecurityGroupId", refs={String.class}, tree="[0]")
+    private Output<String> clusterSecurityGroupId;
+
+    /**
+     * @return The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+     * 
+     */
+    public Output<String> clusterSecurityGroupId() {
+        return this.clusterSecurityGroupId;
     }
     /**
      * The EKS cluster and its dependencies.
@@ -120,6 +148,20 @@ public class Cluster extends com.pulumi.resources.ComponentResource {
         return Codegen.optional(this.defaultNodeGroup);
     }
     /**
+     * The name of the default node group&#39;s AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+     * 
+     */
+    @Export(name="defaultNodeGroupAsgName", refs={String.class}, tree="[0]")
+    private Output<String> defaultNodeGroupAsgName;
+
+    /**
+     * @return The name of the default node group&#39;s AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+     * 
+     */
+    public Output<String> defaultNodeGroupAsgName() {
+        return this.defaultNodeGroupAsgName;
+    }
+    /**
      * The EKS cluster.
      * 
      */
@@ -146,6 +188,34 @@ public class Cluster extends com.pulumi.resources.ComponentResource {
      */
     public Output<Optional<SecurityGroupRule>> eksClusterIngressRule() {
         return Codegen.optional(this.eksClusterIngressRule);
+    }
+    /**
+     * The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+     * 
+     */
+    @Export(name="fargateProfileId", refs={String.class}, tree="[0]")
+    private Output<String> fargateProfileId;
+
+    /**
+     * @return The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+     * 
+     */
+    public Output<String> fargateProfileId() {
+        return this.fargateProfileId;
+    }
+    /**
+     * The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+     * 
+     */
+    @Export(name="fargateProfileStatus", refs={String.class}, tree="[0]")
+    private Output<String> fargateProfileStatus;
+
+    /**
+     * @return The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+     * 
+     */
+    public Output<String> fargateProfileStatus() {
+        return this.fargateProfileStatus;
     }
     /**
      * The service roles used by the EKS cluster. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`.
@@ -202,6 +272,66 @@ public class Cluster extends com.pulumi.resources.ComponentResource {
      */
     public Output<Optional<SecurityGroup>> nodeSecurityGroup() {
         return Codegen.optional(this.nodeSecurityGroup);
+    }
+    /**
+     * The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+     * 
+     */
+    @Export(name="nodeSecurityGroupId", refs={String.class}, tree="[0]")
+    private Output<String> nodeSecurityGroupId;
+
+    /**
+     * @return The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+     * 
+     */
+    public Output<String> nodeSecurityGroupId() {
+        return this.nodeSecurityGroupId;
+    }
+    /**
+     * The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+     * 
+     * This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+     * 
+     */
+    @Export(name="oidcIssuer", refs={String.class}, tree="[0]")
+    private Output<String> oidcIssuer;
+
+    /**
+     * @return The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+     * 
+     * This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+     * 
+     */
+    public Output<String> oidcIssuer() {
+        return this.oidcIssuer;
+    }
+    /**
+     * The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+     * 
+     */
+    @Export(name="oidcProviderArn", refs={String.class}, tree="[0]")
+    private Output<String> oidcProviderArn;
+
+    /**
+     * @return The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+     * 
+     */
+    public Output<String> oidcProviderArn() {
+        return this.oidcProviderArn;
+    }
+    /**
+     * Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+     * 
+     */
+    @Export(name="oidcProviderUrl", refs={String.class}, tree="[0]")
+    private Output<String> oidcProviderUrl;
+
+    /**
+     * @return Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+     * 
+     */
+    public Output<String> oidcProviderUrl() {
+        return this.oidcProviderUrl;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/eks/VpcCniAddon.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/VpcCniAddon.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  * 
  */
 @ResourceType(type="eks:index:VpcCniAddon")
-public class VpcCniAddon extends com.pulumi.resources.CustomResource {
+public class VpcCniAddon extends com.pulumi.resources.ComponentResource {
     /**
      *
      * @param name The _unique_ name of the resulting resource.
@@ -40,40 +40,25 @@ public class VpcCniAddon extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public VpcCniAddon(java.lang.String name, VpcCniAddonArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
-        super("eks:index:VpcCniAddon", name, makeArgs(args, options), makeResourceOptions(options, Codegen.empty()), false);
+    public VpcCniAddon(java.lang.String name, VpcCniAddonArgs args, @Nullable com.pulumi.resources.ComponentResourceOptions options) {
+        super("eks:index:VpcCniAddon", name, makeArgs(args, options), makeResourceOptions(options, Codegen.empty()), true);
     }
 
-    private VpcCniAddon(java.lang.String name, Output<java.lang.String> id, @Nullable com.pulumi.resources.CustomResourceOptions options) {
-        super("eks:index:VpcCniAddon", name, null, makeResourceOptions(options, id), false);
-    }
-
-    private static VpcCniAddonArgs makeArgs(VpcCniAddonArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    private static VpcCniAddonArgs makeArgs(VpcCniAddonArgs args, @Nullable com.pulumi.resources.ComponentResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }
         return args == null ? VpcCniAddonArgs.Empty : args;
     }
 
-    private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
-        var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
+    private static com.pulumi.resources.ComponentResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.ComponentResourceOptions options, @Nullable Output<java.lang.String> id) {
+        var defaultOptions = com.pulumi.resources.ComponentResourceOptions.builder()
             .version(Utilities.getVersion())
             .aliases(List.of(
                 Output.of(Alias.builder().type("eks:index:VpcCni").build())
             ))
             .build();
-        return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
+        return com.pulumi.resources.ComponentResourceOptions.merge(defaultOptions, options, id);
     }
 
-    /**
-     * Get an existing Host resource's state with the given name, ID, and optional extra
-     * properties used to qualify the lookup.
-     *
-     * @param name The _unique_ name of the resulting resource.
-     * @param id The _unique_ provider ID of the resource to lookup.
-     * @param options Optional settings to control the behavior of the CustomResource.
-     */
-    public static VpcCniAddon get(java.lang.String name, Output<java.lang.String> id, @Nullable com.pulumi.resources.CustomResourceOptions options) {
-        return new VpcCniAddon(name, id, options);
-    }
 }

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -52,9 +52,17 @@ export class Cluster extends pulumi.ComponentResource {
      */
     public /*out*/ readonly awsProvider!: pulumi.Output<pulumiAws.Provider>;
     /**
+     * The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+     */
+    public /*out*/ readonly clusterIngressRuleId!: pulumi.Output<string>;
+    /**
      * The security group for the EKS cluster.
      */
     public readonly clusterSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup | undefined>;
+    /**
+     * The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+     */
+    public /*out*/ readonly clusterSecurityGroupId!: pulumi.Output<string>;
     /**
      * The EKS cluster and its dependencies.
      */
@@ -64,6 +72,10 @@ export class Cluster extends pulumi.ComponentResource {
      */
     public /*out*/ readonly defaultNodeGroup!: pulumi.Output<outputs.NodeGroupData | undefined>;
     /**
+     * The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+     */
+    public /*out*/ readonly defaultNodeGroupAsgName!: pulumi.Output<string>;
+    /**
      * The EKS cluster.
      */
     public /*out*/ readonly eksCluster!: pulumi.Output<pulumiAws.eks.Cluster>;
@@ -71,6 +83,14 @@ export class Cluster extends pulumi.ComponentResource {
      * The ingress rule that gives node group access to cluster API server.
      */
     public /*out*/ readonly eksClusterIngressRule!: pulumi.Output<pulumiAws.ec2.SecurityGroupRule | undefined>;
+    /**
+     * The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+     */
+    public /*out*/ readonly fargateProfileId!: pulumi.Output<string>;
+    /**
+     * The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+     */
+    public /*out*/ readonly fargateProfileStatus!: pulumi.Output<string>;
     /**
      * The service roles used by the EKS cluster. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`.
      */
@@ -87,6 +107,24 @@ export class Cluster extends pulumi.ComponentResource {
      * The security group for the cluster's nodes.
      */
     public /*out*/ readonly nodeSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup | undefined>;
+    /**
+     * The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+     */
+    public /*out*/ readonly nodeSecurityGroupId!: pulumi.Output<string>;
+    /**
+     * The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+     *
+     * This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+     */
+    public /*out*/ readonly oidcIssuer!: pulumi.Output<string>;
+    /**
+     * The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+     */
+    public /*out*/ readonly oidcProviderArn!: pulumi.Output<string>;
+    /**
+     * Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+     */
+    public /*out*/ readonly oidcProviderUrl!: pulumi.Output<string>;
 
     /**
      * Create a Cluster resource with the given unique name, arguments, and options.
@@ -153,24 +191,42 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["vpcCniOptions"] = args ? (args.vpcCniOptions ? inputs.vpcCniOptionsArgsProvideDefaults(args.vpcCniOptions) : undefined) : undefined;
             resourceInputs["vpcId"] = args ? args.vpcId : undefined;
             resourceInputs["awsProvider"] = undefined /*out*/;
+            resourceInputs["clusterIngressRuleId"] = undefined /*out*/;
+            resourceInputs["clusterSecurityGroupId"] = undefined /*out*/;
             resourceInputs["core"] = undefined /*out*/;
             resourceInputs["defaultNodeGroup"] = undefined /*out*/;
+            resourceInputs["defaultNodeGroupAsgName"] = undefined /*out*/;
             resourceInputs["eksCluster"] = undefined /*out*/;
             resourceInputs["eksClusterIngressRule"] = undefined /*out*/;
+            resourceInputs["fargateProfileId"] = undefined /*out*/;
+            resourceInputs["fargateProfileStatus"] = undefined /*out*/;
             resourceInputs["kubeconfig"] = undefined /*out*/;
             resourceInputs["kubeconfigJson"] = undefined /*out*/;
             resourceInputs["nodeSecurityGroup"] = undefined /*out*/;
+            resourceInputs["nodeSecurityGroupId"] = undefined /*out*/;
+            resourceInputs["oidcIssuer"] = undefined /*out*/;
+            resourceInputs["oidcProviderArn"] = undefined /*out*/;
+            resourceInputs["oidcProviderUrl"] = undefined /*out*/;
         } else {
             resourceInputs["awsProvider"] = undefined /*out*/;
+            resourceInputs["clusterIngressRuleId"] = undefined /*out*/;
             resourceInputs["clusterSecurityGroup"] = undefined /*out*/;
+            resourceInputs["clusterSecurityGroupId"] = undefined /*out*/;
             resourceInputs["core"] = undefined /*out*/;
             resourceInputs["defaultNodeGroup"] = undefined /*out*/;
+            resourceInputs["defaultNodeGroupAsgName"] = undefined /*out*/;
             resourceInputs["eksCluster"] = undefined /*out*/;
             resourceInputs["eksClusterIngressRule"] = undefined /*out*/;
+            resourceInputs["fargateProfileId"] = undefined /*out*/;
+            resourceInputs["fargateProfileStatus"] = undefined /*out*/;
             resourceInputs["instanceRoles"] = undefined /*out*/;
             resourceInputs["kubeconfig"] = undefined /*out*/;
             resourceInputs["kubeconfigJson"] = undefined /*out*/;
             resourceInputs["nodeSecurityGroup"] = undefined /*out*/;
+            resourceInputs["nodeSecurityGroupId"] = undefined /*out*/;
+            resourceInputs["oidcIssuer"] = undefined /*out*/;
+            resourceInputs["oidcProviderArn"] = undefined /*out*/;
+            resourceInputs["oidcProviderUrl"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Cluster.__pulumiType, name, resourceInputs, opts, true /*remote*/);

--- a/sdk/nodejs/vpcCniAddon.ts
+++ b/sdk/nodejs/vpcCniAddon.ts
@@ -11,19 +11,7 @@ import * as utilities from "./utilities";
  * VpcCniAddon manages the configuration of the Amazon VPC CNI plugin for Kubernetes by leveraging the EKS managed add-on.
  * For more information see: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
  */
-export class VpcCniAddon extends pulumi.CustomResource {
-    /**
-     * Get an existing VpcCniAddon resource's state with the given name, ID, and optional extra
-     * properties used to qualify the lookup.
-     *
-     * @param name The _unique_ name of the resulting resource.
-     * @param id The _unique_ provider ID of the resource to lookup.
-     * @param opts Optional settings to control the behavior of the CustomResource.
-     */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): VpcCniAddon {
-        return new VpcCniAddon(name, undefined as any, { ...opts, id: id });
-    }
-
+export class VpcCniAddon extends pulumi.ComponentResource {
     /** @internal */
     public static readonly __pulumiType = 'eks:index:VpcCniAddon';
 
@@ -46,7 +34,7 @@ export class VpcCniAddon extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: VpcCniAddonArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: VpcCniAddonArgs, opts?: pulumi.ComponentResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
@@ -85,7 +73,7 @@ export class VpcCniAddon extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const aliasOpts = { aliases: [{ type: "eks:index:VpcCni" }] };
         opts = pulumi.mergeOptions(opts, aliasOpts);
-        super(VpcCniAddon.__pulumiType, name, resourceInputs, opts);
+        super(VpcCniAddon.__pulumiType, name, resourceInputs, opts, true /*remote*/);
     }
 }
 

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -1552,13 +1552,22 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["vpc_cni_options"] = vpc_cni_options
             __props__.__dict__["vpc_id"] = vpc_id
             __props__.__dict__["aws_provider"] = None
+            __props__.__dict__["cluster_ingress_rule_id"] = None
+            __props__.__dict__["cluster_security_group_id"] = None
             __props__.__dict__["core"] = None
             __props__.__dict__["default_node_group"] = None
+            __props__.__dict__["default_node_group_asg_name"] = None
             __props__.__dict__["eks_cluster"] = None
             __props__.__dict__["eks_cluster_ingress_rule"] = None
+            __props__.__dict__["fargate_profile_id"] = None
+            __props__.__dict__["fargate_profile_status"] = None
             __props__.__dict__["kubeconfig"] = None
             __props__.__dict__["kubeconfig_json"] = None
             __props__.__dict__["node_security_group"] = None
+            __props__.__dict__["node_security_group_id"] = None
+            __props__.__dict__["oidc_issuer"] = None
+            __props__.__dict__["oidc_provider_arn"] = None
+            __props__.__dict__["oidc_provider_url"] = None
         super(Cluster, __self__).__init__(
             'eks:index:Cluster',
             resource_name,
@@ -1575,12 +1584,28 @@ class Cluster(pulumi.ComponentResource):
         return pulumi.get(self, "aws_provider")
 
     @property
+    @pulumi.getter(name="clusterIngressRuleId")
+    def cluster_ingress_rule_id(self) -> pulumi.Output[str]:
+        """
+        The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true.
+        """
+        return pulumi.get(self, "cluster_ingress_rule_id")
+
+    @property
     @pulumi.getter(name="clusterSecurityGroup")
     def cluster_security_group(self) -> pulumi.Output[Optional['pulumi_aws.ec2.SecurityGroup']]:
         """
         The security group for the EKS cluster.
         """
         return pulumi.get(self, "cluster_security_group")
+
+    @property
+    @pulumi.getter(name="clusterSecurityGroupId")
+    def cluster_security_group_id(self) -> pulumi.Output[str]:
+        """
+        The cluster security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+        """
+        return pulumi.get(self, "cluster_security_group_id")
 
     @property
     @pulumi.getter
@@ -1599,6 +1624,14 @@ class Cluster(pulumi.ComponentResource):
         return pulumi.get(self, "default_node_group")
 
     @property
+    @pulumi.getter(name="defaultNodeGroupAsgName")
+    def default_node_group_asg_name(self) -> pulumi.Output[str]:
+        """
+        The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true.
+        """
+        return pulumi.get(self, "default_node_group_asg_name")
+
+    @property
     @pulumi.getter(name="eksCluster")
     def eks_cluster(self) -> pulumi.Output['pulumi_aws.eks.Cluster']:
         """
@@ -1613,6 +1646,22 @@ class Cluster(pulumi.ComponentResource):
         The ingress rule that gives node group access to cluster API server.
         """
         return pulumi.get(self, "eks_cluster_ingress_rule")
+
+    @property
+    @pulumi.getter(name="fargateProfileId")
+    def fargate_profile_id(self) -> pulumi.Output[str]:
+        """
+        The ID of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+        """
+        return pulumi.get(self, "fargate_profile_id")
+
+    @property
+    @pulumi.getter(name="fargateProfileStatus")
+    def fargate_profile_status(self) -> pulumi.Output[str]:
+        """
+        The status of the Fargate Profile. Defaults to an empty string if no Fargate profile is configured.
+        """
+        return pulumi.get(self, "fargate_profile_status")
 
     @property
     @pulumi.getter(name="instanceRoles")
@@ -1645,6 +1694,40 @@ class Cluster(pulumi.ComponentResource):
         The security group for the cluster's nodes.
         """
         return pulumi.get(self, "node_security_group")
+
+    @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> pulumi.Output[str]:
+        """
+        The node security group ID of the EKS cluster. Returns the EKS created security group if `skipDefaultSecurityGroups` is set to true.
+        """
+        return pulumi.get(self, "node_security_group_id")
+
+    @property
+    @pulumi.getter(name="oidcIssuer")
+    def oidc_issuer(self) -> pulumi.Output[str]:
+        """
+        The OIDC Issuer of the EKS cluster (OIDC Provider URL without leading `https://`).
+
+        This value can be used to associate kubernetes service accounts with IAM roles. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+        """
+        return pulumi.get(self, "oidc_issuer")
+
+    @property
+    @pulumi.getter(name="oidcProviderArn")
+    def oidc_provider_arn(self) -> pulumi.Output[str]:
+        """
+        The ARN of the IAM OpenID Connect Provider for the EKS cluster. Defaults to an empty string if no OIDC provider is configured.
+        """
+        return pulumi.get(self, "oidc_provider_arn")
+
+    @property
+    @pulumi.getter(name="oidcProviderUrl")
+    def oidc_provider_url(self) -> pulumi.Output[str]:
+        """
+        Issuer URL for the OpenID Connect identity provider of the EKS cluster.
+        """
+        return pulumi.get(self, "oidc_provider_url")
 
     @pulumi.output_type
     class GetKubeconfigResult:

--- a/sdk/python/pulumi_eks/vpc_cni_addon.py
+++ b/sdk/python/pulumi_eks/vpc_cni_addon.py
@@ -516,7 +516,7 @@ class VpcCniAddonArgs:
         pulumi.set(self, "warm_prefix_target", value)
 
 
-class VpcCniAddon(pulumi.CustomResource):
+class VpcCniAddon(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
@@ -667,7 +667,9 @@ class VpcCniAddon(pulumi.CustomResource):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
             raise TypeError('Expected resource options to be a ResourceOptions instance')
-        if opts.id is None:
+        if opts.id is not None:
+            raise ValueError('ComponentResource classes do not support opts.id')
+        else:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = VpcCniAddonArgs.__new__(VpcCniAddonArgs)
@@ -711,23 +713,6 @@ class VpcCniAddon(pulumi.CustomResource):
             'eks:index:VpcCniAddon',
             resource_name,
             __props__,
-            opts)
-
-    @staticmethod
-    def get(resource_name: str,
-            id: pulumi.Input[str],
-            opts: Optional[pulumi.ResourceOptions] = None) -> 'VpcCniAddon':
-        """
-        Get an existing VpcCniAddon resource's state with the given name, id, and optional extra
-        properties used to qualify the lookup.
-
-        :param str resource_name: The unique name of the resulting resource.
-        :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
-        :param pulumi.ResourceOptions opts: Options for the resource.
-        """
-        opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
-
-        __props__ = VpcCniAddonArgs.__new__(VpcCniAddonArgs)
-
-        return VpcCniAddon(resource_name, opts=opts, __props__=__props__)
+            opts,
+            remote=True)
 


### PR DESCRIPTION
To ease the impact of the breaking API changes caused by generating the node SDK, we decided to add additional scalar inputs that simplify UX across all SDKs (for more details [see internal doc](https://docs.google.com/document/d/1f97nmDUG_nrZSllYxu_XSeI7ON8vhZzfVrdBTQQmZzw/edit#heading=h.fbweiu8gc5bw)).

This change adds the scalar properties mentioned in the doc and adds acceptance tests for them.
While adding the acceptance tests I noticed that running pods on Fargate doesn't work deterministically. In some cases the cluster fails to get healthy (coredns stuck in pending).
This was caused by a race-condition between coredns starting and the fargate profile being created. If the fargate profile deployed after coredns, the pods got stuck in pending because they got assigned to the `default-scheduler` instead of the `fargate-scheduler`.
The fix is relatively easy; making coredns depend on the fargate profile.

I'll separately update the migration guide.

### New properties

| Existing Resource |  | New Top Level Property | Description |
| :---- | :---- | :---- | :---- |
| `clusterSecurityGroup: Output<aws.ec2.SecurityGroup \| undefined>` |  | `clusterSecurityGroupId: Output<string>` | Only really useful property of a security group. Used to add additional ingress/egress rules. Default to `the EKS created security group id` |
| `nodeSecurityGroup: Output<aws.ec2.SecurityGroup \| undefined>` |  | `nodeSecurityGroupId: Output<string>` |  |
| `eksClusterIngressRule: Output<aws.ec2.SecurityGroupRule \| undefined>` |  | `clusterIngressRuleId: Output<string>` | Only really useful property of a rule. Default to `””` |
| `defaultNodeGroup: Output<eks.NodeGroupData \| undefined>` |  | `defaultNodeGroupAsgName: Output<string>` | The only useful property of the default node group is the auto scaling group. Exposing its name allows users to reference it in IAM roles, tags, etc. Default to `””` |
| `core` | `fargateProfile: Output<aws.eks.FargateProfile \| undefined>` | `fargateProfileId: Output<string>` | The id of the fargate profile. Can be used to reference it. Default to `””` |
|  |  | `fargateProfileStatus: Output<string>` | The status of the fargate profile. Default to `””` |
|  | `oidcProvider: Output<aws.iam.OpenIdConnectProvider \| undefined>` | `oidcProviderArn: Output<string>` & `oidcProviderUrl: Output<string>` & `oidcIssuer: Output<string` | Arn and Url are properties needed to set up IAM identities for pods (required for the assume role policy of the IAM role). Users currently need to trim the `https://` part of the url to actually use it. We should expose `oidcProvider` with that already done to ease usage. |


Fixes https://github.com/pulumi/pulumi-eks/issues/1041