### PR TITLE
Allow creating default instance role even when no default node group is created

### DIFF
--- a/nodejs/eks/cluster.ts
+++ b/nodejs/eks/cluster.ts
@@ -824,7 +824,10 @@ export function createCore(
         }
         instanceRoles = pulumi.output([args.instanceRole]);
         defaultInstanceRole = pulumi.output(args.instanceRole);
-    } else if (!args.skipDefaultNodeGroup) {
+    } else if (
+        args.createInstanceRole ||
+        (!args.skipDefaultNodeGroup && args.createInstanceRole === undefined)
+    ) {
         const instanceRole = new ServiceRole(
             `${name}-instanceRole`,
             {
@@ -1772,6 +1775,13 @@ export interface ClusterOptions {
      * See for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/access-entries.html
      */
     accessEntries?: { [key: string]: AccessEntry };
+
+    /**
+     * Whether to create the instance role for the EKS cluster.
+     * Defaults to true when using the default node group, false otherwise.
+     * If set to false when using the default node group, an instance role or instance profile must be provided.
+     */
+    createInstanceRole?: boolean;
 }
 
 /**

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -762,6 +762,16 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 						},
 						Description: "Options for managing the `kube-proxy` addon.",
 					},
+					"createInstanceRole": {
+						TypeSpec: schema.TypeSpec{
+							Type:  "boolean",
+							Plain: true,
+						},
+						Description: "Whether to create the instance role for the EKS cluster. " +
+							"Defaults to true when using the default node group, false otherwise.\n" +
+							"If set to false when using the default node group, an instance role or instance profile must be provided.n\n" +
+							"Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.",
+					},
 				},
 				Methods: map[string]string{
 					"getKubeconfig": "eks:index:Cluster/getKubeconfig",

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -1220,6 +1220,11 @@
                     "plain": true,
                     "description": "Options for managing the `coredns` addon."
                 },
+                "createInstanceRole": {
+                    "type": "boolean",
+                    "plain": true,
+                    "description": "Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.\nIf set to false when using the default node group, an instance role or instance profile must be provided.n\nNote: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`."
+                },
                 "createOidcProvider": {
                     "type": "boolean",
                     "description": "Indicates whether an IAM OIDC Provider is created for the EKS cluster.\n\nThe OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.\n\nSee for more details:\n - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html\n - https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html\n - https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/\n - https://www.pulumi.com/registry/packages/aws/api-docs/eks/cluster/#enabling-iam-roles-for-service-accounts"

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -261,6 +261,14 @@ namespace Pulumi.Eks
         public Inputs.CoreDnsAddonOptionsArgs? CorednsAddonOptions { get; set; }
 
         /// <summary>
+        /// Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+        /// If set to false when using the default node group, an instance role or instance profile must be provided.n
+        /// Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+        /// </summary>
+        [Input("createInstanceRole")]
+        public bool? CreateInstanceRole { get; set; }
+
+        /// <summary>
         /// Indicates whether an IAM OIDC Provider is created for the EKS cluster.
         /// 
         /// The OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -138,6 +138,10 @@ type clusterArgs struct {
 	ClusterTags map[string]string `pulumi:"clusterTags"`
 	// Options for managing the `coredns` addon.
 	CorednsAddonOptions *CoreDnsAddonOptions `pulumi:"corednsAddonOptions"`
+	// Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+	// If set to false when using the default node group, an instance role or instance profile must be provided.n
+	// Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+	CreateInstanceRole *bool `pulumi:"createInstanceRole"`
 	// Indicates whether an IAM OIDC Provider is created for the EKS cluster.
 	//
 	// The OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.
@@ -374,6 +378,10 @@ type ClusterArgs struct {
 	ClusterTags pulumi.StringMapInput
 	// Options for managing the `coredns` addon.
 	CorednsAddonOptions *CoreDnsAddonOptionsArgs
+	// Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+	// If set to false when using the default node group, an instance role or instance profile must be provided.n
+	// Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+	CreateInstanceRole *bool
 	// Indicates whether an IAM OIDC Provider is created for the EKS cluster.
 	//
 	// The OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -141,6 +141,25 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+     * If set to false when using the default node group, an instance role or instance profile must be provided.n
+     * Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+     * 
+     */
+    @Import(name="createInstanceRole")
+    private @Nullable Boolean createInstanceRole;
+
+    /**
+     * @return Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+     * If set to false when using the default node group, an instance role or instance profile must be provided.n
+     * Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+     * 
+     */
+    public Optional<Boolean> createInstanceRole() {
+        return Optional.ofNullable(this.createInstanceRole);
+    }
+
+    /**
      * Indicates whether an IAM OIDC Provider is created for the EKS cluster.
      * 
      * The OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.
@@ -1090,6 +1109,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         this.clusterSecurityGroupTags = $.clusterSecurityGroupTags;
         this.clusterTags = $.clusterTags;
         this.corednsAddonOptions = $.corednsAddonOptions;
+        this.createInstanceRole = $.createInstanceRole;
         this.createOidcProvider = $.createOidcProvider;
         this.creationRoleProvider = $.creationRoleProvider;
         this.defaultAddonsToRemove = $.defaultAddonsToRemove;
@@ -1260,6 +1280,19 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder corednsAddonOptions(@Nullable CoreDnsAddonOptionsArgs corednsAddonOptions) {
             $.corednsAddonOptions = corednsAddonOptions;
+            return this;
+        }
+
+        /**
+         * @param createInstanceRole Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+         * If set to false when using the default node group, an instance role or instance profile must be provided.n
+         * Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder createInstanceRole(@Nullable Boolean createInstanceRole) {
+            $.createInstanceRole = createInstanceRole;
             return this;
         }
 

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -143,6 +143,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["clusterSecurityGroupTags"] = args ? args.clusterSecurityGroupTags : undefined;
             resourceInputs["clusterTags"] = args ? args.clusterTags : undefined;
             resourceInputs["corednsAddonOptions"] = args ? (args.corednsAddonOptions ? inputs.coreDnsAddonOptionsArgsProvideDefaults(args.corednsAddonOptions) : undefined) : undefined;
+            resourceInputs["createInstanceRole"] = args ? args.createInstanceRole : undefined;
             resourceInputs["createOidcProvider"] = args ? args.createOidcProvider : undefined;
             resourceInputs["creationRoleProvider"] = args ? args.creationRoleProvider : undefined;
             resourceInputs["defaultAddonsToRemove"] = args ? args.defaultAddonsToRemove : undefined;
@@ -288,6 +289,12 @@ export interface ClusterArgs {
      * Options for managing the `coredns` addon.
      */
     corednsAddonOptions?: inputs.CoreDnsAddonOptionsArgs;
+    /**
+     * Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+     * If set to false when using the default node group, an instance role or instance profile must be provided.n
+     * Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+     */
+    createInstanceRole?: boolean;
     /**
      * Indicates whether an IAM OIDC Provider is created for the EKS cluster.
      *

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -31,6 +31,7 @@ class ClusterArgs:
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  coredns_addon_options: Optional['CoreDnsAddonOptionsArgs'] = None,
+                 create_instance_role: Optional[bool] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
                  creation_role_provider: Optional['CreationRoleProviderArgs'] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -94,6 +95,9 @@ class ClusterArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param 'CoreDnsAddonOptionsArgs' coredns_addon_options: Options for managing the `coredns` addon.
+        :param bool create_instance_role: Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+               If set to false when using the default node group, an instance role or instance profile must be provided.n
+               Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
                
                The OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.
@@ -272,6 +276,8 @@ class ClusterArgs:
             pulumi.set(__self__, "cluster_tags", cluster_tags)
         if coredns_addon_options is not None:
             pulumi.set(__self__, "coredns_addon_options", coredns_addon_options)
+        if create_instance_role is not None:
+            pulumi.set(__self__, "create_instance_role", create_instance_role)
         if create_oidc_provider is not None:
             pulumi.set(__self__, "create_oidc_provider", create_oidc_provider)
         if creation_role_provider is not None:
@@ -446,6 +452,20 @@ class ClusterArgs:
     @coredns_addon_options.setter
     def coredns_addon_options(self, value: Optional['CoreDnsAddonOptionsArgs']):
         pulumi.set(self, "coredns_addon_options", value)
+
+    @property
+    @pulumi.getter(name="createInstanceRole")
+    def create_instance_role(self) -> Optional[bool]:
+        """
+        Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+        If set to false when using the default node group, an instance role or instance profile must be provided.n
+        Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
+        """
+        return pulumi.get(self, "create_instance_role")
+
+    @create_instance_role.setter
+    def create_instance_role(self, value: Optional[bool]):
+        pulumi.set(self, "create_instance_role", value)
 
     @property
     @pulumi.getter(name="createOidcProvider")
@@ -1141,6 +1161,7 @@ class Cluster(pulumi.ComponentResource):
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  coredns_addon_options: Optional[Union['CoreDnsAddonOptionsArgs', 'CoreDnsAddonOptionsArgsDict']] = None,
+                 create_instance_role: Optional[bool] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
                  creation_role_provider: Optional[Union['CreationRoleProviderArgs', 'CreationRoleProviderArgsDict']] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -1226,6 +1247,9 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_security_group_tags: The tags to apply to the cluster security group.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] cluster_tags: The tags to apply to the EKS cluster.
         :param Union['CoreDnsAddonOptionsArgs', 'CoreDnsAddonOptionsArgsDict'] coredns_addon_options: Options for managing the `coredns` addon.
+        :param bool create_instance_role: Whether to create the instance role for the EKS cluster. Defaults to true when using the default node group, false otherwise.
+               If set to false when using the default node group, an instance role or instance profile must be provided.n
+               Note: this option has no effect if a custom instance role is provided with `instanceRole` or `instanceRoles`.
         :param pulumi.Input[bool] create_oidc_provider: Indicates whether an IAM OIDC Provider is created for the EKS cluster.
                
                The OIDC provider is used in the cluster in combination with k8s Service Account annotations to provide IAM roles at the k8s Pod level.
@@ -1440,6 +1464,7 @@ class Cluster(pulumi.ComponentResource):
                  cluster_security_group_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  coredns_addon_options: Optional[Union['CoreDnsAddonOptionsArgs', 'CoreDnsAddonOptionsArgsDict']] = None,
+                 create_instance_role: Optional[bool] = None,
                  create_oidc_provider: Optional[pulumi.Input[bool]] = None,
                  creation_role_provider: Optional[Union['CreationRoleProviderArgs', 'CreationRoleProviderArgsDict']] = None,
                  default_addons_to_remove: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -1504,6 +1529,7 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["cluster_security_group_tags"] = cluster_security_group_tags
             __props__.__dict__["cluster_tags"] = cluster_tags
             __props__.__dict__["coredns_addon_options"] = coredns_addon_options
+            __props__.__dict__["create_instance_role"] = create_instance_role
             __props__.__dict__["create_oidc_provider"] = create_oidc_provider
             __props__.__dict__["creation_role_provider"] = creation_role_provider
             __props__.__dict__["default_addons_to_remove"] = default_addons_to_remove

--- a/tests/nodejs_test.go
+++ b/tests/nodejs_test.go
@@ -1221,6 +1221,28 @@ func TestAccScalarTypes(t *testing.T) {
 	programTestWithExtraOptions(t, &test, nil)
 }
 
+func TestAccDefaultInstanceRole(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getTestPrograms(t), "default-instance-role"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.RunEKSSmokeTest(t,
+					info.Deployment.Resources,
+					info.Outputs["kubeconfig"],
+				)
+
+				require.NotNil(t, info.Outputs["instanceRoles"])
+				instanceRoles := info.Outputs["instanceRoles"].([]interface{})
+				assert.Len(t, instanceRoles, 1, "expected the default instance role to be created")
+			},
+		})
+
+	programTestWithExtraOptions(t, &test, nil)
+}
+
 func getOidcProviderUrl(t *testing.T, eksCluster map[string]interface{}) string {
 	require.NotEmpty(t, eksCluster["identities"])
 	identities := eksCluster["identities"].([]interface{})

--- a/tests/testdata/programs/default-instance-role/Pulumi.yaml
+++ b/tests/testdata/programs/default-instance-role/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: default-instance-role
+description: EKS cluster without default node group but with instance role
+runtime: nodejs

--- a/tests/testdata/programs/default-instance-role/index.ts
+++ b/tests/testdata/programs/default-instance-role/index.ts
@@ -1,0 +1,40 @@
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+
+// Create a new VPC
+const eksVpc = new awsx.ec2.Vpc("default-instance-role", {
+  enableDnsHostnames: true,
+  cidrBlock: "10.0.0.0/16",
+  subnetSpecs: [
+    { type: "Public" }
+  ],
+  natGateways: {
+      strategy: "None",
+  }
+});
+
+const cluster = new eks.Cluster("default-instance-role", {
+  vpcId: eksVpc.vpcId,
+  authenticationMode: eks.AuthenticationMode.Api,
+  publicSubnetIds: eksVpc.publicSubnetIds,
+  skipDefaultNodeGroup: true,
+  createInstanceRole: true,
+});
+
+export const instanceRoles = cluster.instanceRoles.apply(roles => roles.map(role => role.name));
+export const kubeconfig = cluster.kubeconfig;
+
+const mng = eks.createManagedNodeGroup("default-instance-role-mng", {
+  scalingConfig: {
+    minSize: 1,
+    maxSize: 1,
+    desiredSize: 1,
+  },
+  cluster: cluster,
+  operatingSystem: eks.OperatingSystem.AL2023,
+  instanceTypes: ["t3.medium"],
+  nodeRole: cluster.instanceRoles.apply(roles => roles[0]),
+});

--- a/tests/testdata/programs/default-instance-role/package.json
+++ b/tests/testdata/programs/default-instance-role/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "default-instance-role",
+    "devDependencies": {
+        "@types/node": "latest",
+        "typescript": "^4.0.0"
+    },
+    "dependencies": {
+        "@pulumi/awsx": "^2.0.0",
+        "@pulumi/aws": "^6.50.1",
+        "@pulumi/eks": "latest",
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/tests/testdata/programs/default-instance-role/tsconfig.json
+++ b/tests/testdata/programs/default-instance-role/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
As part of https://github.com/pulumi/pulumi-eks/issues/1176 we took the decision to not create the default instance role if users disable the default node groups. Our assumption back then was that there's not a substantial need for this role when users opt out of the default node groups.

https://github.com/pulumi/pulumi-eks/issues/1510 has shown that there is indeed users that were relying on this default instance role that was created "by accident". This original change made the upgrade to v3 more painful than necessary for this set of users!

This change introduces a new plain flag `createInstanceRole` that can be used to opt-into creating the default instance role even when no default node group is needed.

Resolves https://github.com/pulumi/pulumi-eks/issues/1510
