### PR TITLE
Correct description of NodeadmOptions.content

### DIFF
--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -2010,7 +2010,7 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 					Properties: map[string]schema.PropertySpec{
 						"content": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},
-							Description: "The ARN of the access policy to associate with the principal",
+							Description: "The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.",
 						},
 						"contentType": {
 							TypeSpec:    schema.TypeSpec{Type: "string"},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -768,7 +768,7 @@
             "properties": {
                 "content": {
                     "type": "string",
-                    "description": "The ARN of the access policy to associate with the principal"
+                    "description": "The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType."
                 },
                 "contentType": {
                     "type": "string",

--- a/sdk/dotnet/Inputs/NodeadmOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/NodeadmOptionsArgs.cs
@@ -18,7 +18,7 @@ namespace Pulumi.Eks.Inputs
     public sealed class NodeadmOptionsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// The ARN of the access policy to associate with the principal
+        /// The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         /// </summary>
         [Input("content", required: true)]
         public Input<string> Content { get; set; } = null!;

--- a/sdk/dotnet/Outputs/NodeadmOptions.cs
+++ b/sdk/dotnet/Outputs/NodeadmOptions.cs
@@ -19,7 +19,7 @@ namespace Pulumi.Eks.Outputs
     public sealed class NodeadmOptions
     {
         /// <summary>
-        /// The ARN of the access policy to associate with the principal
+        /// The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         /// </summary>
         public readonly string Content;
         /// <summary>

--- a/sdk/go/eks/pulumiTypes.go
+++ b/sdk/go/eks/pulumiTypes.go
@@ -3294,7 +3294,7 @@ func (o NodeGroupDataPtrOutput) NodeSecurityGroup() ec2.SecurityGroupOutput {
 //
 // See for more details: https://awslabs.github.io/amazon-eks-ami/nodeadm/.
 type NodeadmOptions struct {
-	// The ARN of the access policy to associate with the principal
+	// The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
 	Content string `pulumi:"content"`
 	// The MIME type of the content. Examples are `text/x-shellscript; charset="us-ascii"` for shell scripts, and `application/node.eks.aws` nodeadm configuration.
 	ContentType string `pulumi:"contentType"`
@@ -3315,7 +3315,7 @@ type NodeadmOptionsInput interface {
 //
 // See for more details: https://awslabs.github.io/amazon-eks-ami/nodeadm/.
 type NodeadmOptionsArgs struct {
-	// The ARN of the access policy to associate with the principal
+	// The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
 	Content pulumi.StringInput `pulumi:"content"`
 	// The MIME type of the content. Examples are `text/x-shellscript; charset="us-ascii"` for shell scripts, and `application/node.eks.aws` nodeadm configuration.
 	ContentType pulumi.StringInput `pulumi:"contentType"`
@@ -3375,7 +3375,7 @@ func (o NodeadmOptionsOutput) ToNodeadmOptionsOutputWithContext(ctx context.Cont
 	return o
 }
 
-// The ARN of the access policy to associate with the principal
+// The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
 func (o NodeadmOptionsOutput) Content() pulumi.StringOutput {
 	return o.ApplyT(func(v NodeadmOptions) string { return v.Content }).(pulumi.StringOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/eks/inputs/NodeadmOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/inputs/NodeadmOptionsArgs.java
@@ -21,14 +21,14 @@ public final class NodeadmOptionsArgs extends com.pulumi.resources.ResourceArgs 
     public static final NodeadmOptionsArgs Empty = new NodeadmOptionsArgs();
 
     /**
-     * The ARN of the access policy to associate with the principal
+     * The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
      * 
      */
     @Import(name="content", required=true)
     private Output<String> content;
 
     /**
-     * @return The ARN of the access policy to associate with the principal
+     * @return The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
      * 
      */
     public Output<String> content() {
@@ -76,7 +76,7 @@ public final class NodeadmOptionsArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param content The ARN of the access policy to associate with the principal
+         * @param content The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
          * 
          * @return builder
          * 
@@ -87,7 +87,7 @@ public final class NodeadmOptionsArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param content The ARN of the access policy to associate with the principal
+         * @param content The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/eks/outputs/NodeadmOptions.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/outputs/NodeadmOptions.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 @CustomType
 public final class NodeadmOptions {
     /**
-     * @return The ARN of the access policy to associate with the principal
+     * @return The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
      * 
      */
     private String content;
@@ -23,7 +23,7 @@ public final class NodeadmOptions {
 
     private NodeadmOptions() {}
     /**
-     * @return The ARN of the access policy to associate with the principal
+     * @return The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
      * 
      */
     public String content() {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -571,7 +571,7 @@ export interface KubeconfigOptionsArgs {
  */
 export interface NodeadmOptionsArgs {
     /**
-     * The ARN of the access policy to associate with the principal
+     * The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
      */
     content: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -412,7 +412,7 @@ export interface NodeGroupData {
  */
 export interface NodeadmOptions {
     /**
-     * The ARN of the access policy to associate with the principal
+     * The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
      */
     content: string;
     /**

--- a/sdk/python/pulumi_eks/_inputs.py
+++ b/sdk/python/pulumi_eks/_inputs.py
@@ -2363,7 +2363,7 @@ if not MYPY:
         """
         content: pulumi.Input[str]
         """
-        The ARN of the access policy to associate with the principal
+        The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         """
         content_type: pulumi.Input[str]
         """
@@ -2381,7 +2381,7 @@ class NodeadmOptionsArgs:
         MIME document parts for nodeadm configuration. This can be shell scripts, nodeadm configuration or any other user data compatible script.
 
         See for more details: https://awslabs.github.io/amazon-eks-ami/nodeadm/.
-        :param pulumi.Input[str] content: The ARN of the access policy to associate with the principal
+        :param pulumi.Input[str] content: The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         :param pulumi.Input[str] content_type: The MIME type of the content. Examples are `text/x-shellscript; charset="us-ascii"` for shell scripts, and `application/node.eks.aws` nodeadm configuration.
         """
         pulumi.set(__self__, "content", content)
@@ -2391,7 +2391,7 @@ class NodeadmOptionsArgs:
     @pulumi.getter
     def content(self) -> pulumi.Input[str]:
         """
-        The ARN of the access policy to associate with the principal
+        The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         """
         return pulumi.get(self, "content")
 

--- a/sdk/python/pulumi_eks/outputs.py
+++ b/sdk/python/pulumi_eks/outputs.py
@@ -1342,7 +1342,7 @@ class NodeadmOptions(dict):
         MIME document parts for nodeadm configuration. This can be shell scripts, nodeadm configuration or any other user data compatible script.
 
         See for more details: https://awslabs.github.io/amazon-eks-ami/nodeadm/.
-        :param str content: The ARN of the access policy to associate with the principal
+        :param str content: The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         :param str content_type: The MIME type of the content. Examples are `text/x-shellscript; charset="us-ascii"` for shell scripts, and `application/node.eks.aws` nodeadm configuration.
         """
         pulumi.set(__self__, "content", content)
@@ -1352,7 +1352,7 @@ class NodeadmOptions(dict):
     @pulumi.getter
     def content(self) -> str:
         """
-        The ARN of the access policy to associate with the principal
+        The actual content of the MIME document part, such as shell script code or nodeadm configuration. Must be compatible with the specified contentType.
         """
         return pulumi.get(self, "content")
 


### PR DESCRIPTION
There was a copy&paste error in the description of `NodeadmOptions.content`. This corrects that.