### PR TITLE
Add region to kubeconfig

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -209,7 +209,7 @@ export function generateKubeconfig(
     opts?: KubeconfigOptions,
 ) {
     let args = [
-        "region",
+        "--region",
         region,
         "eks",
         "get-token",

--- a/nodejs/eks/utilities.test.ts
+++ b/nodejs/eks/utilities.test.ts
@@ -1,0 +1,47 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getRegionFromArn } from "./utilities";
+
+describe("getRegionFromArn", () => {
+    test.each([
+        ["arn:aws:eks:us-east-1:123456789012:cluster/my-awesome-cluster", "us-east-1"],
+        ["arn:aws:eks:us-west-2:123456789012:cluster/my-awesome-cluster", "us-west-2"],
+        ["arn:aws-cn:eks:cn-north-1:123456789012:cluster/my-awesome-cluster", "cn-north-1"],
+        [
+            "arn:aws-us-gov:eks:us-gov-west-1:123456789012:cluster/my-awesome-cluster",
+            "us-gov-west-1",
+        ],
+    ])("should extract the region from the ARN", (arn, expected) => {
+        const region = getRegionFromArn(arn);
+        expect(region).toEqual(expected);
+    });
+
+    it("should throw an error for an ARN with less than 4 parts", () => {
+        const arn = "arn:aws:service";
+        expect(() => getRegionFromArn(arn)).toThrow("Invalid ARN: 'arn:aws:service'");
+    });
+
+    it("should throw an error for an ARN not starting with 'arn'", () => {
+        const arn = "invalid:aws:service:region:account-id:resource";
+        expect(() => getRegionFromArn(arn)).toThrow(
+            "Invalid ARN: 'invalid:aws:service:region:account-id:resource'",
+        );
+    });
+
+    it("should throw an error for an empty ARN", () => {
+        const arn = "";
+        expect(() => getRegionFromArn(arn)).toThrow("Invalid ARN: ''");
+    });
+});

--- a/nodejs/eks/utilities.ts
+++ b/nodejs/eks/utilities.ts
@@ -26,3 +26,18 @@ export function getVersion(): string {
 export function isObject(obj: any): obj is Record<string, any> {
     return obj !== null && typeof obj === "object" && !Array.isArray(obj);
 }
+
+/**
+ * Extracts the AWS region from an Amazon Resource Name (ARN).
+ *
+ * @param arn - The ARN from which to extract the region.
+ * @returns The region extracted from the ARN.
+ * @throws Will throw an error if the ARN is invalid.
+ */
+export function getRegionFromArn(arn: string): string {
+    const arnParts = arn.split(":");
+    if (arnParts.length < 4 || arnParts[0] !== "arn") {
+        throw new Error(`Invalid ARN: '${arn}'`);
+    }
+    return arnParts[3];
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

The generated kubeconfig is missing the region argument. This can lead to issues in many scenarios, e.g. when a user has `AWS_DEFAULT_REGION` set or when they have no default region set and use the provider configuration for setting the pulumi region (i.e. `aws:region`).

This change uses the cluster ARN to identify the cluster's region and sets it in the kubeconfig.

### Related issues (optional)

Fixes #1038 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
