### PR TITLE
Allow passing scalar security group properties to node groups

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -923,6 +923,23 @@ func TestAccSelfManagedNodeGroupOS(t *testing.T) {
 
 				assert.NoError(t, utils.ValidateNodePodCapacity(t, info.Outputs["kubeconfig"], 4, 100, "increased-pod-capacity"))
 				assert.NoError(t, utils.ValidateNodeStorage(t, info.Outputs["kubeconfig"], 4, 100*1_000_000_000, "increased-storage-capacity"))
+
+				// Validate that nodeSecurityGroupId is set to the security group passed in as an input
+				require.NotNil(t, info.Outputs["standardNodeSecurityGroup"])
+				require.NotNil(t, info.Outputs["standardNodeSecurityGroupV2"])
+				standardSecurityGroup := info.Outputs["standardNodeSecurityGroup"].(map[string]interface{})
+				standardSecurityGroupV2 := info.Outputs["standardNodeSecurityGroupV2"].(map[string]interface{})
+				assert.Equal(t, standardSecurityGroup["id"], info.Outputs["standardNodeSecurityGroupId"])
+				assert.Equal(t, standardSecurityGroupV2["id"], info.Outputs["standardNodeSecurityGroupIdV2"])
+
+				// Validate that the nodeSecurityGroupId is set to security group ID passed in as an input
+				assert.Nil(t, info.Outputs["customNodeSecurityGroup"])
+				assert.Nil(t, info.Outputs["customNodeSecurityGroupV2"])
+				require.NotEmpty(t, info.Outputs["clusterNodeSecurityGroupId"])
+				clusterNodeGroupId := info.Outputs["clusterNodeSecurityGroupId"].(string)
+
+				assert.Equal(t, clusterNodeGroupId, info.Outputs["customNodeSecurityGroupId"])
+				assert.Equal(t, clusterNodeGroupId, info.Outputs["customNodeSecurityGroupIdV2"])
 			},
 		})
 

--- a/examples/tests/migrate-nodegroups/utils.ts
+++ b/examples/tests/migrate-nodegroups/utils.ts
@@ -16,8 +16,8 @@ export function createNodeGroup(
 ): eks.NodeGroup {
     return new eks.NodeGroup(name, {
         cluster: args.cluster,
-        nodeSecurityGroup: args.cluster.nodeSecurityGroup.apply(v => v!),
-        clusterIngressRule: args.cluster.eksClusterIngressRule.apply(v => v!),
+        nodeSecurityGroupId: args.cluster.nodeSecurityGroupId,
+        clusterIngressRuleId: args.cluster.clusterIngressRuleId,
         instanceType: args.instanceType,
         nodeAssociatePublicIpAddress: false,
         desiredCapacity: args.desiredCapacity,

--- a/examples/tests/self-managed-ng-os/index.ts
+++ b/examples/tests/self-managed-ng-os/index.ts
@@ -186,3 +186,32 @@ const nodeGroupBottlerocketUserdata = new eks.NodeGroupV2("bottlerocket-userdata
     },
   },
 });
+
+const nodegroupWithSecurityGroupId = new eks.NodeGroup("ng-security-group-id", {
+  ...capacity,
+  cluster: cluster,
+  instanceType: "t3.medium",
+  instanceProfile: instanceProfile,
+  nodeSecurityGroupId: cluster.nodeSecurityGroupId,
+  clusterIngressRuleId: cluster.clusterIngressRuleId,
+});
+
+const nodegroupV2WithSecurityGroupId = new eks.NodeGroupV2("ng-security-group-id", {
+  ...capacity,
+  cluster: cluster,
+  instanceType: "t3.medium",
+  instanceProfile: instanceProfile,
+  nodeSecurityGroupId: cluster.nodeSecurityGroupId,
+  clusterIngressRuleId: cluster.clusterIngressRuleId,
+});
+
+export const standardNodeSecurityGroup = nodeGroupAL2023V1.nodeSecurityGroup;
+export const standardNodeSecurityGroupId = nodeGroupAL2023V1.nodeSecurityGroupId;
+export const standardNodeSecurityGroupV2 = nodeGroupAL2023.nodeSecurityGroup;
+export const standardNodeSecurityGroupIdV2 = nodeGroupAL2023.nodeSecurityGroupId;
+
+export const clusterNodeSecurityGroupId = cluster.nodeSecurityGroupId;
+export const customNodeSecurityGroup = nodegroupWithSecurityGroupId.nodeSecurityGroup;
+export const customNodeSecurityGroupId = nodegroupWithSecurityGroupId.nodeSecurityGroupId;
+export const customNodeSecurityGroupV2 = nodegroupV2WithSecurityGroupId.nodeSecurityGroup;
+export const customNodeSecurityGroupIdV2 = nodegroupV2WithSecurityGroupId.nodeSecurityGroupId;

