### PR TITLE
Remove faulty IPv6 example

### DIFF
--- a/examples/cluster-go/step1/main.go
+++ b/examples/cluster-go/step1/main.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	awseks "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
 	"github.com/pulumi/pulumi-eks/sdk/v3/go/eks"
@@ -82,54 +78,6 @@ func main() {
 			return err
 		}
 
-		//////////////////////////////////////////////////
-		///     Create an ipv6 enabled EKS cluster     ///
-		//////////////////////////////////////////////////
-
-		// 1. Create a VPC with IPv6 CIDR block.
-		vpc, err := ec2.NewVpc(ctx, "ipv6-vpc", &ec2.VpcArgs{
-			AssignGeneratedIpv6CidrBlock: pulumi.Bool(true),
-			EnableDnsSupport:             pulumi.Bool(true),
-			EnableDnsHostnames:           pulumi.Bool(true),
-			CidrBlock:                    pulumi.String("10.100.0.0/16"),
-		})
-		if err != nil {
-			return err
-		}
-
-		// 2. Create two subnets with IPv6 CIDR block in two different availability zones.
-		//    EKS requires at least two subnets in different availability zones.
-		var subnetIDs []pulumi.StringInput
-		for idx, az := range []string{"us-west-2a", "us-west-2b"} {
-			subnet, err := ec2.NewSubnet(ctx, fmt.Sprintf("ipv6-subnet-%d", idx), &ec2.SubnetArgs{
-				VpcId:                       vpc.ID().ToStringOutput(),
-				AssignIpv6AddressOnCreation: pulumi.Bool(true),
-				AvailabilityZone:            pulumi.String(az),
-				CidrBlock:                   pulumi.String(fmt.Sprintf("10.100.%d.0/24", len(subnetIDs))),
-				Ipv6CidrBlock:               calculateIPV6CidrBlock(vpc.Ipv6CidrBlock, idx),
-			})
-			if err != nil {
-				return err
-			}
-
-			subnetIDs = append(subnetIDs, subnet.ID().ToStringOutput())
-		}
-
-		// 3. Create an EKS cluster with IPv6 networking enabled.
-		cluster4, err := eks.NewCluster(ctx, "example-cluster-4", &eks.ClusterArgs{
-			IpFamily:         pulumi.StringPtr("ipv6"),
-			VpcId:            vpc.ID().ToStringOutput(),
-			SubnetIds:        pulumi.StringArray(subnetIDs),
-			NodeGroupOptions: &eks.ClusterNodeGroupOptionsArgs{
-				DesiredCapacity: pulumi.IntPtr(2),
-				MinSize:         pulumi.IntPtr(2),
-				MaxSize:         pulumi.IntPtr(2),
-			},
-		})
-		if err != nil {
-			return err
-		}
-
 		//////////////////////////////////////////
 		///     Export cluster kubeconfigs     ///
 		//////////////////////////////////////////
@@ -137,20 +85,6 @@ func main() {
 		ctx.Export("kubeconfig1", cluster1.Kubeconfig)
 		ctx.Export("kubeconfig2", cluster2.Kubeconfig)
 		ctx.Export("kubeconfig3", cluster3.Kubeconfig)
-		ctx.Export("kubeconfig4", cluster4.Kubeconfig)
 		return nil
 	})
-}
-
-// calculateIPV6CidrBlock is a very simple function to calculate the ipv6 subnet cidr block for testing purpose.
-// Usage for real workloads should implement a more robust function.
-// Example: If the VPC ipv6 cidr block is 2600:1f13:e6:c000::/56, then the subnet ipv6 cidr block will be:
-// 2600:1f13:e6:c005::/64, 2600:1f13:e6:c006::/64, 2600:1f13:e6:c007::/64, ...
-func calculateIPV6CidrBlock(ipv6CidrBlock pulumi.StringOutput, subnetID int) pulumi.StringInput {
-	return ipv6CidrBlock.ApplyT(func(cidr string) (string, error) {
-		cidrStripped := strings.TrimSuffix(cidr, "::/56")
-		cidrStripped = cidrStripped[:len(cidrStripped)-1]
-		return fmt.Sprintf("%s%d::/64", cidrStripped, subnetID+5), nil
-
-	}).(pulumi.StringOutput)
 }

--- a/examples/cluster-go/step2/main.go
+++ b/examples/cluster-go/step2/main.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	awseks "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
 	"github.com/pulumi/pulumi-eks/sdk/v3/go/eks"

--- a/examples/cluster-go/step2/main.go
+++ b/examples/cluster-go/step2/main.go
@@ -83,55 +83,6 @@ func main() {
 			return err
 		}
 
