### PR TITLE
chore: make renovate to generate but not build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ PKG_ARGS   := --no-bytecode --public-packages "*" --public
 PKG_TARGET := ./bin/cmd/provider/index.js
 SCHEMA_PATH := provider/cmd/$(PROVIDER)/schema.json
 
+generate:: schema generate_nodejs generate_python generate_go generate_dotnet generate_java
 build:: schema provider build_nodejs build_python build_go build_dotnet build_java
 
 schema::
@@ -45,39 +46,56 @@ build_nodejs:: .pulumi/bin/pulumi schema
 		yarn run build && \
 		cp package.json yarn.lock ./bin/
 
-bin/pulumi-java-gen::
-	mkdir -p bin/
+bin/pulumi-java-gen.v$(JAVA_GEN_VERSION):
+	@mkdir -p bin/
+	@rm -f bin/pulumi-java-gen.v*
+	@echo "$(JAVA_GEN_VERSION)" >"$@"
+
+bin/pulumi-java-gen: bin/pulumi-java-gen.v$(JAVA_GEN_VERSION)
+	@mkdir -p bin/
 	pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
 
-build_java:: PACKAGE_VERSION := ${VERSION_GENERIC}
-build_java:: bin/pulumi-java-gen schema
+generate_java:: PACKAGE_VERSION := ${VERSION_GENERIC}
+generate_java:: bin/pulumi-java-gen schema
 	rm -rf sdk/java
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema provider/cmd/$(PROVIDER)/schema.json --out sdk/java --build gradle-nexus
 	cd sdk/java && \
-		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
-		gradle --console=plain build
+		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod
 
-build_python:: schema
+build_java:: PACKAGE_VERSION := ${VERSION_GENERIC}
+build_java:: generate_java
+	cd sdk/java && gradle --console=plain build
+
+generate_python:: schema
 	rm -rf sdk/python
 	cd provider/cmd/$(CODEGEN) && go run main.go python ../../../sdk/python $(CURDIR) ../$(PROVIDER)/schema.json $(VERSION_GENERIC)
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
-		cp ../../README.md . && \
+		cp ../../README.md .
+
+build_python:: generate_python
+	cd sdk/python/ && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build && \
 		cd ./bin && \
 		../venv/bin/python -m build .
 
-build_go:: schema
+generate_go:: schema
 	rm -rf sdk/go
 	cd provider/cmd/$(CODEGEN) && go run main.go go ../../../sdk/go $(CURDIR) ../$(PROVIDER)/schema.json $(VERSION_GENERIC)
 
-build_dotnet:: schema
+build_go:: generate_go
+	cd sdk go && go build ./...
+
+generate_dotnet:: schema
 	rm -rf sdk/dotnet
 	cd provider/cmd/$(CODEGEN) && go run main.go dotnet ../../../sdk/dotnet $(CURDIR) ../$(PROVIDER)/schema.json $(VERSION_GENERIC)
 	cd sdk/dotnet/ && \
-		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
+		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod
+
+build_dotnet:: generate_dotnet
+	cd sdk/dotnet/ && \
 		echo "${VERSION_GENERIC}" >version.txt && \
 		dotnet build
 
@@ -204,6 +222,6 @@ test_provider:
 	@echo ""
 	cd provider && go test -v -short ./... -parallel $(TESTPARALLELISM)
 
-renovate:: build
+renovate:: generate
 
-.PHONY: build build_dotnet build_go build_java build_nodejs build_python dev dist generate_schema install_dotnet_sdk install_java_sdk install_provider install_python_sdk lint lint_fix lint_provider provider renovate schema specific_test specific_test_local test test_dotnet test_java test_nodejs test_nodejs_upgrade test_provider test_python test_unit_tests
+.PHONY: build generate generate_dotnet generate_go generate_java generate_nodejs generate_python build_dotnet build_go build_java build_nodejs build_python dev dist generate_schema install_dotnet_sdk install_java_sdk install_provider install_python_sdk lint lint_fix lint_provider provider renovate schema specific_test specific_test_local test test_dotnet test_java test_nodejs test_nodejs_upgrade test_provider test_python test_unit_tests

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,9 +3,10 @@
   extends: ["github>pulumi/renovate-config//default.json5"],
   packageRules: [
     {
-      // Update metadata when eks is bumped.
-      matchDatasources: ["npm"],
-      matchPackageNames: ["@pulumi/eks"],
+      // Dependent files need to be rebuilt when key dependencies change.
+      //
+      // https://docs.renovatebot.com/configuration-options/#postupgradetasks
+      fileFilters: ["go.mod", "nodejs/eks/package.json", "nodejs/eks/yarn.lock"],
       postUpgradeTasks: {
         commands: ["make renovate"],
         executionMode: "branch", // Only run once.


### PR DESCRIPTION
Tweaking renovate config to more aggressively regenerate the files but not to build them.

Optimizing not re-downloading java-gen.

Hoping to get https://github.com/pulumi/pulumi-eks/pull/1540 past the point where it is failing.
