### PR TITLE
Removes gotestfmt from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ test_nodejs:: provider install_nodejs_sdk
 
 test_nodejs_upgrade:: PATH := $(WORKING_DIR)/bin:$(PATH)
 test_nodejs_upgrade:: provider install_nodejs_sdk
-	cd tests && go test -run Upgrade -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM}
+	cd tests && go test -run Upgrade -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} .
 
 test_python:: install_provider test_build
 	cd tests && go test -tags=python -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} .

--- a/Makefile
+++ b/Makefile
@@ -169,20 +169,20 @@ dist:: dist/${GZIP_PREFIX}-windows-amd64.tar.gz
 
 test_nodejs:: PATH := $(WORKING_DIR)/bin:$(PATH)
 test_nodejs:: provider install_nodejs_sdk
-	cd tests && go test -tags=nodejs -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd tests && go test -tags=nodejs -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} .
 
 test_nodejs_upgrade:: PATH := $(WORKING_DIR)/bin:$(PATH)
 test_nodejs_upgrade:: provider install_nodejs_sdk
-	cd tests && go test -v -run Upgrade -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd tests && go test -run Upgrade -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM}
 
 test_python:: install_provider test_build
-	cd tests && go test -tags=python -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd tests && go test -tags=python -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} .
 
 test_dotnet:: install_provider
-	cd tests && go test -tags=dotnet -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd tests && go test -tags=dotnet -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} .
 
 test_java:: install_provider
-	cd tests && go test -tags=java -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd tests && go test -tags=java -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} .
 
 test_unit_tests:
 	cd nodejs/eks && \
@@ -190,10 +190,10 @@ test_unit_tests:
 		yarn run test
 
 specific_test:: install_nodejs_sdk test_build
-	cd tests && go test -tags=$(LanguageTags) -v -json -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . --run=TestAcc$(TestName) 2>&1 | tee /tmp/gotest.log | gotestfmt
+	cd tests && go test -tags=$(LanguageTags) -count=1 -cover -timeout 3h -parallel ${TESTPARALLELISM} . --run=TestAcc$(TestName)
 
 specific_test_local:: install_nodejs_sdk test_build
-	cd tests && go test -tags=$(LanguageTags) -v -count=1 -cover -timeout 3h . --run=TestAcc$(TestName)
+	cd tests && go test -tags=$(LanguageTags) -count=1 -cover -timeout 3h . --run=TestAcc$(TestName)
 
 dev:: lint build_nodejs
 test:: test_nodejs


### PR DESCRIPTION
Continuing with #1529 this removes the last remaining references to `gotestfmt` from the codebase.

