### PR TITLE
Fix ManagedNodeGroup with custom launch template and AMI type

### DIFF
--- a/examples/tests/managed-ng-os/index.ts
+++ b/examples/tests/managed-ng-os/index.ts
@@ -54,6 +54,16 @@ const managedNodeGroupAL2023 = eks.createManagedNodeGroup("al-2023-mng", {
   nodeRole: role,
 });
 
+// Create a node group with a launch template and custom AMI
+const managedNodeGroup = new eks.ManagedNodeGroup("al-2023-mng-amitype-launch-template", {
+  ...scalingConfig,
+  cluster: cluster,
+  nodeRole: role,
+  amiType: "AL2023_ARM_64_STANDARD",
+  instanceTypes: ["t4g.medium"],
+  kubeletExtraArgs: "--max-pods=110",
+});
+
 const managedNodeGroupAL2023Taints = eks.createManagedNodeGroup("al-2023-mng-taints", {
   ...scalingConfig,
   cluster: cluster,

--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -2089,6 +2089,7 @@ export function createManagedNodeGroupInternal(
         delete nodeGroupArgs.version;
         delete nodeGroupArgs.releaseVersion;
         delete nodeGroupArgs.amiType;
+        amiType = undefined;
     } else if (amiType === undefined && args.operatingSystem !== undefined) {
         // if no ami type is provided, but operating system is provided, determine the ami type based on the operating system
 


### PR DESCRIPTION
When creating an EKS managed NodeGroup with a custom launch template, the AMI type must be removed from the nodegroup itself and instead specified in the launch template.
This did not work if the user specified the AMI type instead of the provider determining it.

This change fixes that by correctly omitting the user defined AMI type as well in that case.

Fixes #1463 
