### PR TITLE
chore: fix renovate config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,6 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-renovate::
-	@echo "re-computing dependent files is not implemented yet"
+renovate:: build
 
 .PHONY: build build_dotnet build_go build_java build_nodejs build_python dev dist generate_schema install_dotnet_sdk install_java_sdk install_provider install_python_sdk lint lint_fix lint_provider provider renovate schema specific_test specific_test_local test test_dotnet test_java test_nodejs test_nodejs_upgrade test_provider test_python test_unit_tests

--- a/Makefile
+++ b/Makefile
@@ -206,3 +206,5 @@ test_provider:
 
 renovate::
 	@echo "re-computing dependent files is not implemented yet"
+
+.PHONY: build build_dotnet build_go build_java build_nodejs build_python dev dist generate_schema install_dotnet_sdk install_java_sdk install_provider install_python_sdk lint lint_fix lint_provider provider renovate schema specific_test specific_test_local test test_dotnet test_java test_nodejs test_nodejs_upgrade test_provider test_python test_unit_tests

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,9 +3,9 @@
   extends: ["github>pulumi/renovate-config//default.json5"],
   packageRules: [
     {
-      // Update metadata when aws-native is bumped.
+      // Update metadata when eks is bumped.
       matchDatasources: ["npm"],
-      matchPackageNames: ["@pulumi/aws-native"],
+      matchPackageNames: ["@pulumi/eks"],
       postUpgradeTasks: {
         commands: ["make renovate"],
         executionMode: "branch", // Only run once.


### PR DESCRIPTION
Introducing renovate config from aws-native accidentally had a typo specific to aws-native, this is now fixed.

Also adding .PHONY targets.

Also linking `make renovate` to run `make build` that should recompute dependent files.