### PR TITLE
Fix ManagedNodeGroup ignoring custom AMI if no user data is configured

### DIFF
--- a/nodejs/eks/nodegroup.ts
+++ b/nodejs/eks/nodegroup.ts
@@ -2113,7 +2113,7 @@ export function createManagedNodeGroupInternal(
     // amiType, releaseVersion and version cannot be set if an AMI ID is set in a custom launch template.
     // The AMI ID is set in the launch template if custom user data is required.
     // See https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#mng-ami-id-conditions
-    if (requiresCustomUserData(userDataArgs) || args.userData) {
+    if (requiresCustomUserData(userDataArgs) || args.userData || args.amiId) {
         delete nodeGroupArgs.version;
         delete nodeGroupArgs.releaseVersion;
         delete nodeGroupArgs.amiType;
@@ -2228,7 +2228,9 @@ function createMNGCustomLaunchTemplate(
         });
 
     let userData: pulumi.Output<string> | undefined;
-    if (requiresCustomUserData(customUserDataArgs) || args.userData) {
+    // when amiId is provided, we need to create a custom user data script because
+    // EKS will not provide default user data when an AMI ID is provided.
+    if (requiresCustomUserData(customUserDataArgs) || args.userData || args.amiId) {
         userData = pulumi
             .all([
                 clusterMetadata,


### PR DESCRIPTION
When users specified a custom AMI for an EKS Managed Node Group, the setting was only taking effect if their configuration already triggered custom user data generation, otherwise it used the default AMI. To fix this, I modified the logic to generate custom user data whenever a custom AMI is configured. This ensures the node group launches successfully with proper bootstrap settings regardless of other configuration options (AWS EKS does not provide default user data if an AMI ID is specified in the launch template).

The previous E2E tests worked because they coincidentally used the same AMI ID as the default AMI. The updated test intentionally chooses an AMI for the previous minor version and verifies the EC2 instances are using this exact AMI.

Fixes #1550