### PR TITLE
chore: remove Renovate file filters

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,7 +8,6 @@
       //
       // https://docs.renovatebot.com/configuration-options/#postupgradetasks
       postUpgradeTasks: {
-        fileFilters: ["go.mod", "nodejs/eks/package.json", "nodejs/eks/yarn.lock"],
         commands: ["make renovate"],
         executionMode: "branch", // Only run once.
       },


### PR DESCRIPTION
Per https://docs.renovatebot.com/configuration-options/#filefilters

The current configuration did update files with `make renovate` but ignored the changes to files such as the provider schema based on the incorrect filter filter configuration.

Logs included things like this:

    DEBUG: Checking 47 added or modified files for post-upgrade changes (repository=pulumi/pulumi-eks, branch=renovate/pulumi

    DEBUG: Post-upgrade file did not match any file filters (repository=pulumi/pulumi-eks, branch=renovate/pulumi)

For the purposes of this repository the default value of fileFilters seems better suited.
