### PR TITLE
chore: Remove gotestfmt from CI

### DIFF
--- a/.github/workflows/eks-cron.yml
+++ b/.github/workflows/eks-cron.yml
@@ -241,11 +241,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -268,7 +263,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=nodejs -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -346,11 +341,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
       - name: Install dependencies
         run: make install_python_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -373,7 +363,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=python -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       matrix:
@@ -450,11 +440,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
       - name: Install dependencies
         run: make install_dotnet_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - run: dotnet nuget add source ${{ github.workspace }}/nuget
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -470,7 +455,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=dotnet -count=1 -cover -timeout 3h -parallel 6 .
   test-go:
     name: Run Go Tests
     needs:
@@ -533,11 +518,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install NodeJS SDK
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Download Go SDK
         uses: actions/download-artifact@v4
         with:
@@ -559,7 +539,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=go -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=go -count=1 -cover -timeout 3h -parallel 6 .
 name: cron
 "on":
   schedule:

--- a/.github/workflows/eks-record.yml
+++ b/.github/workflows/eks-record.yml
@@ -170,12 +170,6 @@ jobs:
           repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v2.0.0
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
-
       - name: Download provider binary
         uses: actions/download-artifact@v4
         with:
@@ -224,16 +218,8 @@ jobs:
 
       - name: Record provider test snapshots
         run: |
-          cd tests && go test -tags nodejs -run '${{ inputs.runTests }}' -provider-snapshot -v -json -count=1 -cover -timeout 4h -parallel 20 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+          cd tests && go test -tags nodejs -run '${{ inputs.runTests }}' -provider-snapshot -count=1 -cover -timeout 4h -parallel 20 .
 
-        # TODO,tkappler Not sure why this is happening, but gotestfmt-action seems to download and unpack into the repository's root folder.
-        # https://github.com/GoTestTools/gotestfmt-action/blob/v2/index.js#L6
-      - name: Clean up after gotestfmt
-        continue-on-error: true
-        run: |
-          rm gotestfmt
-          rm LICENSE.md
-          git restore README.md
       - name: Open a PR with newly recorded test snapshots
         id: create-pr
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -257,11 +257,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -284,7 +279,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=nodejs -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -362,11 +357,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
       - name: Install dependencies
         run: make install_python_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -389,7 +379,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=python -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -467,11 +457,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
       - name: Install dependencies
         run: make install_dotnet_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - run: dotnet nuget add source ${{ github.workspace }}/nuget
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -487,7 +472,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=dotnet -count=1 -cover -timeout 3h -parallel 6 .
   test-go:
     name: Run Go Tests
     needs:
@@ -550,11 +535,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install NodeJS SDK
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Download Go SDK
         uses: actions/download-artifact@v4
         with:
@@ -576,7 +556,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=go -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=go -count=1 -cover -timeout 3h -parallel 6 .
 name: master
 "on":
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,11 +249,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -276,7 +271,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=nodejs -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -354,11 +349,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
       - name: Install dependencies
         run: make install_python_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -381,7 +371,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=python -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -459,11 +449,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
       - name: Install dependencies
         run: make install_dotnet_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - run: dotnet nuget add source ${{ github.workspace }}/nuget
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -479,7 +464,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=dotnet -count=1 -cover -timeout 3h -parallel 6 .
   test-go:
     name: Run Go Tests
     needs:
@@ -542,11 +527,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install NodeJS SDK
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Download Go SDK
         uses: actions/download-artifact@v4
         with:
@@ -568,7 +548,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=go -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=go -count=1 -cover -timeout 3h -parallel 6 .
 name: release
 "on":
   push:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -283,11 +283,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -379,11 +374,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install dependencies
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -406,7 +396,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=nodejs -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -476,11 +466,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install NodeJS SDK
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Download Python SDK
         uses: actions/download-artifact@v4
         with:
@@ -512,7 +497,7 @@ jobs:
           total: ${{ matrix.total }}
           index: ${{ matrix.index }}
       - name: Run tests
-        run: cd tests && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}" 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=python -count=1 -cover -timeout 3h -parallel 6 . --run="${{ steps.test_split.outputs.run}}"
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -582,11 +567,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install NodeJS SDK
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Download DotNet SDK
         uses: actions/download-artifact@v4
         with:
@@ -611,7 +591,7 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=dotnet -count=1 -cover -timeout 3h -parallel 6 .
   test-go:
     name: Run Go Tests
     needs:
@@ -675,11 +655,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/nodejs.tar.gz -C ${{github.workspace}}/nodejs
       - name: Install NodeJS SDK
         run: make install_nodejs_sdk
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.4.0
       - name: Download Go SDK
         uses: actions/download-artifact@v4
         with:
@@ -701,4 +676,4 @@ jobs:
           cd ${{ github.workspace }}/bin
           yarn install && yarn link @pulumi/eks
       - name: Run tests
-        run: cd tests && go test -tags=go -v -json -count=1 -cover -timeout 3h -parallel 6 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: cd tests && go test -tags=go -count=1 -cover -timeout 3h -parallel 6 .


### PR DESCRIPTION
Instead use standard go test logging without -v and -json options. This should help reduce confusion as to which test is failing and which log belongs to which test.

Follows: https://github.com/pulumi/pulumi-gcp/pull/2712
Re: https://github.com/pulumi/pulumi-eks/issues/1527
