### PR TITLE
Add a postUpgradeTask to regenerate schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ build:: schema provider build_nodejs build_python build_go build_dotnet build_ja
 schema::
 	(cd provider/cmd/$(CODEGEN) && go run main.go schema ../$(PROVIDER) $(VERSION_GENERIC))
 
+# Renovate can re-build our schema as a postUpgradeTask.
+renovte: schema
+
 provider:: bin/${PROVIDER}
 
 .pulumi/bin/pulumi: PULUMI_VERSION := $(shell cd nodejs/eks && yarn list --pattern @pulumi/pulumi --json --no-progress | jq -r '.data.trees[].name' | cut -d'@' -f3)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ schema::
 	(cd provider/cmd/$(CODEGEN) && go run main.go schema ../$(PROVIDER) $(VERSION_GENERIC))
 
 # Renovate can re-build our schema as a postUpgradeTask.
-renovte: schema
+renovate: schema
 
 provider:: bin/${PROVIDER}
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,18 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>pulumi/renovate-config//default.json5"],
+  packageRules: [
+    {
+      // Regenerate the schema if aws, k8s, or pu/pu are bumped.
+      matchPackageNames: [
+        "@pulumi/aws",
+        "@pulumi/kubernetes",
+        "github.com/pulumi/pulumi/pkg/v3",
+      ],
+      postUpgradeTasks: {
+        commands: ["make renovate"],
+        executionMode: "branch", // Only run once.
+      },
+    },
+  ],
+}


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi-cdk/pull/267, although I'm less confident `go run` will work inside Renovate. Worth a shot! If this does

Re-generate the schema whenever we bump codegen, aws, or k8s.

Edit: SDK steps will still need at least gradle, etc. Moving this to WIP.