--- a/nodejs/eks/cmd/provider/nodegroup.ts
+++ b/nodejs/eks/cmd/provider/nodegroup.ts
@@ -28,6 +28,7 @@ const nodeGroupProvider: pulumi.provider.Provider = {
                 urn: nodegroup.urn,
                 state: {
                     nodeSecurityGroup: nodegroup.nodeSecurityGroup,
+                    nodeSecurityGroupId: nodegroup.nodeSecurityGroupId,
                     extraNodeSecurityGroups: nodegroup.extraNodeSecurityGroups,
                     cfnStack: nodegroup.cfnStack,
                     autoScalingGroupName: nodegroup.autoScalingGroupName,
@@ -85,6 +86,7 @@ const nodeGroupV2Provider: pulumi.provider.Provider = {
                 urn: nodegroup.urn,
                 state: {
                     nodeSecurityGroup: nodegroup.nodeSecurityGroup,
+                    nodeSecurityGroupId: nodegroup.nodeSecurityGroupId,
                     extraNodeSecurityGroups: nodegroup.extraNodeSecurityGroups,
                     autoScalingGroup: nodegroup.autoScalingGroup,
                 },

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -983,7 +983,7 @@ function createNodeGroupInternal(
             // ingress rule is applied.
             securityGroups: pulumi
                 .all([nodeSecurityGroupId, extraNodeSecurityGroupIds, eksClusterIngressRuleId])
-                .apply(([sg, extraSG, ingress]) => [sg, ...extraSG]),
+                .apply(([sg, extraSG, _]) => [sg, ...extraSG]),
             spotPrice: args.spotPrice,
             rootBlockDevice,
             ebsBlockDevices,
@@ -1475,7 +1475,7 @@ function createNodeGroupV2Internal(
                             extraNodeSecurityGroupIds,
                             eksClusterIngressRuleId,
                         ])
-                        .apply(([sg, extraSG, ingress]) => [sg, ...extraSG]),
+                        .apply(([sg, extraSG, _]) => [sg, ...extraSG]),
                 },
             ],
             metadataOptions: args.metadataOptions,

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -102,11 +102,13 @@ export interface NodeGroupBaseOptions {
      * `nodeSecurityGroupTags` are mutually exclusive.
      */
     nodeSecurityGroup?: aws.ec2.SecurityGroup;
+    nodeSecurityGroupId?: pulumi.Input<string>;
 
     /**
      * The ingress rule that gives node group access.
      */
     clusterIngressRule?: aws.ec2.SecurityGroupRule;
+    clusterIngressRuleId?: pulumi.Input<string>;
 
     /**
      * Extra security groups to attach on all nodes in this worker node group.
@@ -407,7 +409,8 @@ export interface NodeGroupData {
     /**
      * The security group for the node group to communicate with the cluster.
      */
-    nodeSecurityGroup: aws.ec2.SecurityGroup;
+    nodeSecurityGroup: aws.ec2.SecurityGroup | undefined;
+    nodeSecurityGroupId: pulumi.Output<string>;
     /**
      * The CloudFormation Stack which defines the node group's AutoScalingGroup.
      */
@@ -426,7 +429,8 @@ export interface NodeGroupV2Data {
     /**
      * The security group for the node group to communicate with the cluster.
      */
-    nodeSecurityGroup: aws.ec2.SecurityGroup;
+    nodeSecurityGroup: aws.ec2.SecurityGroup | undefined;
+    nodeSecurityGroupId: pulumi.Output<string>;
     /**
      * The AutoScalingGroup name for the node group.
      */
@@ -444,7 +448,8 @@ export class NodeGroup extends pulumi.ComponentResource implements NodeGroupData
     /**
      * The security group for the node group to communicate with the cluster.
      */
-    public readonly nodeSecurityGroup: aws.ec2.SecurityGroup;
+    public readonly nodeSecurityGroup: aws.ec2.SecurityGroup | undefined;
+    public readonly nodeSecurityGroupId: pulumi.Output<string>;
     /**
      * The additional security groups for the node group that captures user-specific rules.
      */
@@ -473,6 +478,7 @@ export class NodeGroup extends pulumi.ComponentResource implements NodeGroupData
 
         const group = createNodeGroup(name, args, this, opts?.provider);
         this.nodeSecurityGroup = group.nodeSecurityGroup;
+        this.nodeSecurityGroupId = group.nodeSecurityGroupId;
         this.cfnStack = group.cfnStack;
         this.autoScalingGroupName = group.autoScalingGroupName;
         this.registerOutputs(undefined);
@@ -490,7 +496,8 @@ export class NodeGroupInternal extends pulumi.ComponentResource {
     public readonly autoScalingGroupName!: pulumi.Output<string>;
     public readonly cfnStack!: pulumi.Output<aws.cloudformation.Stack>;
     public readonly extraNodeSecurityGroups!: pulumi.Output<aws.ec2.SecurityGroup[]>;
-    public readonly nodeSecurityGroup!: pulumi.Output<aws.ec2.SecurityGroup>;
+    public readonly nodeSecurityGroup!: pulumi.Output<aws.ec2.SecurityGroup | undefined>;
+    public readonly nodeSecurityGroupId!: pulumi.Output<string>;
 
     constructor(name: string, args: NodeGroupInternalArgs, opts?: pulumi.ComponentResourceOptions) {
         const type = "eks:index:NodeGroup";
@@ -501,6 +508,7 @@ export class NodeGroupInternal extends pulumi.ComponentResource {
                 cfnStack: undefined,
                 extraNodeSecurityGroups: undefined,
                 nodeSecurityGroup: undefined,
+                nodeSecurityGroupId: undefined,
             };
             super(type, name, props, opts);
             return;
@@ -519,11 +527,13 @@ export class NodeGroupInternal extends pulumi.ComponentResource {
         this.cfnStack = pulumi.output(group.cfnStack);
         this.extraNodeSecurityGroups = pulumi.output(group.extraNodeSecurityGroups ?? []);
         this.nodeSecurityGroup = pulumi.output(group.nodeSecurityGroup);
+        this.nodeSecurityGroupId = pulumi.output(group.nodeSecurityGroupId);
         this.registerOutputs({
             autoScalingGroupName: this.autoScalingGroupName,
             cfnStack: this.cfnStack,
             extraNodeSecurityGroups: this.extraNodeSecurityGroups,
             nodeSecurityGroup: this.nodeSecurityGroup,
+            nodeSecurityGroupId: this.nodeSecurityGroupId,
         });
     }
 }
@@ -537,7 +547,8 @@ export class NodeGroupV2 extends pulumi.ComponentResource implements NodeGroupV2
     /**
      * The security group for the node group to communicate with the cluster.
      */
-    public readonly nodeSecurityGroup: aws.ec2.SecurityGroup;
+    public readonly nodeSecurityGroup: aws.ec2.SecurityGroup | undefined;
+    public readonly nodeSecurityGroupId: pulumi.Output<string>;
     /**
      * The additional security groups for the node group that captures user-specific rules.
      */
@@ -561,6 +572,7 @@ export class NodeGroupV2 extends pulumi.ComponentResource implements NodeGroupV2
 
         const group = createNodeGroupV2(name, args, this, opts?.provider);
         this.nodeSecurityGroup = group.nodeSecurityGroup;
+        this.nodeSecurityGroupId = group.nodeSecurityGroupId;
         this.autoScalingGroup = group.autoScalingGroup;
         this.registerOutputs(undefined);
     }
@@ -576,7 +588,8 @@ export class NodeGroupV2 extends pulumi.ComponentResource implements NodeGroupV2
 export class NodeGroupV2Internal extends pulumi.ComponentResource {
     public readonly autoScalingGroup!: pulumi.Output<aws.autoscaling.Group>;
     public readonly extraNodeSecurityGroups!: pulumi.Output<aws.ec2.SecurityGroup[]>;
-    public readonly nodeSecurityGroup!: pulumi.Output<aws.ec2.SecurityGroup>;
+    public readonly nodeSecurityGroup!: pulumi.Output<aws.ec2.SecurityGroup | undefined>;
+    public readonly nodeSecurityGroupId!: pulumi.Output<string>;
 
     constructor(
         name: string,
@@ -590,6 +603,7 @@ export class NodeGroupV2Internal extends pulumi.ComponentResource {
                 autoScalingGroup: undefined,
                 extraNodeSecurityGroups: undefined,
                 nodeSecurityGroup: undefined,
+                nodeSecurityGroupId: undefined,
             };
             super(type, name, props, opts);
             return;
@@ -607,10 +621,12 @@ export class NodeGroupV2Internal extends pulumi.ComponentResource {
         this.autoScalingGroup = pulumi.output(group.autoScalingGroup);
         this.extraNodeSecurityGroups = pulumi.output(group.extraNodeSecurityGroups ?? []);
         this.nodeSecurityGroup = pulumi.output(group.nodeSecurityGroup);
+        this.nodeSecurityGroupId = pulumi.output(group.nodeSecurityGroupId);
         this.registerOutputs({
             autoScalingGroup: this.autoScalingGroup,
             extraNodeSecurityGroups: this.extraNodeSecurityGroups,
             nodeSecurityGroup: this.nodeSecurityGroup,
+            nodeSecurityGroupId: this.nodeSecurityGroupId,
         });
     }
 }
@@ -650,6 +666,20 @@ function createNodeGroupInternal(
         return args.instanceProfile ?? c.nodeGroupOptions.instanceProfile!;
     });
 
+    if (args.clusterIngressRule && args.clusterIngressRuleId) {
+        throw new pulumi.ResourceError(
+            `invalid args for node group ${name}, clusterIngressRule and clusterIngressRuleId are mutually exclusive`,
+            parent,
+        );
+    }
+
+    if (args.nodeSecurityGroup && args.nodeSecurityGroupId) {
+        throw new pulumi.ResourceError(
+            `invalid args for node group ${name}, nodeSecurityGroup and nodeSecurityGroupId are mutually exclusive`,
+            parent,
+        );
+    }
+
     const coreSecurityGroupId = core.nodeGroupOptions.nodeSecurityGroup?.apply((sg) => sg?.id);
     pulumi
         .all([coreSecurityGroupId, args.nodeSecurityGroup?.id, core.nodeSecurityGroupTags])
@@ -688,7 +718,8 @@ function createNodeGroupInternal(
         );
     }
 
-    let nodeSecurityGroup: aws.ec2.SecurityGroup;
+    let nodeSecurityGroupId: pulumi.Output<string>;
+    let nodeSecurityGroup: aws.ec2.SecurityGroup | undefined;
     const eksCluster = core.cluster;
 
     const cfnStackDeps = core.apply((c) => {
@@ -702,17 +733,20 @@ function createNodeGroupInternal(
         return result;
     });
 
-    let eksClusterIngressRule: aws.ec2.SecurityGroupRule = args.clusterIngressRule!;
-    if (args.nodeSecurityGroup) {
-        nodeSecurityGroup = args.nodeSecurityGroup;
-        if (eksClusterIngressRule === undefined) {
+    let eksClusterIngressRuleId: pulumi.Output<string>;
+    if (args.nodeSecurityGroup || args.nodeSecurityGroupId) {
+        if (args.clusterIngressRule === undefined && args.clusterIngressRuleId === undefined) {
             throw new pulumi.ResourceError(
-                `invalid args for node group ${name}, clusterIngressRule is required when nodeSecurityGroup is manually specified`,
+                `invalid args for node group ${name}, clusterIngressRule or clusterIngressRuleId is required when nodeSecurityGroup is manually specified`,
                 parent,
             );
         }
+
+        nodeSecurityGroup = args.nodeSecurityGroup;
+        nodeSecurityGroupId = args.nodeSecurityGroup?.id ?? pulumi.output(args.nodeSecurityGroupId!);
+        eksClusterIngressRuleId = args.clusterIngressRule?.id ?? pulumi.output(args.clusterIngressRuleId!);
     } else {
-        [nodeSecurityGroup, eksClusterIngressRule] = createNodeGroupSecurityGroup(
+        const [nodeSg, eksClusterIngressRule] = createNodeGroupSecurityGroup(
             name,
             {
                 vpcId: core.vpcId,
@@ -730,15 +764,10 @@ function createNodeGroupInternal(
             },
             parent,
         );
+        nodeSecurityGroup = nodeSg;
+        nodeSecurityGroupId = nodeSecurityGroup.id;
+        eksClusterIngressRuleId = eksClusterIngressRule.id;
     }
-
-    // This apply is necessary in s.t. the launchConfiguration picks up a
-    // dependency on the eksClusterIngressRule. The nodes may fail to
-    // connect to the cluster if we attempt to create them before the
-    // ingress rule is applied.
-    const nodeSecurityGroupId = pulumi
-        .all([nodeSecurityGroup.id, eksClusterIngressRule.id])
-        .apply(([id]) => id);
 
     // Collect the IDs of any extra, user-specific security groups.
     const extraSGOutput = pulumi.output(args.extraNodeSecurityGroups);
@@ -942,9 +971,12 @@ function createNodeGroupInternal(
             instanceType: args.instanceType || "t3.medium",
             iamInstanceProfile: instanceProfile,
             keyName: keyName,
-            securityGroups: pulumi
-                .all([nodeSecurityGroupId, extraNodeSecurityGroupIds])
-                .apply(([sg, extraSG]) => [sg, ...extraSG]),
+            // This apply is necessary in s.t. the launchConfiguration picks up a
+            // dependency on the eksClusterIngressRule. The nodes may fail to
+            // connect to the cluster if we attempt to create them before the
+            // ingress rule is applied.
+            securityGroups: pulumi.all([nodeSecurityGroupId, extraNodeSecurityGroupIds, eksClusterIngressRuleId])
+                .apply(([sg, extraSG, ingress]) => [sg, ...extraSG]),
             spotPrice: args.spotPrice,
             rootBlockDevice,
             ebsBlockDevices,
@@ -1061,6 +1093,7 @@ function createNodeGroupInternal(
 
     return {
         nodeSecurityGroup: nodeSecurityGroup,
+        nodeSecurityGroupId: nodeSecurityGroupId,
         cfnStack: cfnStack,
         autoScalingGroupName: autoScalingGroupName,
         extraNodeSecurityGroups: args.extraNodeSecurityGroups,
@@ -1096,6 +1129,20 @@ function createNodeGroupV2Internal(
         }
         return args.instanceProfile?.arn ?? c.nodeGroupOptions.instanceProfile!.arn;
     });
+
+    if (args.clusterIngressRule && args.clusterIngressRuleId) {
+        throw new pulumi.ResourceError(
+            `invalid args for node group ${name}, clusterIngressRule and clusterIngressRuleId are mutually exclusive`,
+            parent,
+        );
+    }
+
+    if (args.nodeSecurityGroup && args.nodeSecurityGroupId) {
+        throw new pulumi.ResourceError(
+            `invalid args for node group ${name}, nodeSecurityGroup and nodeSecurityGroupId are mutually exclusive`,
+            parent,
+        );
+    }
 
     const coreSecurityGroupId = core.nodeGroupOptions.nodeSecurityGroup?.apply((sg) => sg?.id);
     pulumi
@@ -1136,7 +1183,8 @@ function createNodeGroupV2Internal(
         );
     }
 
-    let nodeSecurityGroup: aws.ec2.SecurityGroup;
+    let nodeSecurityGroupId: pulumi.Output<string>;
+    let nodeSecurityGroup: aws.ec2.SecurityGroup | undefined;
     const eksCluster = core.cluster;
 
     const nodeGroupDeps = core.apply((c) => {
@@ -1150,17 +1198,20 @@ function createNodeGroupV2Internal(
         return result;
     });
 
-    let eksClusterIngressRule: aws.ec2.SecurityGroupRule | undefined = args.clusterIngressRule;
-    if (args.nodeSecurityGroup) {
-        nodeSecurityGroup = args.nodeSecurityGroup;
-        if (eksClusterIngressRule === undefined) {
+    let eksClusterIngressRuleId: pulumi.Output<string>;
+    if (args.nodeSecurityGroup || args.nodeSecurityGroupId) {
+        if (args.clusterIngressRule === undefined && args.clusterIngressRuleId === undefined) {
             throw new pulumi.ResourceError(
-                `invalid args for node group ${name}, clusterIngressRule is required when nodeSecurityGroup is manually specified`,
+                `invalid args for node group ${name}, clusterIngressRule or clusterIngressRuleId is required when nodeSecurityGroup is manually specified`,
                 parent,
             );
         }
+
+        nodeSecurityGroup = args.nodeSecurityGroup;
+        nodeSecurityGroupId = args.nodeSecurityGroup?.id ?? pulumi.output(args.nodeSecurityGroupId!);
+        eksClusterIngressRuleId = args.clusterIngressRule?.id ?? pulumi.output(args.clusterIngressRuleId!);
     } else {
-        [nodeSecurityGroup, eksClusterIngressRule] = createNodeGroupSecurityGroup(
+        const [nodeSg, eksClusterIngressRule] = createNodeGroupSecurityGroup(
             name,
             {
                 vpcId: core.vpcId,
@@ -1178,15 +1229,10 @@ function createNodeGroupV2Internal(
             },
             parent,
         );
+        nodeSecurityGroup = nodeSg;
+        nodeSecurityGroupId = nodeSg.id;
+        eksClusterIngressRuleId = eksClusterIngressRule.id
     }
-
-    // This apply is necessary in s.t. the launchConfiguration picks up a
-    // dependency on the eksClusterIngressRule. The nodes may fail to
-    // connect to the cluster if we attempt to create them before the
-    // ingress rule is applied.
-    const nodeSecurityGroupId = pulumi
-        .all([nodeSecurityGroup.id, eksClusterIngressRule.id])
-        .apply(([id]) => id);
 
     // Collect the IDs of any extra, user-specific security groups.
     const extraNodeSecurityGroupIds = pulumi.all([args.extraNodeSecurityGroups]).apply(([sg]) => {
@@ -1406,9 +1452,12 @@ function createNodeGroupV2Internal(
             networkInterfaces: [
                 {
                     associatePublicIpAddress: String(nodeAssociatePublicIpAddress),
-                    securityGroups: pulumi
-                        .all([nodeSecurityGroupId, extraNodeSecurityGroupIds])
-                        .apply(([sg, extraSG]) => [sg, ...extraSG]),
+                    // This apply is necessary in s.t. the launchTemplate picks up a
+                    // dependency on the eksClusterIngressRule. The nodes may fail to
+                    // connect to the cluster if we attempt to create them before the
+                    // ingress rule is applied.
+                    securityGroups: pulumi.all([nodeSecurityGroupId, extraNodeSecurityGroupIds, eksClusterIngressRuleId])
+                        .apply(([sg, extraSG, ingress]) => [sg, ...extraSG]),
                 },
             ],
             metadataOptions: args.metadataOptions,
@@ -1476,6 +1525,7 @@ function createNodeGroupV2Internal(
 
     return {
         nodeSecurityGroup: nodeSecurityGroup,
+        nodeSecurityGroupId: nodeSecurityGroupId,
         autoScalingGroup: asGroup,
         extraNodeSecurityGroups: args.extraNodeSecurityGroups,
     };

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -682,7 +682,11 @@ function createNodeGroupInternal(
 
     const coreSecurityGroupId = core.nodeGroupOptions.nodeSecurityGroup?.apply((sg) => sg?.id);
     pulumi
-        .all([coreSecurityGroupId, args.nodeSecurityGroup?.id, core.nodeSecurityGroupTags])
+        .all([
+            coreSecurityGroupId,
+            args.nodeSecurityGroup?.id ?? args.nodeSecurityGroupId,
+            core.nodeSecurityGroupTags,
+        ])
         .apply(([coreSecurityGroup, nodeSecurityGroup, sgTags]) => {
             if (coreSecurityGroup && nodeSecurityGroup) {
                 if (sgTags && coreSecurityGroup !== nodeSecurityGroup) {
@@ -743,8 +747,10 @@ function createNodeGroupInternal(
         }
 
         nodeSecurityGroup = args.nodeSecurityGroup;
-        nodeSecurityGroupId = args.nodeSecurityGroup?.id ?? pulumi.output(args.nodeSecurityGroupId!);
-        eksClusterIngressRuleId = args.clusterIngressRule?.id ?? pulumi.output(args.clusterIngressRuleId!);
+        nodeSecurityGroupId =
+            args.nodeSecurityGroup?.id ?? pulumi.output(args.nodeSecurityGroupId!);
+        eksClusterIngressRuleId =
+            args.clusterIngressRule?.id ?? pulumi.output(args.clusterIngressRuleId!);
     } else {
         const [nodeSg, eksClusterIngressRule] = createNodeGroupSecurityGroup(
             name,
@@ -975,7 +981,8 @@ function createNodeGroupInternal(
             // dependency on the eksClusterIngressRule. The nodes may fail to
             // connect to the cluster if we attempt to create them before the
             // ingress rule is applied.
-            securityGroups: pulumi.all([nodeSecurityGroupId, extraNodeSecurityGroupIds, eksClusterIngressRuleId])
+            securityGroups: pulumi
+                .all([nodeSecurityGroupId, extraNodeSecurityGroupIds, eksClusterIngressRuleId])
                 .apply(([sg, extraSG, ingress]) => [sg, ...extraSG]),
             spotPrice: args.spotPrice,
             rootBlockDevice,
@@ -1146,7 +1153,11 @@ function createNodeGroupV2Internal(
 
     const coreSecurityGroupId = core.nodeGroupOptions.nodeSecurityGroup?.apply((sg) => sg?.id);
     pulumi
-        .all([coreSecurityGroupId, args.nodeSecurityGroup?.id, core.nodeSecurityGroupTags])
+        .all([
+            coreSecurityGroupId,
+            args.nodeSecurityGroup?.id ?? args.nodeSecurityGroupId,
+            core.nodeSecurityGroupTags,
+        ])
         .apply(([coreSecurityGroup, nodeSecurityGroup, sgTags]) => {
             if (coreSecurityGroup && nodeSecurityGroup) {
                 if (sgTags && coreSecurityGroup !== nodeSecurityGroup) {
@@ -1208,8 +1219,10 @@ function createNodeGroupV2Internal(
         }
 
         nodeSecurityGroup = args.nodeSecurityGroup;
-        nodeSecurityGroupId = args.nodeSecurityGroup?.id ?? pulumi.output(args.nodeSecurityGroupId!);
-        eksClusterIngressRuleId = args.clusterIngressRule?.id ?? pulumi.output(args.clusterIngressRuleId!);
+        nodeSecurityGroupId =
+            args.nodeSecurityGroup?.id ?? pulumi.output(args.nodeSecurityGroupId!);
+        eksClusterIngressRuleId =
+            args.clusterIngressRule?.id ?? pulumi.output(args.clusterIngressRuleId!);
     } else {
         const [nodeSg, eksClusterIngressRule] = createNodeGroupSecurityGroup(
             name,
@@ -1231,7 +1244,7 @@ function createNodeGroupV2Internal(
         );
         nodeSecurityGroup = nodeSg;
         nodeSecurityGroupId = nodeSg.id;
-        eksClusterIngressRuleId = eksClusterIngressRule.id
+        eksClusterIngressRuleId = eksClusterIngressRule.id;
     }
 
     // Collect the IDs of any extra, user-specific security groups.
@@ -1456,7 +1469,12 @@ function createNodeGroupV2Internal(
                     // dependency on the eksClusterIngressRule. The nodes may fail to
                     // connect to the cluster if we attempt to create them before the
                     // ingress rule is applied.
-                    securityGroups: pulumi.all([nodeSecurityGroupId, extraNodeSecurityGroupIds, eksClusterIngressRuleId])
+                    securityGroups: pulumi
+                        .all([
+                            nodeSecurityGroupId,
+                            extraNodeSecurityGroupIds,
+                            eksClusterIngressRuleId,
+                        ])
                         .apply(([sg, extraSG, ingress]) => [sg, ...extraSG]),
                 },
             ],

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -2110,7 +2110,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 		},
 		"nodeSecurityGroupId": {
 			TypeSpec: schema.TypeSpec{Type: "string"},
-			Description: "The security group ID for the worker node group to communicate with the cluster.\n\n" +
+			Description: "The ID of the security group for the worker node group to communicate with the cluster.\n\n" +
 				"This security group requires specific inbound and outbound rules.\n\n" +
 				"See for more details:\n" +
 				"https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\n" +
@@ -2124,7 +2124,7 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 			Description: "The ingress rule that gives node group access.",
 		},
 		"clusterIngressRuleId": {
-			TypeSpec: schema.TypeSpec{Type: "string"},
+			TypeSpec:    schema.TypeSpec{Type: "string"},
 			Description: "The ID of the ingress rule that gives node group access.",
 		},
 		"extraNodeSecurityGroups": {

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -1035,7 +1035,11 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 					Properties: map[string]schema.PropertySpec{
 						"nodeSecurityGroup": {
 							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup")},
-							Description: "The security group for the node group to communicate with the cluster.",
+							Description: "The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.",
+						},
+						"nodeSecurityGroupId": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The ID of the security group for the node group to communicate with the cluster.",
 						},
 						"extraNodeSecurityGroups": {
 							TypeSpec: schema.TypeSpec{
@@ -1054,7 +1058,7 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 						},
 					},
 					Required: []string{
-						"nodeSecurityGroup",
+						"nodeSecurityGroupId",
 						"extraNodeSecurityGroups",
 						"cfnStack",
 						"autoScalingGroupName",
@@ -1072,7 +1076,11 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 					Properties: map[string]schema.PropertySpec{
 						"nodeSecurityGroup": {
 							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:ec2%2FsecurityGroup:SecurityGroup")},
-							Description: "The security group for the node group to communicate with the cluster.",
+							Description: "The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.",
+						},
+						"nodeSecurityGroupId": {
+							TypeSpec:    schema.TypeSpec{Type: "string"},
+							Description: "The ID of the security group for the node group to communicate with the cluster.",
 						},
 						"extraNodeSecurityGroups": {
 							TypeSpec: schema.TypeSpec{
@@ -1087,7 +1095,7 @@ func generateSchema(version semver.Version) schema.PackageSpec {
 						},
 					},
 					Required: []string{
-						"nodeSecurityGroup",
+						"nodeSecurityGroupId",
 						"extraNodeSecurityGroups",
 						"autoScalingGroup",
 					},
@@ -2100,11 +2108,24 @@ func nodeGroupProperties(cluster, v2 bool) map[string]schema.PropertySpec {
 				"Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are " +
 				"mutually exclusive.",
 		},
+		"nodeSecurityGroupId": {
+			TypeSpec: schema.TypeSpec{Type: "string"},
+			Description: "The security group ID for the worker node group to communicate with the cluster.\n\n" +
+				"This security group requires specific inbound and outbound rules.\n\n" +
+				"See for more details:\n" +
+				"https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\n" +
+				"Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are " +
+				"mutually exclusive.",
+		},
 		"clusterIngressRule": {
 			TypeSpec: schema.TypeSpec{
 				Ref: awsRef("#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule"),
 			},
 			Description: "The ingress rule that gives node group access.",
+		},
+		"clusterIngressRuleId": {
+			TypeSpec: schema.TypeSpec{Type: "string"},
+			Description: "The ID of the ingress rule that gives node group access.",
 		},
 		"extraNodeSecurityGroups": {
 			TypeSpec: schema.TypeSpec{

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -264,6 +264,10 @@
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access."
                 },
+                "clusterIngressRuleId": {
+                    "type": "string",
+                    "description": "The ID of the ingress rule that gives node group access."
+                },
                 "desiredCapacity": {
                     "type": "integer",
                     "description": "The number of worker nodes that should be running in the cluster. Defaults to 2."
@@ -370,6 +374,10 @@
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
+                },
+                "nodeSecurityGroupId": {
+                    "type": "string",
+                    "description": "The security group ID for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
                     "type": "array",
@@ -1678,11 +1686,15 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "description": "The security group for the node group to communicate with the cluster."
+                    "description": "The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`."
+                },
+                "nodeSecurityGroupId": {
+                    "type": "string",
+                    "description": "The ID of the security group for the node group to communicate with the cluster."
                 }
             },
             "required": [
-                "nodeSecurityGroup",
+                "nodeSecurityGroupId",
                 "extraNodeSecurityGroups",
                 "cfnStack",
                 "autoScalingGroupName"
@@ -1735,6 +1747,10 @@
                 "clusterIngressRule": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access."
+                },
+                "clusterIngressRuleId": {
+                    "type": "string",
+                    "description": "The ID of the ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
                     "type": "integer",
@@ -1826,6 +1842,10 @@
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
+                },
+                "nodeSecurityGroupId": {
+                    "type": "string",
+                    "description": "The security group ID for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
                     "type": "array",
@@ -1935,11 +1955,15 @@
                 },
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
-                    "description": "The security group for the node group to communicate with the cluster."
+                    "description": "The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`."
+                },
+                "nodeSecurityGroupId": {
+                    "type": "string",
+                    "description": "The ID of the security group for the node group to communicate with the cluster."
                 }
             },
             "required": [
-                "nodeSecurityGroup",
+                "nodeSecurityGroupId",
                 "extraNodeSecurityGroups",
                 "autoScalingGroup"
             ],
@@ -1991,6 +2015,10 @@
                 "clusterIngressRule": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access."
+                },
+                "clusterIngressRuleId": {
+                    "type": "string",
+                    "description": "The ID of the ingress rule that gives node group access."
                 },
                 "desiredCapacity": {
                     "type": "integer",
@@ -2098,6 +2126,10 @@
                 "nodeSecurityGroup": {
                     "$ref": "/aws/v6.18.2/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
+                },
+                "nodeSecurityGroupId": {
+                    "type": "string",
+                    "description": "The security group ID for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
                     "type": "array",

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -377,7 +377,7 @@
                 },
                 "nodeSecurityGroupId": {
                     "type": "string",
-                    "description": "The security group ID for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
+                    "description": "The ID of the security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
                     "type": "array",
@@ -1845,7 +1845,7 @@
                 },
                 "nodeSecurityGroupId": {
                     "type": "string",
-                    "description": "The security group ID for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
+                    "description": "The ID of the security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
                     "type": "array",
@@ -2129,7 +2129,7 @@
                 },
                 "nodeSecurityGroupId": {
                     "type": "string",
-                    "description": "The security group ID for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
+                    "description": "The ID of the security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSubnetIds": {
                     "type": "array",

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -102,6 +102,12 @@ namespace Pulumi.Eks.Inputs
         public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
 
         /// <summary>
+        /// The ID of the ingress rule that gives node group access.
+        /// </summary>
+        [Input("clusterIngressRuleId")]
+        public Input<string>? ClusterIngressRuleId { get; set; }
+
+        /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
         /// </summary>
         [Input("desiredCapacity")]
@@ -289,6 +295,19 @@ namespace Pulumi.Eks.Inputs
         /// </summary>
         [Input("nodeSecurityGroup")]
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
+
+        /// <summary>
+        /// The security group ID for the worker node group to communicate with the cluster.
+        /// 
+        /// This security group requires specific inbound and outbound rules.
+        /// 
+        /// See for more details:
+        /// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+        /// 
+        /// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        /// </summary>
+        [Input("nodeSecurityGroupId")]
+        public Input<string>? NodeSecurityGroupId { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;

--- a/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/ClusterNodeGroupOptionsArgs.cs
@@ -297,7 +297,7 @@ namespace Pulumi.Eks.Inputs
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
 
         /// <summary>
-        /// The security group ID for the worker node group to communicate with the cluster.
+        /// The ID of the security group for the worker node group to communicate with the cluster.
         /// 
         /// This security group requires specific inbound and outbound rules.
         /// 

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -336,7 +336,7 @@ namespace Pulumi.Eks
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
 
         /// <summary>
-        /// The security group ID for the worker node group to communicate with the cluster.
+        /// The ID of the security group for the worker node group to communicate with the cluster.
         /// 
         /// This security group requires specific inbound and outbound rules.
         /// 

--- a/sdk/dotnet/NodeGroup.cs
+++ b/sdk/dotnet/NodeGroup.cs
@@ -35,10 +35,16 @@ namespace Pulumi.Eks
         public Output<ImmutableArray<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups { get; private set; } = null!;
 
         /// <summary>
-        /// The security group for the node group to communicate with the cluster.
+        /// The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
         /// </summary>
         [Output("nodeSecurityGroup")]
-        public Output<Pulumi.Aws.Ec2.SecurityGroup> NodeSecurityGroup { get; private set; } = null!;
+        public Output<Pulumi.Aws.Ec2.SecurityGroup?> NodeSecurityGroup { get; private set; } = null!;
+
+        /// <summary>
+        /// The ID of the security group for the node group to communicate with the cluster.
+        /// </summary>
+        [Output("nodeSecurityGroupId")]
+        public Output<string> NodeSecurityGroupId { get; private set; } = null!;
 
 
         /// <summary>
@@ -159,6 +165,12 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("clusterIngressRule")]
         public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
+
+        /// <summary>
+        /// The ID of the ingress rule that gives node group access.
+        /// </summary>
+        [Input("clusterIngressRuleId")]
+        public Input<string>? ClusterIngressRuleId { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -322,6 +334,19 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("nodeSecurityGroup")]
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
+
+        /// <summary>
+        /// The security group ID for the worker node group to communicate with the cluster.
+        /// 
+        /// This security group requires specific inbound and outbound rules.
+        /// 
+        /// See for more details:
+        /// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+        /// 
+        /// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        /// </summary>
+        [Input("nodeSecurityGroupId")]
+        public Input<string>? NodeSecurityGroupId { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -355,7 +355,7 @@ namespace Pulumi.Eks
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
 
         /// <summary>
-        /// The security group ID for the worker node group to communicate with the cluster.
+        /// The ID of the security group for the worker node group to communicate with the cluster.
         /// 
         /// This security group requires specific inbound and outbound rules.
         /// 

--- a/sdk/dotnet/NodeGroupV2.cs
+++ b/sdk/dotnet/NodeGroupV2.cs
@@ -28,10 +28,16 @@ namespace Pulumi.Eks
         public Output<ImmutableArray<Pulumi.Aws.Ec2.SecurityGroup>> ExtraNodeSecurityGroups { get; private set; } = null!;
 
         /// <summary>
-        /// The security group for the node group to communicate with the cluster.
+        /// The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
         /// </summary>
         [Output("nodeSecurityGroup")]
-        public Output<Pulumi.Aws.Ec2.SecurityGroup> NodeSecurityGroup { get; private set; } = null!;
+        public Output<Pulumi.Aws.Ec2.SecurityGroup?> NodeSecurityGroup { get; private set; } = null!;
+
+        /// <summary>
+        /// The ID of the security group for the node group to communicate with the cluster.
+        /// </summary>
+        [Output("nodeSecurityGroupId")]
+        public Output<string> NodeSecurityGroupId { get; private set; } = null!;
 
 
         /// <summary>
@@ -152,6 +158,12 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("clusterIngressRule")]
         public Input<Pulumi.Aws.Ec2.SecurityGroupRule>? ClusterIngressRule { get; set; }
+
+        /// <summary>
+        /// The ID of the ingress rule that gives node group access.
+        /// </summary>
+        [Input("clusterIngressRuleId")]
+        public Input<string>? ClusterIngressRuleId { get; set; }
 
         /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -341,6 +353,19 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("nodeSecurityGroup")]
         public Input<Pulumi.Aws.Ec2.SecurityGroup>? NodeSecurityGroup { get; set; }
+
+        /// <summary>
+        /// The security group ID for the worker node group to communicate with the cluster.
+        /// 
+        /// This security group requires specific inbound and outbound rules.
+        /// 
+        /// See for more details:
+        /// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+        /// 
+        /// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        /// </summary>
+        [Input("nodeSecurityGroupId")]
+        public Input<string>? NodeSecurityGroupId { get; set; }
 
         [Input("nodeSubnetIds")]
         private InputList<string>? _nodeSubnetIds;

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -71,6 +71,10 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly Pulumi.Aws.Ec2.SecurityGroupRule? ClusterIngressRule;
         /// <summary>
+        /// The ID of the ingress rule that gives node group access.
+        /// </summary>
+        public readonly string? ClusterIngressRuleId;
+        /// <summary>
         /// The number of worker nodes that should be running in the cluster. Defaults to 2.
         /// </summary>
         public readonly int? DesiredCapacity;
@@ -194,6 +198,17 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup;
         /// <summary>
+        /// The security group ID for the worker node group to communicate with the cluster.
+        /// 
+        /// This security group requires specific inbound and outbound rules.
+        /// 
+        /// See for more details:
+        /// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+        /// 
+        /// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        /// </summary>
+        public readonly string? NodeSecurityGroupId;
+        /// <summary>
         /// The set of subnets to override and use for the worker node group.
         /// 
         /// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -259,6 +274,8 @@ namespace Pulumi.Eks.Outputs
 
             Pulumi.Aws.Ec2.SecurityGroupRule? clusterIngressRule,
 
+            string? clusterIngressRuleId,
+
             int? desiredCapacity,
 
             bool? enableDetailedMonitoring,
@@ -307,6 +324,8 @@ namespace Pulumi.Eks.Outputs
 
             Pulumi.Aws.Ec2.SecurityGroup? nodeSecurityGroup,
 
+            string? nodeSecurityGroupId,
+
             ImmutableArray<string> nodeSubnetIds,
 
             string? nodeUserData,
@@ -330,6 +349,7 @@ namespace Pulumi.Eks.Outputs
             BottlerocketSettings = bottlerocketSettings;
             CloudFormationTags = cloudFormationTags;
             ClusterIngressRule = clusterIngressRule;
+            ClusterIngressRuleId = clusterIngressRuleId;
             DesiredCapacity = desiredCapacity;
             EnableDetailedMonitoring = enableDetailedMonitoring;
             EncryptRootBlockDevice = encryptRootBlockDevice;
@@ -354,6 +374,7 @@ namespace Pulumi.Eks.Outputs
             NodeRootVolumeThroughput = nodeRootVolumeThroughput;
             NodeRootVolumeType = nodeRootVolumeType;
             NodeSecurityGroup = nodeSecurityGroup;
+            NodeSecurityGroupId = nodeSecurityGroupId;
             NodeSubnetIds = nodeSubnetIds;
             NodeUserData = nodeUserData;
             NodeUserDataOverride = nodeUserDataOverride;

--- a/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
+++ b/sdk/dotnet/Outputs/ClusterNodeGroupOptions.cs
@@ -198,7 +198,7 @@ namespace Pulumi.Eks.Outputs
         /// </summary>
         public readonly Pulumi.Aws.Ec2.SecurityGroup? NodeSecurityGroup;
         /// <summary>
-        /// The security group ID for the worker node group to communicate with the cluster.
+        /// The ID of the security group for the worker node group to communicate with the cluster.
         /// 
         /// This security group requires specific inbound and outbound rules.
         /// 

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -27,8 +27,10 @@ type NodeGroup struct {
 	CfnStack cloudformation.StackOutput `pulumi:"cfnStack"`
 	// The additional security groups for the node group that captures user-specific rules.
 	ExtraNodeSecurityGroups ec2.SecurityGroupArrayOutput `pulumi:"extraNodeSecurityGroups"`
-	// The security group for the node group to communicate with the cluster.
+	// The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
 	NodeSecurityGroup ec2.SecurityGroupOutput `pulumi:"nodeSecurityGroup"`
+	// The ID of the security group for the node group to communicate with the cluster.
+	NodeSecurityGroupId pulumi.StringOutput `pulumi:"nodeSecurityGroupId"`
 }
 
 // NewNodeGroup registers a new resource with the given unique name, arguments, and options.
@@ -93,6 +95,8 @@ type nodeGroupArgs struct {
 	Cluster interface{} `pulumi:"cluster"`
 	// The ingress rule that gives node group access.
 	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
+	// The ID of the ingress rule that gives node group access.
+	ClusterIngressRuleId *string `pulumi:"clusterIngressRuleId"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
@@ -160,6 +164,15 @@ type nodeGroupArgs struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
+	// The security group ID for the worker node group to communicate with the cluster.
+	//
+	// This security group requires specific inbound and outbound rules.
+	//
+	// See for more details:
+	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+	//
+	// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+	NodeSecurityGroupId *string `pulumi:"nodeSecurityGroupId"`
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -239,6 +252,8 @@ type NodeGroupArgs struct {
 	Cluster pulumi.Input
 	// The ingress rule that gives node group access.
 	ClusterIngressRule ec2.SecurityGroupRuleInput
+	// The ID of the ingress rule that gives node group access.
+	ClusterIngressRuleId pulumi.StringPtrInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
 	// Enables/disables detailed monitoring of the EC2 instances.
@@ -306,6 +321,15 @@ type NodeGroupArgs struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup ec2.SecurityGroupInput
+	// The security group ID for the worker node group to communicate with the cluster.
+	//
+	// This security group requires specific inbound and outbound rules.
+	//
+	// See for more details:
+	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+	//
+	// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+	NodeSecurityGroupId pulumi.StringPtrInput
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -443,9 +467,14 @@ func (o NodeGroupOutput) ExtraNodeSecurityGroups() ec2.SecurityGroupArrayOutput 
 	return o.ApplyT(func(v *NodeGroup) ec2.SecurityGroupArrayOutput { return v.ExtraNodeSecurityGroups }).(ec2.SecurityGroupArrayOutput)
 }
 
-// The security group for the node group to communicate with the cluster.
+// The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
 func (o NodeGroupOutput) NodeSecurityGroup() ec2.SecurityGroupOutput {
 	return o.ApplyT(func(v *NodeGroup) ec2.SecurityGroupOutput { return v.NodeSecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+// The ID of the security group for the node group to communicate with the cluster.
+func (o NodeGroupOutput) NodeSecurityGroupId() pulumi.StringOutput {
+	return o.ApplyT(func(v *NodeGroup) pulumi.StringOutput { return v.NodeSecurityGroupId }).(pulumi.StringOutput)
 }
 
 type NodeGroupArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/eks/nodeGroup.go
+++ b/sdk/go/eks/nodeGroup.go
@@ -164,7 +164,7 @@ type nodeGroupArgs struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
-	// The security group ID for the worker node group to communicate with the cluster.
+	// The ID of the security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
 	//
@@ -321,7 +321,7 @@ type NodeGroupArgs struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup ec2.SecurityGroupInput
-	// The security group ID for the worker node group to communicate with the cluster.
+	// The ID of the security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
 	//

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -23,8 +23,10 @@ type NodeGroupV2 struct {
 	AutoScalingGroup autoscaling.GroupOutput `pulumi:"autoScalingGroup"`
 	// The additional security groups for the node group that captures user-specific rules.
 	ExtraNodeSecurityGroups ec2.SecurityGroupArrayOutput `pulumi:"extraNodeSecurityGroups"`
-	// The security group for the node group to communicate with the cluster.
+	// The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
 	NodeSecurityGroup ec2.SecurityGroupOutput `pulumi:"nodeSecurityGroup"`
+	// The ID of the security group for the node group to communicate with the cluster.
+	NodeSecurityGroupId pulumi.StringOutput `pulumi:"nodeSecurityGroupId"`
 }
 
 // NewNodeGroupV2 registers a new resource with the given unique name, arguments, and options.
@@ -89,6 +91,8 @@ type nodeGroupV2Args struct {
 	Cluster interface{} `pulumi:"cluster"`
 	// The ingress rule that gives node group access.
 	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
+	// The ID of the ingress rule that gives node group access.
+	ClusterIngressRuleId *string `pulumi:"clusterIngressRuleId"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
@@ -164,6 +168,15 @@ type nodeGroupV2Args struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
+	// The security group ID for the worker node group to communicate with the cluster.
+	//
+	// This security group requires specific inbound and outbound rules.
+	//
+	// See for more details:
+	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+	//
+	// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+	NodeSecurityGroupId *string `pulumi:"nodeSecurityGroupId"`
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -243,6 +256,8 @@ type NodeGroupV2Args struct {
 	Cluster pulumi.Input
 	// The ingress rule that gives node group access.
 	ClusterIngressRule ec2.SecurityGroupRuleInput
+	// The ID of the ingress rule that gives node group access.
+	ClusterIngressRuleId pulumi.StringPtrInput
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput
 	// Enables/disables detailed monitoring of the EC2 instances.
@@ -318,6 +333,15 @@ type NodeGroupV2Args struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup ec2.SecurityGroupInput
+	// The security group ID for the worker node group to communicate with the cluster.
+	//
+	// This security group requires specific inbound and outbound rules.
+	//
+	// See for more details:
+	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+	//
+	// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+	NodeSecurityGroupId pulumi.StringPtrInput
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -450,9 +474,14 @@ func (o NodeGroupV2Output) ExtraNodeSecurityGroups() ec2.SecurityGroupArrayOutpu
 	return o.ApplyT(func(v *NodeGroupV2) ec2.SecurityGroupArrayOutput { return v.ExtraNodeSecurityGroups }).(ec2.SecurityGroupArrayOutput)
 }
 
-// The security group for the node group to communicate with the cluster.
+// The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
 func (o NodeGroupV2Output) NodeSecurityGroup() ec2.SecurityGroupOutput {
 	return o.ApplyT(func(v *NodeGroupV2) ec2.SecurityGroupOutput { return v.NodeSecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+// The ID of the security group for the node group to communicate with the cluster.
+func (o NodeGroupV2Output) NodeSecurityGroupId() pulumi.StringOutput {
+	return o.ApplyT(func(v *NodeGroupV2) pulumi.StringOutput { return v.NodeSecurityGroupId }).(pulumi.StringOutput)
 }
 
 type NodeGroupV2ArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/eks/nodeGroupV2.go
+++ b/sdk/go/eks/nodeGroupV2.go
@@ -168,7 +168,7 @@ type nodeGroupV2Args struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
-	// The security group ID for the worker node group to communicate with the cluster.
+	// The ID of the security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
 	//
@@ -333,7 +333,7 @@ type NodeGroupV2Args struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup ec2.SecurityGroupInput
-	// The security group ID for the worker node group to communicate with the cluster.
+	// The ID of the security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
 	//

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -339,6 +339,8 @@ type ClusterNodeGroupOptions struct {
 	CloudFormationTags map[string]string `pulumi:"cloudFormationTags"`
 	// The ingress rule that gives node group access.
 	ClusterIngressRule *ec2.SecurityGroupRule `pulumi:"clusterIngressRule"`
+	// The ID of the ingress rule that gives node group access.
+	ClusterIngressRuleId *string `pulumi:"clusterIngressRuleId"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity *int `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
@@ -414,6 +416,15 @@ type ClusterNodeGroupOptions struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
+	// The security group ID for the worker node group to communicate with the cluster.
+	//
+	// This security group requires specific inbound and outbound rules.
+	//
+	// See for more details:
+	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+	//
+	// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+	NodeSecurityGroupId *string `pulumi:"nodeSecurityGroupId"`
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -502,6 +513,8 @@ type ClusterNodeGroupOptionsArgs struct {
 	CloudFormationTags pulumi.StringMapInput `pulumi:"cloudFormationTags"`
 	// The ingress rule that gives node group access.
 	ClusterIngressRule ec2.SecurityGroupRuleInput `pulumi:"clusterIngressRule"`
+	// The ID of the ingress rule that gives node group access.
+	ClusterIngressRuleId pulumi.StringPtrInput `pulumi:"clusterIngressRuleId"`
 	// The number of worker nodes that should be running in the cluster. Defaults to 2.
 	DesiredCapacity pulumi.IntPtrInput `pulumi:"desiredCapacity"`
 	// Enables/disables detailed monitoring of the EC2 instances.
@@ -577,6 +590,15 @@ type ClusterNodeGroupOptionsArgs struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup ec2.SecurityGroupInput `pulumi:"nodeSecurityGroup"`
+	// The security group ID for the worker node group to communicate with the cluster.
+	//
+	// This security group requires specific inbound and outbound rules.
+	//
+	// See for more details:
+	// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+	//
+	// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+	NodeSecurityGroupId pulumi.StringPtrInput `pulumi:"nodeSecurityGroupId"`
 	// The set of subnets to override and use for the worker node group.
 	//
 	// Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -751,6 +773,11 @@ func (o ClusterNodeGroupOptionsOutput) ClusterIngressRule() ec2.SecurityGroupRul
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *ec2.SecurityGroupRule { return v.ClusterIngressRule }).(ec2.SecurityGroupRuleOutput)
 }
 
+// The ID of the ingress rule that gives node group access.
+func (o ClusterNodeGroupOptionsOutput) ClusterIngressRuleId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *string { return v.ClusterIngressRuleId }).(pulumi.StringPtrOutput)
+}
+
 // The number of worker nodes that should be running in the cluster. Defaults to 2.
 func (o ClusterNodeGroupOptionsOutput) DesiredCapacity() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *int { return v.DesiredCapacity }).(pulumi.IntPtrOutput)
@@ -898,6 +925,18 @@ func (o ClusterNodeGroupOptionsOutput) NodeRootVolumeType() pulumi.StringPtrOutp
 // Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 func (o ClusterNodeGroupOptionsOutput) NodeSecurityGroup() ec2.SecurityGroupOutput {
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *ec2.SecurityGroup { return v.NodeSecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+// The security group ID for the worker node group to communicate with the cluster.
+//
+// This security group requires specific inbound and outbound rules.
+//
+// See for more details:
+// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+//
+// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+func (o ClusterNodeGroupOptionsOutput) NodeSecurityGroupId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ClusterNodeGroupOptions) *string { return v.NodeSecurityGroupId }).(pulumi.StringPtrOutput)
 }
 
 // The set of subnets to override and use for the worker node group.
@@ -1075,6 +1114,16 @@ func (o ClusterNodeGroupOptionsPtrOutput) ClusterIngressRule() ec2.SecurityGroup
 		}
 		return v.ClusterIngressRule
 	}).(ec2.SecurityGroupRuleOutput)
+}
+
+// The ID of the ingress rule that gives node group access.
+func (o ClusterNodeGroupOptionsPtrOutput) ClusterIngressRuleId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *string {
+		if v == nil {
+			return nil
+		}
+		return v.ClusterIngressRuleId
+	}).(pulumi.StringPtrOutput)
 }
 
 // The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -1342,6 +1391,23 @@ func (o ClusterNodeGroupOptionsPtrOutput) NodeSecurityGroup() ec2.SecurityGroupO
 		}
 		return v.NodeSecurityGroup
 	}).(ec2.SecurityGroupOutput)
+}
+
+// The security group ID for the worker node group to communicate with the cluster.
+//
+// This security group requires specific inbound and outbound rules.
+//
+// See for more details:
+// https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+//
+// Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+func (o ClusterNodeGroupOptionsPtrOutput) NodeSecurityGroupId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ClusterNodeGroupOptions) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NodeSecurityGroupId
+	}).(pulumi.StringPtrOutput)
 }
 
 // The set of subnets to override and use for the worker node group.

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -416,7 +416,7 @@ type ClusterNodeGroupOptions struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup *ec2.SecurityGroup `pulumi:"nodeSecurityGroup"`
-	// The security group ID for the worker node group to communicate with the cluster.
+	// The ID of the security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
 	//
@@ -590,7 +590,7 @@ type ClusterNodeGroupOptionsArgs struct {
 	//
 	// Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
 	NodeSecurityGroup ec2.SecurityGroupInput `pulumi:"nodeSecurityGroup"`
-	// The security group ID for the worker node group to communicate with the cluster.
+	// The ID of the security group for the worker node group to communicate with the cluster.
 	//
 	// This security group requires specific inbound and outbound rules.
 	//
@@ -927,7 +927,7 @@ func (o ClusterNodeGroupOptionsOutput) NodeSecurityGroup() ec2.SecurityGroupOutp
 	return o.ApplyT(func(v ClusterNodeGroupOptions) *ec2.SecurityGroup { return v.NodeSecurityGroup }).(ec2.SecurityGroupOutput)
 }
 
-// The security group ID for the worker node group to communicate with the cluster.
+// The ID of the security group for the worker node group to communicate with the cluster.
 //
 // This security group requires specific inbound and outbound rules.
 //
@@ -1393,7 +1393,7 @@ func (o ClusterNodeGroupOptionsPtrOutput) NodeSecurityGroup() ec2.SecurityGroupO
 	}).(ec2.SecurityGroupOutput)
 }
 
-// The security group ID for the worker node group to communicate with the cluster.
+// The ID of the security group for the worker node group to communicate with the cluster.
 //
 // This security group requires specific inbound and outbound rules.
 //

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroup.java
@@ -13,6 +13,7 @@ import com.pulumi.eks.NodeGroupArgs;
 import com.pulumi.eks.Utilities;
 import java.lang.String;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -68,18 +69,32 @@ public class NodeGroup extends com.pulumi.resources.ComponentResource {
         return this.extraNodeSecurityGroups;
     }
     /**
-     * The security group for the node group to communicate with the cluster.
+     * The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
      * 
      */
     @Export(name="nodeSecurityGroup", refs={SecurityGroup.class}, tree="[0]")
-    private Output<SecurityGroup> nodeSecurityGroup;
+    private Output</* @Nullable */ SecurityGroup> nodeSecurityGroup;
 
     /**
-     * @return The security group for the node group to communicate with the cluster.
+     * @return The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
      * 
      */
-    public Output<SecurityGroup> nodeSecurityGroup() {
-        return this.nodeSecurityGroup;
+    public Output<Optional<SecurityGroup>> nodeSecurityGroup() {
+        return Codegen.optional(this.nodeSecurityGroup);
+    }
+    /**
+     * The ID of the security group for the node group to communicate with the cluster.
+     * 
+     */
+    @Export(name="nodeSecurityGroupId", refs={String.class}, tree="[0]")
+    private Output<String> nodeSecurityGroupId;
+
+    /**
+     * @return The ID of the security group for the node group to communicate with the cluster.
+     * 
+     */
+    public Output<String> nodeSecurityGroupId() {
+        return this.nodeSecurityGroupId;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -203,6 +203,21 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The ID of the ingress rule that gives node group access.
+     * 
+     */
+    @Import(name="clusterIngressRuleId")
+    private @Nullable Output<String> clusterIngressRuleId;
+
+    /**
+     * @return The ID of the ingress rule that gives node group access.
+     * 
+     */
+    public Optional<Output<String>> clusterIngressRuleId() {
+        return Optional.ofNullable(this.clusterIngressRuleId);
+    }
+
+    /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      * 
      */
@@ -568,6 +583,35 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    @Import(name="nodeSecurityGroupId")
+    private @Nullable Output<String> nodeSecurityGroupId;
+
+    /**
+     * @return The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    public Optional<Output<String>> nodeSecurityGroupId() {
+        return Optional.ofNullable(this.nodeSecurityGroupId);
+    }
+
+    /**
      * The set of subnets to override and use for the worker node group.
      * 
      * Setting this option overrides which subnets to use for the worker node group, regardless if the cluster&#39;s `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -732,6 +776,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         this.cloudFormationTags = $.cloudFormationTags;
         this.cluster = $.cluster;
         this.clusterIngressRule = $.clusterIngressRule;
+        this.clusterIngressRuleId = $.clusterIngressRuleId;
         this.desiredCapacity = $.desiredCapacity;
         this.enableDetailedMonitoring = $.enableDetailedMonitoring;
         this.encryptRootBlockDevice = $.encryptRootBlockDevice;
@@ -753,6 +798,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         this.nodeRootVolumeThroughput = $.nodeRootVolumeThroughput;
         this.nodeRootVolumeType = $.nodeRootVolumeType;
         this.nodeSecurityGroup = $.nodeSecurityGroup;
+        this.nodeSecurityGroupId = $.nodeSecurityGroupId;
         this.nodeSubnetIds = $.nodeSubnetIds;
         this.nodeUserData = $.nodeUserData;
         this.nodeUserDataOverride = $.nodeUserDataOverride;
@@ -1019,6 +1065,27 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
             return clusterIngressRule(Output.of(clusterIngressRule));
+        }
+
+        /**
+         * @param clusterIngressRuleId The ID of the ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRuleId(@Nullable Output<String> clusterIngressRuleId) {
+            $.clusterIngressRuleId = clusterIngressRuleId;
+            return this;
+        }
+
+        /**
+         * @param clusterIngressRuleId The ID of the ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRuleId(String clusterIngressRuleId) {
+            return clusterIngressRuleId(Output.of(clusterIngressRuleId));
         }
 
         /**
@@ -1512,6 +1579,41 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
             return nodeSecurityGroup(Output.of(nodeSecurityGroup));
+        }
+
+        /**
+         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroupId(@Nullable Output<String> nodeSecurityGroupId) {
+            $.nodeSecurityGroupId = nodeSecurityGroupId;
+            return this;
+        }
+
+        /**
+         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroupId(String nodeSecurityGroupId) {
+            return nodeSecurityGroupId(Output.of(nodeSecurityGroupId));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupArgs.java
@@ -583,7 +583,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -597,7 +597,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<String> nodeSecurityGroupId;
 
     /**
-     * @return The security group ID for the worker node group to communicate with the cluster.
+     * @return The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -1582,7 +1582,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * @param nodeSecurityGroupId The ID of the security group for the worker node group to communicate with the cluster.
          * 
          * This security group requires specific inbound and outbound rules.
          * 
@@ -1600,7 +1600,7 @@ public final class NodeGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * @param nodeSecurityGroupId The ID of the security group for the worker node group to communicate with the cluster.
          * 
          * This security group requires specific inbound and outbound rules.
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2.java
@@ -11,7 +11,9 @@ import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.eks.NodeGroupV2Args;
 import com.pulumi.eks.Utilities;
+import java.lang.String;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -49,18 +51,32 @@ public class NodeGroupV2 extends com.pulumi.resources.ComponentResource {
         return this.extraNodeSecurityGroups;
     }
     /**
-     * The security group for the node group to communicate with the cluster.
+     * The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
      * 
      */
     @Export(name="nodeSecurityGroup", refs={SecurityGroup.class}, tree="[0]")
-    private Output<SecurityGroup> nodeSecurityGroup;
+    private Output</* @Nullable */ SecurityGroup> nodeSecurityGroup;
 
     /**
-     * @return The security group for the node group to communicate with the cluster.
+     * @return The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
      * 
      */
-    public Output<SecurityGroup> nodeSecurityGroup() {
-        return this.nodeSecurityGroup;
+    public Output<Optional<SecurityGroup>> nodeSecurityGroup() {
+        return Codegen.optional(this.nodeSecurityGroup);
+    }
+    /**
+     * The ID of the security group for the node group to communicate with the cluster.
+     * 
+     */
+    @Export(name="nodeSecurityGroupId", refs={String.class}, tree="[0]")
+    private Output<String> nodeSecurityGroupId;
+
+    /**
+     * @return The ID of the security group for the node group to communicate with the cluster.
+     * 
+     */
+    public Output<String> nodeSecurityGroupId() {
+        return this.nodeSecurityGroupId;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -633,7 +633,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -647,7 +647,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     private @Nullable Output<String> nodeSecurityGroupId;
 
     /**
-     * @return The security group ID for the worker node group to communicate with the cluster.
+     * @return The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -1700,7 +1700,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * @param nodeSecurityGroupId The ID of the security group for the worker node group to communicate with the cluster.
          * 
          * This security group requires specific inbound and outbound rules.
          * 
@@ -1718,7 +1718,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * @param nodeSecurityGroupId The ID of the security group for the worker node group to communicate with the cluster.
          * 
          * This security group requires specific inbound and outbound rules.
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/NodeGroupV2Args.java
@@ -204,6 +204,21 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The ID of the ingress rule that gives node group access.
+     * 
+     */
+    @Import(name="clusterIngressRuleId")
+    private @Nullable Output<String> clusterIngressRuleId;
+
+    /**
+     * @return The ID of the ingress rule that gives node group access.
+     * 
+     */
+    public Optional<Output<String>> clusterIngressRuleId() {
+        return Optional.ofNullable(this.clusterIngressRuleId);
+    }
+
+    /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      * 
      */
@@ -618,6 +633,35 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    @Import(name="nodeSecurityGroupId")
+    private @Nullable Output<String> nodeSecurityGroupId;
+
+    /**
+     * @return The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    public Optional<Output<String>> nodeSecurityGroupId() {
+        return Optional.ofNullable(this.nodeSecurityGroupId);
+    }
+
+    /**
      * The set of subnets to override and use for the worker node group.
      * 
      * Setting this option overrides which subnets to use for the worker node group, regardless if the cluster&#39;s `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -782,6 +826,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         this.cloudFormationTags = $.cloudFormationTags;
         this.cluster = $.cluster;
         this.clusterIngressRule = $.clusterIngressRule;
+        this.clusterIngressRuleId = $.clusterIngressRuleId;
         this.desiredCapacity = $.desiredCapacity;
         this.enableDetailedMonitoring = $.enableDetailedMonitoring;
         this.encryptRootBlockDevice = $.encryptRootBlockDevice;
@@ -806,6 +851,7 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
         this.nodeRootVolumeThroughput = $.nodeRootVolumeThroughput;
         this.nodeRootVolumeType = $.nodeRootVolumeType;
         this.nodeSecurityGroup = $.nodeSecurityGroup;
+        this.nodeSecurityGroupId = $.nodeSecurityGroupId;
         this.nodeSubnetIds = $.nodeSubnetIds;
         this.nodeUserData = $.nodeUserData;
         this.nodeUserDataOverride = $.nodeUserDataOverride;
@@ -1072,6 +1118,27 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          */
         public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
             return clusterIngressRule(Output.of(clusterIngressRule));
+        }
+
+        /**
+         * @param clusterIngressRuleId The ID of the ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRuleId(@Nullable Output<String> clusterIngressRuleId) {
+            $.clusterIngressRuleId = clusterIngressRuleId;
+            return this;
+        }
+
+        /**
+         * @param clusterIngressRuleId The ID of the ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRuleId(String clusterIngressRuleId) {
+            return clusterIngressRuleId(Output.of(clusterIngressRuleId));
         }
 
         /**
@@ -1630,6 +1697,41 @@ public final class NodeGroupV2Args extends com.pulumi.resources.ResourceArgs {
          */
         public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
             return nodeSecurityGroup(Output.of(nodeSecurityGroup));
+        }
+
+        /**
+         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroupId(@Nullable Output<String> nodeSecurityGroupId) {
+            $.nodeSecurityGroupId = nodeSecurityGroupId;
+            return this;
+        }
+
+        /**
+         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroupId(String nodeSecurityGroupId) {
+            return nodeSecurityGroupId(Output.of(nodeSecurityGroupId));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -189,6 +189,21 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
+     * The ID of the ingress rule that gives node group access.
+     * 
+     */
+    @Import(name="clusterIngressRuleId")
+    private @Nullable Output<String> clusterIngressRuleId;
+
+    /**
+     * @return The ID of the ingress rule that gives node group access.
+     * 
+     */
+    public Optional<Output<String>> clusterIngressRuleId() {
+        return Optional.ofNullable(this.clusterIngressRuleId);
+    }
+
+    /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      * 
      */
@@ -603,6 +618,35 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    @Import(name="nodeSecurityGroupId")
+    private @Nullable Output<String> nodeSecurityGroupId;
+
+    /**
+     * @return The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    public Optional<Output<String>> nodeSecurityGroupId() {
+        return Optional.ofNullable(this.nodeSecurityGroupId);
+    }
+
+    /**
      * The set of subnets to override and use for the worker node group.
      * 
      * Setting this option overrides which subnets to use for the worker node group, regardless if the cluster&#39;s `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -766,6 +810,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         this.bottlerocketSettings = $.bottlerocketSettings;
         this.cloudFormationTags = $.cloudFormationTags;
         this.clusterIngressRule = $.clusterIngressRule;
+        this.clusterIngressRuleId = $.clusterIngressRuleId;
         this.desiredCapacity = $.desiredCapacity;
         this.enableDetailedMonitoring = $.enableDetailedMonitoring;
         this.encryptRootBlockDevice = $.encryptRootBlockDevice;
@@ -790,6 +835,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         this.nodeRootVolumeThroughput = $.nodeRootVolumeThroughput;
         this.nodeRootVolumeType = $.nodeRootVolumeType;
         this.nodeSecurityGroup = $.nodeSecurityGroup;
+        this.nodeSecurityGroupId = $.nodeSecurityGroupId;
         this.nodeSubnetIds = $.nodeSubnetIds;
         this.nodeUserData = $.nodeUserData;
         this.nodeUserDataOverride = $.nodeUserDataOverride;
@@ -1015,6 +1061,27 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          */
         public Builder clusterIngressRule(SecurityGroupRule clusterIngressRule) {
             return clusterIngressRule(Output.of(clusterIngressRule));
+        }
+
+        /**
+         * @param clusterIngressRuleId The ID of the ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRuleId(@Nullable Output<String> clusterIngressRuleId) {
+            $.clusterIngressRuleId = clusterIngressRuleId;
+            return this;
+        }
+
+        /**
+         * @param clusterIngressRuleId The ID of the ingress rule that gives node group access.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder clusterIngressRuleId(String clusterIngressRuleId) {
+            return clusterIngressRuleId(Output.of(clusterIngressRuleId));
         }
 
         /**
@@ -1573,6 +1640,41 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
          */
         public Builder nodeSecurityGroup(SecurityGroup nodeSecurityGroup) {
             return nodeSecurityGroup(Output.of(nodeSecurityGroup));
+        }
+
+        /**
+         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroupId(@Nullable Output<String> nodeSecurityGroupId) {
+            $.nodeSecurityGroupId = nodeSecurityGroupId;
+            return this;
+        }
+
+        /**
+         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * 
+         * This security group requires specific inbound and outbound rules.
+         * 
+         * See for more details:
+         * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+         * 
+         * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder nodeSecurityGroupId(String nodeSecurityGroupId) {
+            return nodeSecurityGroupId(Output.of(nodeSecurityGroupId));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/ClusterNodeGroupOptionsArgs.java
@@ -618,7 +618,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     }
 
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -632,7 +632,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
     private @Nullable Output<String> nodeSecurityGroupId;
 
     /**
-     * @return The security group ID for the worker node group to communicate with the cluster.
+     * @return The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -1643,7 +1643,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         }
 
         /**
-         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * @param nodeSecurityGroupId The ID of the security group for the worker node group to communicate with the cluster.
          * 
          * This security group requires specific inbound and outbound rules.
          * 
@@ -1661,7 +1661,7 @@ public final class ClusterNodeGroupOptionsArgs extends com.pulumi.resources.Reso
         }
 
         /**
-         * @param nodeSecurityGroupId The security group ID for the worker node group to communicate with the cluster.
+         * @param nodeSecurityGroupId The ID of the security group for the worker node group to communicate with the cluster.
          * 
          * This security group requires specific inbound and outbound rules.
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -237,7 +237,7 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable SecurityGroup nodeSecurityGroup;
     /**
-     * @return The security group ID for the worker node group to communicate with the cluster.
+     * @return The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 
@@ -585,7 +585,7 @@ public final class ClusterNodeGroupOptions {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
     /**
-     * @return The security group ID for the worker node group to communicate with the cluster.
+     * @return The ID of the security group for the worker node group to communicate with the cluster.
      * 
      * This security group requires specific inbound and outbound rules.
      * 

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/ClusterNodeGroupOptions.java
@@ -85,6 +85,11 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable SecurityGroupRule clusterIngressRule;
     /**
+     * @return The ID of the ingress rule that gives node group access.
+     * 
+     */
+    private @Nullable String clusterIngressRuleId;
+    /**
      * @return The number of worker nodes that should be running in the cluster. Defaults to 2.
      * 
      */
@@ -232,6 +237,18 @@ public final class ClusterNodeGroupOptions {
      */
     private @Nullable SecurityGroup nodeSecurityGroup;
     /**
+     * @return The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    private @Nullable String nodeSecurityGroupId;
+    /**
      * @return The set of subnets to override and use for the worker node group.
      * 
      * Setting this option overrides which subnets to use for the worker node group, regardless if the cluster&#39;s `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -364,6 +381,13 @@ public final class ClusterNodeGroupOptions {
      */
     public Optional<SecurityGroupRule> clusterIngressRule() {
         return Optional.ofNullable(this.clusterIngressRule);
+    }
+    /**
+     * @return The ID of the ingress rule that gives node group access.
+     * 
+     */
+    public Optional<String> clusterIngressRuleId() {
+        return Optional.ofNullable(this.clusterIngressRuleId);
     }
     /**
      * @return The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -561,6 +585,20 @@ public final class ClusterNodeGroupOptions {
         return Optional.ofNullable(this.nodeSecurityGroup);
     }
     /**
+     * @return The security group ID for the worker node group to communicate with the cluster.
+     * 
+     * This security group requires specific inbound and outbound rules.
+     * 
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     * 
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     * 
+     */
+    public Optional<String> nodeSecurityGroupId() {
+        return Optional.ofNullable(this.nodeSecurityGroupId);
+    }
+    /**
      * @return The set of subnets to override and use for the worker node group.
      * 
      * Setting this option overrides which subnets to use for the worker node group, regardless if the cluster&#39;s `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -650,6 +688,7 @@ public final class ClusterNodeGroupOptions {
         private @Nullable Map<String,Object> bottlerocketSettings;
         private @Nullable Map<String,String> cloudFormationTags;
         private @Nullable SecurityGroupRule clusterIngressRule;
+        private @Nullable String clusterIngressRuleId;
         private @Nullable Integer desiredCapacity;
         private @Nullable Boolean enableDetailedMonitoring;
         private @Nullable Boolean encryptRootBlockDevice;
@@ -674,6 +713,7 @@ public final class ClusterNodeGroupOptions {
         private @Nullable Integer nodeRootVolumeThroughput;
         private @Nullable String nodeRootVolumeType;
         private @Nullable SecurityGroup nodeSecurityGroup;
+        private @Nullable String nodeSecurityGroupId;
         private @Nullable List<String> nodeSubnetIds;
         private @Nullable String nodeUserData;
         private @Nullable String nodeUserDataOverride;
@@ -692,6 +732,7 @@ public final class ClusterNodeGroupOptions {
     	      this.bottlerocketSettings = defaults.bottlerocketSettings;
     	      this.cloudFormationTags = defaults.cloudFormationTags;
     	      this.clusterIngressRule = defaults.clusterIngressRule;
+    	      this.clusterIngressRuleId = defaults.clusterIngressRuleId;
     	      this.desiredCapacity = defaults.desiredCapacity;
     	      this.enableDetailedMonitoring = defaults.enableDetailedMonitoring;
     	      this.encryptRootBlockDevice = defaults.encryptRootBlockDevice;
@@ -716,6 +757,7 @@ public final class ClusterNodeGroupOptions {
     	      this.nodeRootVolumeThroughput = defaults.nodeRootVolumeThroughput;
     	      this.nodeRootVolumeType = defaults.nodeRootVolumeType;
     	      this.nodeSecurityGroup = defaults.nodeSecurityGroup;
+    	      this.nodeSecurityGroupId = defaults.nodeSecurityGroupId;
     	      this.nodeSubnetIds = defaults.nodeSubnetIds;
     	      this.nodeUserData = defaults.nodeUserData;
     	      this.nodeUserDataOverride = defaults.nodeUserDataOverride;
@@ -766,6 +808,12 @@ public final class ClusterNodeGroupOptions {
         public Builder clusterIngressRule(@Nullable SecurityGroupRule clusterIngressRule) {
 
             this.clusterIngressRule = clusterIngressRule;
+            return this;
+        }
+        @CustomType.Setter
+        public Builder clusterIngressRuleId(@Nullable String clusterIngressRuleId) {
+
+            this.clusterIngressRuleId = clusterIngressRuleId;
             return this;
         }
         @CustomType.Setter
@@ -919,6 +967,12 @@ public final class ClusterNodeGroupOptions {
             return this;
         }
         @CustomType.Setter
+        public Builder nodeSecurityGroupId(@Nullable String nodeSecurityGroupId) {
+
+            this.nodeSecurityGroupId = nodeSecurityGroupId;
+            return this;
+        }
+        @CustomType.Setter
         public Builder nodeSubnetIds(@Nullable List<String> nodeSubnetIds) {
 
             this.nodeSubnetIds = nodeSubnetIds;
@@ -981,6 +1035,7 @@ public final class ClusterNodeGroupOptions {
             _resultValue.bottlerocketSettings = bottlerocketSettings;
             _resultValue.cloudFormationTags = cloudFormationTags;
             _resultValue.clusterIngressRule = clusterIngressRule;
+            _resultValue.clusterIngressRuleId = clusterIngressRuleId;
             _resultValue.desiredCapacity = desiredCapacity;
             _resultValue.enableDetailedMonitoring = enableDetailedMonitoring;
             _resultValue.encryptRootBlockDevice = encryptRootBlockDevice;
@@ -1005,6 +1060,7 @@ public final class ClusterNodeGroupOptions {
             _resultValue.nodeRootVolumeThroughput = nodeRootVolumeThroughput;
             _resultValue.nodeRootVolumeType = nodeRootVolumeType;
             _resultValue.nodeSecurityGroup = nodeSecurityGroup;
+            _resultValue.nodeSecurityGroupId = nodeSecurityGroupId;
             _resultValue.nodeSubnetIds = nodeSubnetIds;
             _resultValue.nodeUserData = nodeUserData;
             _resultValue.nodeUserDataOverride = nodeUserDataOverride;

--- a/sdk/nodejs/nodeGroup.ts
+++ b/sdk/nodejs/nodeGroup.ts
@@ -298,7 +298,7 @@ export interface NodeGroupArgs {
      */
     nodeSecurityGroup?: pulumi.Input<pulumiAws.ec2.SecurityGroup>;
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      *
      * This security group requires specific inbound and outbound rules.
      *

--- a/sdk/nodejs/nodeGroup.ts
+++ b/sdk/nodejs/nodeGroup.ts
@@ -45,9 +45,13 @@ export class NodeGroup extends pulumi.ComponentResource {
      */
     public readonly extraNodeSecurityGroups!: pulumi.Output<pulumiAws.ec2.SecurityGroup[]>;
     /**
-     * The security group for the node group to communicate with the cluster.
+     * The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
      */
-    public readonly nodeSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup>;
+    public readonly nodeSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup | undefined>;
+    /**
+     * The ID of the security group for the node group to communicate with the cluster.
+     */
+    public readonly nodeSecurityGroupId!: pulumi.Output<string>;
 
     /**
      * Create a NodeGroup resource with the given unique name, arguments, and options.
@@ -73,6 +77,7 @@ export class NodeGroup extends pulumi.ComponentResource {
             resourceInputs["cloudFormationTags"] = args ? args.cloudFormationTags : undefined;
             resourceInputs["cluster"] = args ? args.cluster : undefined;
             resourceInputs["clusterIngressRule"] = args ? args.clusterIngressRule : undefined;
+            resourceInputs["clusterIngressRuleId"] = args ? args.clusterIngressRuleId : undefined;
             resourceInputs["desiredCapacity"] = args ? args.desiredCapacity : undefined;
             resourceInputs["enableDetailedMonitoring"] = args ? args.enableDetailedMonitoring : undefined;
             resourceInputs["encryptRootBlockDevice"] = args ? args.encryptRootBlockDevice : undefined;
@@ -94,6 +99,7 @@ export class NodeGroup extends pulumi.ComponentResource {
             resourceInputs["nodeRootVolumeThroughput"] = args ? args.nodeRootVolumeThroughput : undefined;
             resourceInputs["nodeRootVolumeType"] = args ? args.nodeRootVolumeType : undefined;
             resourceInputs["nodeSecurityGroup"] = args ? args.nodeSecurityGroup : undefined;
+            resourceInputs["nodeSecurityGroupId"] = args ? args.nodeSecurityGroupId : undefined;
             resourceInputs["nodeSubnetIds"] = args ? args.nodeSubnetIds : undefined;
             resourceInputs["nodeUserData"] = args ? args.nodeUserData : undefined;
             resourceInputs["nodeUserDataOverride"] = args ? args.nodeUserDataOverride : undefined;
@@ -109,6 +115,7 @@ export class NodeGroup extends pulumi.ComponentResource {
             resourceInputs["cfnStack"] = undefined /*out*/;
             resourceInputs["extraNodeSecurityGroups"] = undefined /*out*/;
             resourceInputs["nodeSecurityGroup"] = undefined /*out*/;
+            resourceInputs["nodeSecurityGroupId"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(NodeGroup.__pulumiType, name, resourceInputs, opts, true /*remote*/);
@@ -177,6 +184,10 @@ export interface NodeGroupArgs {
      * The ingress rule that gives node group access.
      */
     clusterIngressRule?: pulumi.Input<pulumiAws.ec2.SecurityGroupRule>;
+    /**
+     * The ID of the ingress rule that gives node group access.
+     */
+    clusterIngressRuleId?: pulumi.Input<string>;
     /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      */
@@ -286,6 +297,17 @@ export interface NodeGroupArgs {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      */
     nodeSecurityGroup?: pulumi.Input<pulumiAws.ec2.SecurityGroup>;
+    /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     *
+     * This security group requires specific inbound and outbound rules.
+     *
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     *
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     */
+    nodeSecurityGroupId?: pulumi.Input<string>;
     /**
      * The set of subnets to override and use for the worker node group.
      *

--- a/sdk/nodejs/nodeGroupV2.ts
+++ b/sdk/nodejs/nodeGroupV2.ts
@@ -39,9 +39,13 @@ export class NodeGroupV2 extends pulumi.ComponentResource {
      */
     public readonly extraNodeSecurityGroups!: pulumi.Output<pulumiAws.ec2.SecurityGroup[]>;
     /**
-     * The security group for the node group to communicate with the cluster.
+     * The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
      */
-    public readonly nodeSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup>;
+    public readonly nodeSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup | undefined>;
+    /**
+     * The ID of the security group for the node group to communicate with the cluster.
+     */
+    public readonly nodeSecurityGroupId!: pulumi.Output<string>;
 
     /**
      * Create a NodeGroupV2 resource with the given unique name, arguments, and options.
@@ -65,6 +69,7 @@ export class NodeGroupV2 extends pulumi.ComponentResource {
             resourceInputs["cloudFormationTags"] = args ? args.cloudFormationTags : undefined;
             resourceInputs["cluster"] = args ? args.cluster : undefined;
             resourceInputs["clusterIngressRule"] = args ? args.clusterIngressRule : undefined;
+            resourceInputs["clusterIngressRuleId"] = args ? args.clusterIngressRuleId : undefined;
             resourceInputs["desiredCapacity"] = args ? args.desiredCapacity : undefined;
             resourceInputs["enableDetailedMonitoring"] = args ? args.enableDetailedMonitoring : undefined;
             resourceInputs["encryptRootBlockDevice"] = args ? args.encryptRootBlockDevice : undefined;
@@ -89,6 +94,7 @@ export class NodeGroupV2 extends pulumi.ComponentResource {
             resourceInputs["nodeRootVolumeThroughput"] = args ? args.nodeRootVolumeThroughput : undefined;
             resourceInputs["nodeRootVolumeType"] = args ? args.nodeRootVolumeType : undefined;
             resourceInputs["nodeSecurityGroup"] = args ? args.nodeSecurityGroup : undefined;
+            resourceInputs["nodeSecurityGroupId"] = args ? args.nodeSecurityGroupId : undefined;
             resourceInputs["nodeSubnetIds"] = args ? args.nodeSubnetIds : undefined;
             resourceInputs["nodeUserData"] = args ? args.nodeUserData : undefined;
             resourceInputs["nodeUserDataOverride"] = args ? args.nodeUserDataOverride : undefined;
@@ -102,6 +108,7 @@ export class NodeGroupV2 extends pulumi.ComponentResource {
             resourceInputs["autoScalingGroup"] = undefined /*out*/;
             resourceInputs["extraNodeSecurityGroups"] = undefined /*out*/;
             resourceInputs["nodeSecurityGroup"] = undefined /*out*/;
+            resourceInputs["nodeSecurityGroupId"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(NodeGroupV2.__pulumiType, name, resourceInputs, opts, true /*remote*/);
@@ -170,6 +177,10 @@ export interface NodeGroupV2Args {
      * The ingress rule that gives node group access.
      */
     clusterIngressRule?: pulumi.Input<pulumiAws.ec2.SecurityGroupRule>;
+    /**
+     * The ID of the ingress rule that gives node group access.
+     */
+    clusterIngressRuleId?: pulumi.Input<string>;
     /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      */
@@ -293,6 +304,17 @@ export interface NodeGroupV2Args {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      */
     nodeSecurityGroup?: pulumi.Input<pulumiAws.ec2.SecurityGroup>;
+    /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     *
+     * This security group requires specific inbound and outbound rules.
+     *
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     *
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     */
+    nodeSecurityGroupId?: pulumi.Input<string>;
     /**
      * The set of subnets to override and use for the worker node group.
      *

--- a/sdk/nodejs/nodeGroupV2.ts
+++ b/sdk/nodejs/nodeGroupV2.ts
@@ -305,7 +305,7 @@ export interface NodeGroupV2Args {
      */
     nodeSecurityGroup?: pulumi.Input<pulumiAws.ec2.SecurityGroup>;
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      *
      * This security group requires specific inbound and outbound rules.
      *

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -249,7 +249,7 @@ export interface ClusterNodeGroupOptionsArgs {
      */
     nodeSecurityGroup?: pulumi.Input<pulumiAws.ec2.SecurityGroup>;
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      *
      * This security group requires specific inbound and outbound rules.
      *

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -122,6 +122,10 @@ export interface ClusterNodeGroupOptionsArgs {
      */
     clusterIngressRule?: pulumi.Input<pulumiAws.ec2.SecurityGroupRule>;
     /**
+     * The ID of the ingress rule that gives node group access.
+     */
+    clusterIngressRuleId?: pulumi.Input<string>;
+    /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      */
     desiredCapacity?: pulumi.Input<number>;
@@ -244,6 +248,17 @@ export interface ClusterNodeGroupOptionsArgs {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      */
     nodeSecurityGroup?: pulumi.Input<pulumiAws.ec2.SecurityGroup>;
+    /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     *
+     * This security group requires specific inbound and outbound rules.
+     *
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     *
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     */
+    nodeSecurityGroupId?: pulumi.Input<string>;
     /**
      * The set of subnets to override and use for the worker node group.
      *

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -249,7 +249,7 @@ export interface ClusterNodeGroupOptions {
      */
     nodeSecurityGroup?: pulumiAws.ec2.SecurityGroup;
     /**
-     * The security group ID for the worker node group to communicate with the cluster.
+     * The ID of the security group for the worker node group to communicate with the cluster.
      *
      * This security group requires specific inbound and outbound rules.
      *

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -122,6 +122,10 @@ export interface ClusterNodeGroupOptions {
      */
     clusterIngressRule?: pulumiAws.ec2.SecurityGroupRule;
     /**
+     * The ID of the ingress rule that gives node group access.
+     */
+    clusterIngressRuleId?: string;
+    /**
      * The number of worker nodes that should be running in the cluster. Defaults to 2.
      */
     desiredCapacity?: number;
@@ -244,6 +248,17 @@ export interface ClusterNodeGroupOptions {
      * Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
      */
     nodeSecurityGroup?: pulumiAws.ec2.SecurityGroup;
+    /**
+     * The security group ID for the worker node group to communicate with the cluster.
+     *
+     * This security group requires specific inbound and outbound rules.
+     *
+     * See for more details:
+     * https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+     *
+     * Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+     */
+    nodeSecurityGroupId?: string;
     /**
      * The set of subnets to override and use for the worker node group.
      *

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -445,7 +445,7 @@ if not MYPY:
         """
         node_security_group_id: NotRequired[pulumi.Input[str]]
         """
-        The security group ID for the worker node group to communicate with the cluster.
+        The ID of the security group for the worker node group to communicate with the cluster.
 
         This security group requires specific inbound and outbound rules.
 
@@ -637,7 +637,7 @@ class ClusterNodeGroupOptionsArgs:
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+        :param pulumi.Input[str] node_security_group_id: The ID of the security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -1195,7 +1195,7 @@ class ClusterNodeGroupOptionsArgs:
     @pulumi.getter(name="nodeSecurityGroupId")
     def node_security_group_id(self) -> Optional[pulumi.Input[str]]:
         """
-        The security group ID for the worker node group to communicate with the cluster.
+        The ID of the security group for the worker node group to communicate with the cluster.
 
         This security group requires specific inbound and outbound rules.
 

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -316,6 +316,10 @@ if not MYPY:
         """
         The ingress rule that gives node group access.
         """
+        cluster_ingress_rule_id: NotRequired[pulumi.Input[str]]
+        """
+        The ID of the ingress rule that gives node group access.
+        """
         desired_capacity: NotRequired[pulumi.Input[int]]
         """
         The number of worker nodes that should be running in the cluster. Defaults to 2.
@@ -439,6 +443,17 @@ if not MYPY:
 
         Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         """
+        node_security_group_id: NotRequired[pulumi.Input[str]]
+        """
+        The security group ID for the worker node group to communicate with the cluster.
+
+        This security group requires specific inbound and outbound rules.
+
+        See for more details:
+        https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+
+        Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        """
         node_subnet_ids: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
         """
         The set of subnets to override and use for the worker node group.
@@ -501,6 +516,7 @@ class ClusterNodeGroupOptionsArgs:
                  bottlerocket_settings: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -525,6 +541,7 @@ class ClusterNodeGroupOptionsArgs:
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -568,6 +585,7 @@ class ClusterNodeGroupOptionsArgs:
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input[str] cluster_ingress_rule_id: The ID of the ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
@@ -619,6 +637,14 @@ class ClusterNodeGroupOptionsArgs:
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+               
+               This security group requires specific inbound and outbound rules.
+               
+               See for more details:
+               https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+               
+               Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] node_subnet_ids: The set of subnets to override and use for the worker node group.
                
                Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -659,6 +685,8 @@ class ClusterNodeGroupOptionsArgs:
             pulumi.set(__self__, "cloud_formation_tags", cloud_formation_tags)
         if cluster_ingress_rule is not None:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
+        if cluster_ingress_rule_id is not None:
+            pulumi.set(__self__, "cluster_ingress_rule_id", cluster_ingress_rule_id)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
         if enable_detailed_monitoring is not None:
@@ -707,6 +735,8 @@ class ClusterNodeGroupOptionsArgs:
             pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
+        if node_security_group_id is not None:
+            pulumi.set(__self__, "node_security_group_id", node_security_group_id)
         if node_subnet_ids is not None:
             pulumi.set(__self__, "node_subnet_ids", node_subnet_ids)
         if node_user_data is not None:
@@ -833,6 +863,18 @@ class ClusterNodeGroupOptionsArgs:
     @cluster_ingress_rule.setter
     def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
         pulumi.set(self, "cluster_ingress_rule", value)
+
+    @property
+    @pulumi.getter(name="clusterIngressRuleId")
+    def cluster_ingress_rule_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The ID of the ingress rule that gives node group access.
+        """
+        return pulumi.get(self, "cluster_ingress_rule_id")
+
+    @cluster_ingress_rule_id.setter
+    def cluster_ingress_rule_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "cluster_ingress_rule_id", value)
 
     @property
     @pulumi.getter(name="desiredCapacity")
@@ -1148,6 +1190,25 @@ class ClusterNodeGroupOptionsArgs:
     @node_security_group.setter
     def node_security_group(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']]):
         pulumi.set(self, "node_security_group", value)
+
+    @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The security group ID for the worker node group to communicate with the cluster.
+
+        This security group requires specific inbound and outbound rules.
+
+        See for more details:
+        https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+
+        Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        """
+        return pulumi.get(self, "node_security_group_id")
+
+    @node_security_group_id.setter
+    def node_security_group_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_security_group_id", value)
 
     @property
     @pulumi.getter(name="nodeSubnetIds")

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -147,7 +147,7 @@ class NodeGroupArgs:
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+        :param pulumi.Input[str] node_security_group_id: The ID of the security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -674,7 +674,7 @@ class NodeGroupArgs:
     @pulumi.getter(name="nodeSecurityGroupId")
     def node_security_group_id(self) -> Optional[pulumi.Input[str]]:
         """
-        The security group ID for the worker node group to communicate with the cluster.
+        The ID of the security group for the worker node group to communicate with the cluster.
 
         This security group requires specific inbound and outbound rules.
 
@@ -939,7 +939,7 @@ class NodeGroup(pulumi.ComponentResource):
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+        :param pulumi.Input[str] node_security_group_id: The ID of the security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                

--- a/sdk/python/pulumi_eks/node_group.py
+++ b/sdk/python/pulumi_eks/node_group.py
@@ -33,6 +33,7 @@ class NodeGroupArgs:
                  bottlerocket_settings: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -54,6 +55,7 @@ class NodeGroupArgs:
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -98,6 +100,7 @@ class NodeGroupArgs:
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input[str] cluster_ingress_rule_id: The ID of the ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
@@ -144,6 +147,14 @@ class NodeGroupArgs:
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+               
+               This security group requires specific inbound and outbound rules.
+               
+               See for more details:
+               https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+               
+               Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] node_subnet_ids: The set of subnets to override and use for the worker node group.
                
                Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -185,6 +196,8 @@ class NodeGroupArgs:
             pulumi.set(__self__, "cloud_formation_tags", cloud_formation_tags)
         if cluster_ingress_rule is not None:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
+        if cluster_ingress_rule_id is not None:
+            pulumi.set(__self__, "cluster_ingress_rule_id", cluster_ingress_rule_id)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
         if enable_detailed_monitoring is not None:
@@ -227,6 +240,8 @@ class NodeGroupArgs:
             pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
+        if node_security_group_id is not None:
+            pulumi.set(__self__, "node_security_group_id", node_security_group_id)
         if node_subnet_ids is not None:
             pulumi.set(__self__, "node_subnet_ids", node_subnet_ids)
         if node_user_data is not None:
@@ -365,6 +380,18 @@ class NodeGroupArgs:
     @cluster_ingress_rule.setter
     def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
         pulumi.set(self, "cluster_ingress_rule", value)
+
+    @property
+    @pulumi.getter(name="clusterIngressRuleId")
+    def cluster_ingress_rule_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The ID of the ingress rule that gives node group access.
+        """
+        return pulumi.get(self, "cluster_ingress_rule_id")
+
+    @cluster_ingress_rule_id.setter
+    def cluster_ingress_rule_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "cluster_ingress_rule_id", value)
 
     @property
     @pulumi.getter(name="desiredCapacity")
@@ -644,6 +671,25 @@ class NodeGroupArgs:
         pulumi.set(self, "node_security_group", value)
 
     @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The security group ID for the worker node group to communicate with the cluster.
+
+        This security group requires specific inbound and outbound rules.
+
+        See for more details:
+        https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+
+        Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        """
+        return pulumi.get(self, "node_security_group_id")
+
+    @node_security_group_id.setter
+    def node_security_group_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_security_group_id", value)
+
+    @property
     @pulumi.getter(name="nodeSubnetIds")
     def node_subnet_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
@@ -775,6 +821,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -796,6 +843,7 @@ class NodeGroup(pulumi.ComponentResource):
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -844,6 +892,7 @@ class NodeGroup(pulumi.ComponentResource):
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]] cluster: The target EKS cluster.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input[str] cluster_ingress_rule_id: The ID of the ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
@@ -890,6 +939,14 @@ class NodeGroup(pulumi.ComponentResource):
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+               
+               This security group requires specific inbound and outbound rules.
+               
+               See for more details:
+               https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+               
+               Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] node_subnet_ids: The set of subnets to override and use for the worker node group.
                
                Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -948,6 +1005,7 @@ class NodeGroup(pulumi.ComponentResource):
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -969,6 +1027,7 @@ class NodeGroup(pulumi.ComponentResource):
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -999,6 +1058,7 @@ class NodeGroup(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'cluster'")
             __props__.__dict__["cluster"] = cluster
             __props__.__dict__["cluster_ingress_rule"] = cluster_ingress_rule
+            __props__.__dict__["cluster_ingress_rule_id"] = cluster_ingress_rule_id
             __props__.__dict__["desired_capacity"] = desired_capacity
             __props__.__dict__["enable_detailed_monitoring"] = enable_detailed_monitoring
             __props__.__dict__["encrypt_root_block_device"] = encrypt_root_block_device
@@ -1020,6 +1080,7 @@ class NodeGroup(pulumi.ComponentResource):
             __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
             __props__.__dict__["node_root_volume_type"] = node_root_volume_type
             __props__.__dict__["node_security_group"] = node_security_group
+            __props__.__dict__["node_security_group_id"] = node_security_group_id
             __props__.__dict__["node_subnet_ids"] = node_subnet_ids
             __props__.__dict__["node_user_data"] = node_user_data
             __props__.__dict__["node_user_data_override"] = node_user_data_override
@@ -1063,9 +1124,17 @@ class NodeGroup(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> pulumi.Output['pulumi_aws.ec2.SecurityGroup']:
+    def node_security_group(self) -> pulumi.Output[Optional['pulumi_aws.ec2.SecurityGroup']]:
         """
-        The security group for the node group to communicate with the cluster.
+        The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
         """
         return pulumi.get(self, "node_security_group")
+
+    @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> pulumi.Output[str]:
+        """
+        The ID of the security group for the node group to communicate with the cluster.
+        """
+        return pulumi.get(self, "node_security_group_id")
 

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -33,6 +33,7 @@ class NodeGroupV2Args:
                  bottlerocket_settings: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -57,6 +58,7 @@ class NodeGroupV2Args:
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -101,6 +103,7 @@ class NodeGroupV2Args:
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input[str] cluster_ingress_rule_id: The ID of the ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
@@ -152,6 +155,14 @@ class NodeGroupV2Args:
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+               
+               This security group requires specific inbound and outbound rules.
+               
+               See for more details:
+               https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+               
+               Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] node_subnet_ids: The set of subnets to override and use for the worker node group.
                
                Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -193,6 +204,8 @@ class NodeGroupV2Args:
             pulumi.set(__self__, "cloud_formation_tags", cloud_formation_tags)
         if cluster_ingress_rule is not None:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
+        if cluster_ingress_rule_id is not None:
+            pulumi.set(__self__, "cluster_ingress_rule_id", cluster_ingress_rule_id)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
         if enable_detailed_monitoring is not None:
@@ -241,6 +254,8 @@ class NodeGroupV2Args:
             pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
+        if node_security_group_id is not None:
+            pulumi.set(__self__, "node_security_group_id", node_security_group_id)
         if node_subnet_ids is not None:
             pulumi.set(__self__, "node_subnet_ids", node_subnet_ids)
         if node_user_data is not None:
@@ -379,6 +394,18 @@ class NodeGroupV2Args:
     @cluster_ingress_rule.setter
     def cluster_ingress_rule(self, value: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']]):
         pulumi.set(self, "cluster_ingress_rule", value)
+
+    @property
+    @pulumi.getter(name="clusterIngressRuleId")
+    def cluster_ingress_rule_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The ID of the ingress rule that gives node group access.
+        """
+        return pulumi.get(self, "cluster_ingress_rule_id")
+
+    @cluster_ingress_rule_id.setter
+    def cluster_ingress_rule_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "cluster_ingress_rule_id", value)
 
     @property
     @pulumi.getter(name="desiredCapacity")
@@ -696,6 +723,25 @@ class NodeGroupV2Args:
         pulumi.set(self, "node_security_group", value)
 
     @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The security group ID for the worker node group to communicate with the cluster.
+
+        This security group requires specific inbound and outbound rules.
+
+        See for more details:
+        https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+
+        Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        """
+        return pulumi.get(self, "node_security_group_id")
+
+    @node_security_group_id.setter
+    def node_security_group_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "node_security_group_id", value)
+
+    @property
     @pulumi.getter(name="nodeSubnetIds")
     def node_subnet_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
@@ -822,6 +868,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -846,6 +893,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -894,6 +942,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]] cluster: The target EKS cluster.
         :param pulumi.Input['pulumi_aws.ec2.SecurityGroupRule'] cluster_ingress_rule: The ingress rule that gives node group access.
+        :param pulumi.Input[str] cluster_ingress_rule_id: The ID of the ingress rule that gives node group access.
         :param pulumi.Input[int] desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param pulumi.Input[bool] enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
@@ -945,6 +994,14 @@ class NodeGroupV2(pulumi.ComponentResource):
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+               
+               This security group requires specific inbound and outbound rules.
+               
+               See for more details:
+               https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+               
+               Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] node_subnet_ids: The set of subnets to override and use for the worker node group.
                
                Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -1003,6 +1060,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  cloud_formation_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster: Optional[pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]]] = None,
                  cluster_ingress_rule: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroupRule']] = None,
+                 cluster_ingress_rule_id: Optional[pulumi.Input[str]] = None,
                  desired_capacity: Optional[pulumi.Input[int]] = None,
                  enable_detailed_monitoring: Optional[pulumi.Input[bool]] = None,
                  encrypt_root_block_device: Optional[pulumi.Input[bool]] = None,
@@ -1027,6 +1085,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                  node_root_volume_throughput: Optional[pulumi.Input[int]] = None,
                  node_root_volume_type: Optional[pulumi.Input[str]] = None,
                  node_security_group: Optional[pulumi.Input['pulumi_aws.ec2.SecurityGroup']] = None,
+                 node_security_group_id: Optional[pulumi.Input[str]] = None,
                  node_subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  node_user_data: Optional[pulumi.Input[str]] = None,
                  node_user_data_override: Optional[pulumi.Input[str]] = None,
@@ -1056,6 +1115,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'cluster'")
             __props__.__dict__["cluster"] = cluster
             __props__.__dict__["cluster_ingress_rule"] = cluster_ingress_rule
+            __props__.__dict__["cluster_ingress_rule_id"] = cluster_ingress_rule_id
             __props__.__dict__["desired_capacity"] = desired_capacity
             __props__.__dict__["enable_detailed_monitoring"] = enable_detailed_monitoring
             __props__.__dict__["encrypt_root_block_device"] = encrypt_root_block_device
@@ -1080,6 +1140,7 @@ class NodeGroupV2(pulumi.ComponentResource):
             __props__.__dict__["node_root_volume_throughput"] = node_root_volume_throughput
             __props__.__dict__["node_root_volume_type"] = node_root_volume_type
             __props__.__dict__["node_security_group"] = node_security_group
+            __props__.__dict__["node_security_group_id"] = node_security_group_id
             __props__.__dict__["node_subnet_ids"] = node_subnet_ids
             __props__.__dict__["node_user_data"] = node_user_data
             __props__.__dict__["node_user_data_override"] = node_user_data_override
@@ -1114,9 +1175,17 @@ class NodeGroupV2(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="nodeSecurityGroup")
-    def node_security_group(self) -> pulumi.Output['pulumi_aws.ec2.SecurityGroup']:
+    def node_security_group(self) -> pulumi.Output[Optional['pulumi_aws.ec2.SecurityGroup']]:
         """
-        The security group for the node group to communicate with the cluster.
+        The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`.
         """
         return pulumi.get(self, "node_security_group")
+
+    @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> pulumi.Output[str]:
+        """
+        The ID of the security group for the node group to communicate with the cluster.
+        """
+        return pulumi.get(self, "node_security_group_id")
 

--- a/sdk/python/pulumi_eks/node_group_v2.py
+++ b/sdk/python/pulumi_eks/node_group_v2.py
@@ -155,7 +155,7 @@ class NodeGroupV2Args:
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+        :param pulumi.Input[str] node_security_group_id: The ID of the security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -726,7 +726,7 @@ class NodeGroupV2Args:
     @pulumi.getter(name="nodeSecurityGroupId")
     def node_security_group_id(self) -> Optional[pulumi.Input[str]]:
         """
-        The security group ID for the worker node group to communicate with the cluster.
+        The ID of the security group for the worker node group to communicate with the cluster.
 
         This security group requires specific inbound and outbound rules.
 
@@ -994,7 +994,7 @@ class NodeGroupV2(pulumi.ComponentResource):
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-        :param pulumi.Input[str] node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+        :param pulumi.Input[str] node_security_group_id: The ID of the security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -220,6 +220,8 @@ class ClusterNodeGroupOptions(dict):
             suggest = "cloud_formation_tags"
         elif key == "clusterIngressRule":
             suggest = "cluster_ingress_rule"
+        elif key == "clusterIngressRuleId":
+            suggest = "cluster_ingress_rule_id"
         elif key == "desiredCapacity":
             suggest = "desired_capacity"
         elif key == "enableDetailedMonitoring":
@@ -264,6 +266,8 @@ class ClusterNodeGroupOptions(dict):
             suggest = "node_root_volume_type"
         elif key == "nodeSecurityGroup":
             suggest = "node_security_group"
+        elif key == "nodeSecurityGroupId":
+            suggest = "node_security_group_id"
         elif key == "nodeSubnetIds":
             suggest = "node_subnet_ids"
         elif key == "nodeUserData":
@@ -296,6 +300,7 @@ class ClusterNodeGroupOptions(dict):
                  bottlerocket_settings: Optional[Mapping[str, Any]] = None,
                  cloud_formation_tags: Optional[Mapping[str, str]] = None,
                  cluster_ingress_rule: Optional['pulumi_aws.ec2.SecurityGroupRule'] = None,
+                 cluster_ingress_rule_id: Optional[str] = None,
                  desired_capacity: Optional[int] = None,
                  enable_detailed_monitoring: Optional[bool] = None,
                  encrypt_root_block_device: Optional[bool] = None,
@@ -320,6 +325,7 @@ class ClusterNodeGroupOptions(dict):
                  node_root_volume_throughput: Optional[int] = None,
                  node_root_volume_type: Optional[str] = None,
                  node_security_group: Optional['pulumi_aws.ec2.SecurityGroup'] = None,
+                 node_security_group_id: Optional[str] = None,
                  node_subnet_ids: Optional[Sequence[str]] = None,
                  node_user_data: Optional[str] = None,
                  node_user_data_override: Optional[str] = None,
@@ -363,6 +369,7 @@ class ClusterNodeGroupOptions(dict):
                
                Note: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both.
         :param 'pulumi_aws.ec2.SecurityGroupRule' cluster_ingress_rule: The ingress rule that gives node group access.
+        :param str cluster_ingress_rule_id: The ID of the ingress rule that gives node group access.
         :param int desired_capacity: The number of worker nodes that should be running in the cluster. Defaults to 2.
         :param bool enable_detailed_monitoring: Enables/disables detailed monitoring of the EC2 instances.
                
@@ -414,6 +421,14 @@ class ClusterNodeGroupOptions(dict):
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
+        :param str node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+               
+               This security group requires specific inbound and outbound rules.
+               
+               See for more details:
+               https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+               
+               Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
         :param Sequence[str] node_subnet_ids: The set of subnets to override and use for the worker node group.
                
                Setting this option overrides which subnets to use for the worker node group, regardless if the cluster's `subnetIds` is set, or if `publicSubnetIds` and/or `privateSubnetIds` were set.
@@ -454,6 +469,8 @@ class ClusterNodeGroupOptions(dict):
             pulumi.set(__self__, "cloud_formation_tags", cloud_formation_tags)
         if cluster_ingress_rule is not None:
             pulumi.set(__self__, "cluster_ingress_rule", cluster_ingress_rule)
+        if cluster_ingress_rule_id is not None:
+            pulumi.set(__self__, "cluster_ingress_rule_id", cluster_ingress_rule_id)
         if desired_capacity is not None:
             pulumi.set(__self__, "desired_capacity", desired_capacity)
         if enable_detailed_monitoring is not None:
@@ -502,6 +519,8 @@ class ClusterNodeGroupOptions(dict):
             pulumi.set(__self__, "node_root_volume_type", node_root_volume_type)
         if node_security_group is not None:
             pulumi.set(__self__, "node_security_group", node_security_group)
+        if node_security_group_id is not None:
+            pulumi.set(__self__, "node_security_group_id", node_security_group_id)
         if node_subnet_ids is not None:
             pulumi.set(__self__, "node_subnet_ids", node_subnet_ids)
         if node_user_data is not None:
@@ -600,6 +619,14 @@ class ClusterNodeGroupOptions(dict):
         The ingress rule that gives node group access.
         """
         return pulumi.get(self, "cluster_ingress_rule")
+
+    @property
+    @pulumi.getter(name="clusterIngressRuleId")
+    def cluster_ingress_rule_id(self) -> Optional[str]:
+        """
+        The ID of the ingress rule that gives node group access.
+        """
+        return pulumi.get(self, "cluster_ingress_rule_id")
 
     @property
     @pulumi.getter(name="desiredCapacity")
@@ -819,6 +846,21 @@ class ClusterNodeGroupOptions(dict):
         Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
         """
         return pulumi.get(self, "node_security_group")
+
+    @property
+    @pulumi.getter(name="nodeSecurityGroupId")
+    def node_security_group_id(self) -> Optional[str]:
+        """
+        The security group ID for the worker node group to communicate with the cluster.
+
+        This security group requires specific inbound and outbound rules.
+
+        See for more details:
+        https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+
+        Note: The `nodeSecurityGroupId` option and the cluster option `nodeSecurityGroupTags` are mutually exclusive.
+        """
+        return pulumi.get(self, "node_security_group_id")
 
     @property
     @pulumi.getter(name="nodeSubnetIds")

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -421,7 +421,7 @@ class ClusterNodeGroupOptions(dict):
                https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
                
                Note: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive.
-        :param str node_security_group_id: The security group ID for the worker node group to communicate with the cluster.
+        :param str node_security_group_id: The ID of the security group for the worker node group to communicate with the cluster.
                
                This security group requires specific inbound and outbound rules.
                
@@ -851,7 +851,7 @@ class ClusterNodeGroupOptions(dict):
     @pulumi.getter(name="nodeSecurityGroupId")
     def node_security_group_id(self) -> Optional[str]:
         """
-        The security group ID for the worker node group to communicate with the cluster.
+        The ID of the security group for the worker node group to communicate with the cluster.
 
         This security group requires specific inbound and outbound rules.
 


### PR DESCRIPTION
This change builds on top of https://github.com/pulumi/pulumi-eks/pull/1445 and makes `NodeGroup` & `NodeGroupV2` accept the scalar security group properties introduced in that PR.

This way users can connect their node groups to the cluster without having to use any applies.