-		//////////////////////////////////////////////////
-		///     Create an ipv6 enabled EKS cluster     ///
-		//////////////////////////////////////////////////
-
-		// 1. Create a VPC with IPv6 CIDR block.
-		vpc, err := ec2.NewVpc(ctx, "ipv6-vpc", &ec2.VpcArgs{
-			AssignGeneratedIpv6CidrBlock: pulumi.Bool(true),
-			EnableDnsSupport:             pulumi.Bool(true),
-			EnableDnsHostnames:           pulumi.Bool(true),
-			CidrBlock:                    pulumi.String("10.100.0.0/16"),
-		})
-		if err != nil {
-			return err
-		}
-
-		// 2. Create two subnets with IPv6 CIDR block in two different availability zones.
-		//    EKS requires at least two subnets in different availability zones.
-		var subnetIDs []pulumi.StringInput
-		for idx, az := range []string{"us-west-2a", "us-west-2b"} {
-			subnet, err := ec2.NewSubnet(ctx, fmt.Sprintf("ipv6-subnet-%d", idx), &ec2.SubnetArgs{
-				VpcId:                       vpc.ID().ToStringOutput(),
-				AssignIpv6AddressOnCreation: pulumi.Bool(true),
-				AvailabilityZone:            pulumi.String(az),
-				CidrBlock:                   pulumi.String(fmt.Sprintf("10.100.%d.0/24", len(subnetIDs))),
-				Ipv6CidrBlock:               calculateIPV6CidrBlock(vpc.Ipv6CidrBlock, idx),
-			})
-			if err != nil {
-				return err
-			}
-
-			subnetIDs = append(subnetIDs, subnet.ID().ToStringOutput())
-		}
-
-		// 3. Create an EKS cluster with IPv6 networking enabled.
-		cluster4, err := eks.NewCluster(ctx, "example-cluster-4", &eks.ClusterArgs{
-			IpFamily:         pulumi.StringPtr("ipv6"),
-			VpcId:            vpc.ID().ToStringOutput(),
-			SubnetIds:        pulumi.StringArray(subnetIDs),
-			UseDefaultVpcCni: func() *bool { t := true; return &t }(),
-			NodeGroupOptions: &eks.ClusterNodeGroupOptionsArgs{
-				DesiredCapacity: pulumi.IntPtr(2),
-				MinSize:         pulumi.IntPtr(2),
-				MaxSize:         pulumi.IntPtr(2),
-			},
-		})
-		if err != nil {
-			return err
-		}
-
 		////////////////////////////////////////////////
 		///     CreationRoleProvider should fail     ///
 		////////////////////////////////////////////////
@@ -167,21 +118,7 @@ func main() {
 		ctx.Export("kubeconfig1", cluster1.Kubeconfig)
 		ctx.Export("kubeconfig2", cluster2.Kubeconfig)
 		ctx.Export("kubeconfig3", cluster3.Kubeconfig)
-		ctx.Export("kubeconfig4", cluster4.Kubeconfig)
 		ctx.Export("kubeconfig5", cluster5.Kubeconfig)
 		return nil
 	})
-}
-
-// calculateIPV6CidrBlock is a very simple function to calculate the ipv6 subnet cidr block for testing purpose.
-// Usage for real workloads should implement a more robust function.
-// Example: If the VPC ipv6 cidr block is 2600:1f13:e6:c000::/56, then the subnet ipv6 cidr block will be:
-// 2600:1f13:e6:c005::/64, 2600:1f13:e6:c006::/64, 2600:1f13:e6:c007::/64, ...
-func calculateIPV6CidrBlock(ipv6CidrBlock pulumi.StringOutput, subnetID int) pulumi.StringInput {
-	return ipv6CidrBlock.ApplyT(func(cidr string) (string, error) {
-		cidrStripped := strings.TrimSuffix(cidr, "::/56")
-		cidrStripped = cidrStripped[:len(cidrStripped)-1]
-		return fmt.Sprintf("%s%d::/64", cidrStripped, subnetID+5), nil
-
-	}).(pulumi.StringOutput)
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

The existing IPv6 example is wrong and untested. Creating a working example requires additional changes (like ensuring the nodes can perform `ec2:AssignIpv6Addresses`).

This removes the faulty and untested example in order to not create frustration and confusion for users. We'll need to separately work on creating a proper IPv6 example (https://github.com/pulumi/pulumi-eks/issues/1522).

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Relates to https://github.com/pulumi/pulumi-eks/issues/1522
