### PR TITLE
Add validation for public access CIDR

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -587,7 +587,19 @@ export function createCore(
                 subnetIds: clusterSubnetIds,
                 endpointPrivateAccess: args.endpointPrivateAccess,
                 endpointPublicAccess: args.endpointPublicAccess,
-                publicAccessCidrs: args.publicAccessCidrs,
+                publicAccessCidrs: args.publicAccessCidrs
+                    ? pulumi
+                          .all([args.publicAccessCidrs, args.endpointPublicAccess ?? true])
+                          .apply(([cidrs, publicAccess]) => {
+                              if (!publicAccess && cidrs) {
+                                  throw new pulumi.ResourceError(
+                                      "`publicAccessCidrs` can only be set when `endpointPublicAccess` is true",
+                                      eksCluster,
+                                  );
+                              }
+                              return cidrs;
+                          })
+                    : undefined,
             },
             version: args.version,
             enabledClusterLogTypes: args.enabledClusterLogTypes,


### PR DESCRIPTION
Setting public access CIDRs with public access disabled does not work, but the EKS service doesn't validate this case.
This can lead (and has) to very confusing debugging sessions à la "why can my IP not access the cluster endpoint, it's included in the public access CIDR range!".

This change adds validation for the public access CIDR.

Fixes https://github.com/pulumi/pulumi-eks/issues/1436