### PR TITLE
chore: fix renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,11 +3,12 @@
   extends: ["github>pulumi/renovate-config//default.json5"],
   packageRules: [
     {
+      matchDatasources: ["npm", "go", "golang-version"],
       // Dependent files need to be rebuilt when key dependencies change.
       //
       // https://docs.renovatebot.com/configuration-options/#postupgradetasks
-      fileFilters: ["go.mod", "nodejs/eks/package.json", "nodejs/eks/yarn.lock"],
       postUpgradeTasks: {
+        fileFilters: ["go.mod", "nodejs/eks/package.json", "nodejs/eks/yarn.lock"],
         commands: ["make renovate"],
         executionMode: "branch", // Only run once.
       },


### PR DESCRIPTION
It is possible to validate Renovate configuration with:

    npx --yes --package renovate -- renovate-config-validator

Fixes #1548

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
