### PR TITLE
Unpin dependencies of `TestAccOidcIam` and `TestAccCluster`

### DIFF
--- a/examples/cluster/package.json
+++ b/examples/cluster/package.json
@@ -5,9 +5,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "3.144.1",
-        "@pulumi/awsx": "2.19.0",
-        "@pulumi/aws": "6.66.1",
+        "@pulumi/pulumi": "^3.144.1",
+        "@pulumi/awsx": "^2.19.0",
+        "@pulumi/aws": "^6.66.1",
         "@pulumi/eks": "latest"
     },
     "scripts": {

--- a/examples/oidc-iam-sa/package.json
+++ b/examples/oidc-iam-sa/package.json
@@ -5,9 +5,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/aws": "6.66.1",
+        "@pulumi/aws": "^6.66.1",
         "@pulumi/eks": "latest",
-        "@pulumi/kubernetes": "4.19.0",
-        "@pulumi/pulumi": "3.144.1"
+        "@pulumi/kubernetes": "^4.19.0",
+        "@pulumi/pulumi": "^3.144.1"
     }
 }


### PR DESCRIPTION
Renovate pins our test dependencies (`@pulumi/...`), which ultimately leads to having multiple versions of dependencies like `@pulumi/pulumi` in node_modules. This is a known situation that can cause issues (e.g. https://github.com/pulumi/pulumi/issues/13505).

Unless that core issue is resolved, I cannot see how we can pin `@pulumi/...` dependencies in tests. For now I'm gonna revert the failing tests to use version ranges, but we'll need to fix renovate.
