### PR TITLE
Add EFA support for Managed Node Groups

### DIFF
--- a/examples/efa/Pulumi.yaml
+++ b/examples/efa/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: efa
+description: EKS Cluster with EFA enabled
+runtime: nodejs

--- a/examples/efa/README.md
+++ b/examples/efa/README.md
@@ -1,0 +1,11 @@
+# EFA Support
+
+When enabling EFA support for a node group will do the following:
+- All EFA interfaces supported by the instance will be exposed on the launch template used by the node group
+- A `clustered` placement group will be created and passed to the launch template
+- Checks will be performed to ensure that the instance type supports EFA and that the specified AZ is supported by the chosen instance type
+
+The GPU optimized AMIs include all necessary drivers and libraries to support EFA. If you're choosing an instance type without GPU acceleration you will need to install the drivers and libraries manually and bake a custom AMI.
+
+You can use the [aws-efa-k8s-device-plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) Helm chart in order to expose the EFA interfaces on the nodes as an extended resource, and allow pods to request these interfaces to be mounted to their containers.
+Your application container will need to have the necessary libraries and runtimes in order to leverage the EFA interfaces (e.g. libfabric).

--- a/examples/efa/README.md
+++ b/examples/efa/README.md
@@ -1,11 +1,11 @@
 # EFA Support
 
-When enabling EFA support for a node group will do the following:
+Enabling EFA support for a node group will do the following:
 - All EFA interfaces supported by the instance will be exposed on the launch template used by the node group
 - A `clustered` placement group will be created and passed to the launch template
 - Checks will be performed to ensure that the instance type supports EFA and that the specified AZ is supported by the chosen instance type
 
 The GPU optimized AMIs include all necessary drivers and libraries to support EFA. If you're choosing an instance type without GPU acceleration you will need to install the drivers and libraries manually and bake a custom AMI.
 
-You can use the [aws-efa-k8s-device-plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) Helm chart in order to expose the EFA interfaces on the nodes as an extended resource, and allow pods to request these interfaces to be mounted to their containers.
+You can use the [aws-efa-k8s-device-plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) Helm chart to expose the EFA interfaces on the nodes as an extended resource, and allow pods to request these interfaces to be mounted to their containers.
 Your application container will need to have the necessary libraries and runtimes in order to leverage the EFA interfaces (e.g. libfabric).

--- a/examples/efa/iam.ts
+++ b/examples/efa/iam.ts
@@ -1,0 +1,28 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+];
+
+// Creates a role and attches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}

--- a/examples/efa/index.ts
+++ b/examples/efa/index.ts
@@ -1,0 +1,89 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+import * as iam from "./iam";
+
+const config = new pulumi.Config();
+const instanceType = config.require("instanceType");
+const availabilityZones = config.require("availabilityZones").split(",");
+
+const eksVpc = new awsx.ec2.Vpc("efa", {
+    cidrBlock: "10.0.0.0/16",
+    subnetStrategy: "Auto",
+    availabilityZoneNames: availabilityZones,
+});
+
+const role = iam.createRole("efa");
+
+const cluster = new eks.Cluster("efa", {
+    authenticationMode: eks.AuthenticationMode.Api,
+    vpcId: eksVpc.vpcId,
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    privateSubnetIds: eksVpc.privateSubnetIds,
+    skipDefaultNodeGroup: true,
+});
+
+export const kubeconfig = cluster.kubeconfig;
+
+// node group to run system pods (e.g. kube-proxy, coredns, etc.)
+const systemMng = new eks.ManagedNodeGroup("system-mng", {
+    cluster: cluster,
+    subnetIds: eksVpc.privateSubnetIds,
+    nodeRole: role,
+});
+
+// install the EFA device plugin to configure EFA on the nodes
+const efaDevicePlugin = new k8s.helm.v3.Release("efa-device-plugin", {
+    version: "0.5.7",
+    chart: "aws-efa-k8s-device-plugin",
+    repositoryOpts: {
+        repo: "https://aws.github.io/eks-charts",
+    },
+    namespace: "kube-system",
+    atomic: true,
+    values: {
+        tolerations: [{
+            key: "efa-enabled",
+            operator: "Exists",
+            effect: "NoExecute",
+        }],
+    }
+}, { provider: cluster.provider });
+
+// node group to run EFA enabled workloads
+const efaMng = new eks.ManagedNodeGroup("efa-mng", {
+    cluster: cluster,
+    instanceTypes: [instanceType],
+    // EFA needs at least 2 instances, otherwise there's nothing to communicate with
+    scalingConfig: {
+        minSize: 2,
+        maxSize: 2,
+        desiredSize: 2,
+    },
+    gpu: true,
+    nodeRole: role,
+    enableEfaSupport: true,
+    placementGroupAvailabilityZone: availabilityZones[0],
+
+    // taint the nodes so that only pods with the efa-enabled label can be scheduled on them
+    taints: [{
+        key: "efa-enabled",
+        value: "true",
+        effect: "NO_EXECUTE",
+    }],
+
+    // Instances with GPUs usually have nvme instance store volumes, so we can mount them in RAID-0 for kubelet and containerd
+    // These are faster than the regular EBS volumes
+    nodeadmExtraOptions: [{
+        contentType: "application/node.eks.aws",
+        content: `
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  instance:
+    localStorage:
+      strategy: RAID0
+`
+    }]
+}, { dependsOn: [efaDevicePlugin] });

--- a/examples/efa/index.ts
+++ b/examples/efa/index.ts
@@ -87,3 +87,5 @@ spec:
 `
     }]
 }, { dependsOn: [efaDevicePlugin] });
+
+export const placementGroupName = efaMng.placementGroupName;

--- a/examples/efa/package.json
+++ b/examples/efa/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "efa",
+    "devDependencies": {
+        "typescript": "^4.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "3.144.1",
+        "@pulumi/kubernetes": "4.19.0",
+        "@pulumi/awsx": "2.19.0",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/examples/efa/tsconfig.json
+++ b/examples/efa/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/eks/cmd/provider/nodegroup.ts
+++ b/nodejs/eks/cmd/provider/nodegroup.ts
@@ -59,6 +59,7 @@ const managedNodeGroupProvider: pulumi.provider.Provider = {
                 urn: nodegroup.urn,
                 state: {
                     nodeGroup: nodegroup.nodeGroup,
+                    placementGroupName: nodegroup.placementGroupName,
                 },
             });
         } catch (e) {

--- a/nodejs/eks/nodes/instances.test.ts
+++ b/nodejs/eks/nodes/instances.test.ts
@@ -1,0 +1,190 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+
+describe("filterEfaSubnets", () => {
+    const callReturnValues = new Map<string, pulumi.runtime.MockCallResult>();
+
+    beforeAll(() => {
+        pulumi.runtime.setMocks(
+            {
+                newResource: function (args: pulumi.runtime.MockResourceArgs): {
+                    id: string;
+                    state: any;
+                } {
+                    return {
+                        id: args.inputs.name + "_id",
+                        state: args.inputs,
+                    };
+                },
+                call: function (args: pulumi.runtime.MockCallArgs): pulumi.runtime.MockCallResult {
+                    const callReturnValue = callReturnValues.get(args.token);
+                    if (callReturnValue) {
+                        return callReturnValue;
+                    }
+
+                    return args.inputs;
+                },
+            },
+            "project",
+            "stack",
+            false, // Sets the flag `dryRun`, which indicates if pulumi is running in preview mode.
+        );
+    });
+
+    let instances: typeof import("./instances");
+    beforeEach(async function () {
+        instances = await import("./instances");
+    });
+
+    it("should return filtered subnet IDs when the availability zone is supported", async () => {
+        callReturnValues.set("aws:ec2/getInstanceTypeOfferings:getInstanceTypeOfferings", {
+            locations: pulumi.output(["us-west-2a", "us-west-2b"]),
+        });
+
+        const subnetIds = ["subnet-12345", "subnet-67890", "subnet-54321"];
+
+        callReturnValues.set("aws:ec2/getSubnets:getSubnets", {
+            ids: pulumi.output([subnetIds[0]]),
+        });
+
+        const result = await promisify(
+            instances.filterEfaSubnets(subnetIds, "us-west-2a", ["t3.medium"], {}),
+        );
+
+        expect(result).toEqual([subnetIds[0]]);
+    });
+});
+
+describe("getEfaNetworkInterfaces", () => {
+    const callReturnValues = new Map<string, pulumi.runtime.MockCallResult>();
+
+    beforeAll(() => {
+        pulumi.runtime.setMocks(
+            {
+                newResource: function (args: pulumi.runtime.MockResourceArgs): {
+                    id: string;
+                    state: any;
+                } {
+                    return {
+                        id: args.inputs.name + "_id",
+                        state: args.inputs,
+                    };
+                },
+                call: function (args: pulumi.runtime.MockCallArgs): pulumi.runtime.MockCallResult {
+                    const callReturnValue = callReturnValues.get(args.token);
+                    if (callReturnValue) {
+                        return callReturnValue;
+                    }
+
+                    return args.inputs;
+                },
+            },
+            "project",
+            "stack",
+            false, // Sets the flag `dryRun`, which indicates if pulumi is running in preview mode.
+        );
+    });
+
+    let instances: typeof import("./instances");
+    beforeEach(async function () {
+        instances = await import("./instances");
+    });
+
+    it("should return network interfaces for EFA-enabled instance types with a single network card", async () => {
+        callReturnValues.set("aws:ec2/getInstanceType:getInstanceType", {
+            efaSupported: true,
+            maximumNetworkCards: 1,
+        });
+
+        const args = {
+            instanceTypes: ["g6.8xlarge"],
+            securityGroupIds: ["sg-12345"],
+            instanceTypePropertyPath: "instanceTypes",
+            associatePublicIpAddress: true,
+            opts: {},
+        };
+
+        const result = await promisify(pulumi.output(instances.getEfaNetworkInterfaces(args)));
+        expect(result).toEqual([
+            {
+                associatePublicIpAddress: "true",
+                deleteOnTermination: "true",
+                networkCardIndex: 0,
+                deviceIndex: 0,
+                interfaceType: "efa",
+                securityGroups: ["sg-12345"],
+            },
+        ]);
+    });
+
+    it("should return network interfaces for EFA-enabled instance types with multiple network cards", async () => {
+        callReturnValues.set("aws:ec2/getInstanceType:getInstanceType", {
+            efaSupported: true,
+            maximumNetworkCards: 4,
+        });
+
+        const args = {
+            instanceTypes: ["p4d.24xlarge"],
+            securityGroupIds: ["sg-12345"],
+            instanceTypePropertyPath: "instanceTypes",
+            associatePublicIpAddress: true,
+            opts: {},
+        };
+
+        const result = await promisify(pulumi.output(instances.getEfaNetworkInterfaces(args)));
+
+        expect(result).toEqual([
+            {
+                associatePublicIpAddress: "true",
+                deleteOnTermination: "true",
+                networkCardIndex: 0,
+                deviceIndex: 0,
+                interfaceType: "efa",
+                securityGroups: ["sg-12345"],
+            },
+            // Secondary interfaces do not get an IP address because they do not support IP networking.
+            {
+                associatePublicIpAddress: undefined,
+                deleteOnTermination: "true",
+                networkCardIndex: 1,
+                deviceIndex: 1,
+                interfaceType: "efa-only",
+                securityGroups: ["sg-12345"],
+            },
+            {
+                associatePublicIpAddress: undefined,
+                deleteOnTermination: "true",
+                networkCardIndex: 2,
+                deviceIndex: 1,
+                interfaceType: "efa-only",
+                securityGroups: ["sg-12345"],
+            },
+            {
+                associatePublicIpAddress: undefined,
+                deleteOnTermination: "true",
+                networkCardIndex: 3,
+                deviceIndex: 1,
+                interfaceType: "efa-only",
+                securityGroups: ["sg-12345"],
+            },
+        ]);
+    });
+});
+
+function promisify<T>(output: pulumi.Output<T> | undefined): Promise<T> {
+    expect(output).toBeDefined();
+    return new Promise((resolve) => output!.apply(resolve));
+}

--- a/nodejs/eks/nodes/instances.test.ts
+++ b/nodejs/eks/nodes/instances.test.ts
@@ -47,6 +47,7 @@ describe("filterEfaSubnets", () => {
     let instances: typeof import("./instances");
     beforeEach(async function () {
         instances = await import("./instances");
+        callReturnValues.clear();
     });
 
     it("should return filtered subnet IDs when the availability zone is supported", async () => {
@@ -101,6 +102,7 @@ describe("getEfaNetworkInterfaces", () => {
     let instances: typeof import("./instances");
     beforeEach(async function () {
         instances = await import("./instances");
+        callReturnValues.clear();
     });
 
     it("should return network interfaces for EFA-enabled instance types with a single network card", async () => {

--- a/nodejs/eks/nodes/instances.ts
+++ b/nodejs/eks/nodes/instances.ts
@@ -1,0 +1,209 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+export const DEFAULT_INSTANCE_TYPE = "t3.medium";
+
+export interface GetEfaNetworkInterfacesArgs {
+    // The instance types configured for the node group.
+    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined;
+    // The security group IDs to associate with the network interfaces.
+    securityGroupIds: pulumi.Input<pulumi.Input<string>[]>;
+    // The property path to use for the instance type in error messages.
+    instanceTypePropertyPath: string;
+    // Whether to associate a public IP address with the primary network interface.
+    associatePublicIpAddress?: pulumi.Input<boolean>;
+    // Options for the underlying invokes used to retrieve information about the instance types
+    opts: pulumi.InvokeOptions;
+}
+
+/**
+ * Gets the network interface configurations for EFA-enabled instances.
+ *
+ * This function configures network interfaces for EFA (Elastic Fabric Adapter) support based on the instance type.
+ * For instance types that support multiple network cards, it will configure one EFA interface per network card. For other
+ * supported instance types, it will configure a single EFA interface.
+ *
+ * The primary network interface (index 0) is configured with:
+ * - Optional public IP association
+ * - Device index 0
+ * - Interface type "efa"
+ *
+ * Any secondary network interfaces are configured with:
+ * - No public IP
+ * - Device index 1
+ * - Interface type "efa-only"
+ *
+ * @param args - Configuration options for the network interfaces
+ * @returns Array of network interface configurations for the launch template
+ * @throws {pulumi.InputPropertyError} If the selected instance type does not support EFA
+ */
+export function getEfaNetworkInterfaces(
+    args: GetEfaNetworkInterfacesArgs,
+): pulumi.Output<aws.types.input.ec2.LaunchTemplateNetworkInterface[]> {
+    const instanceType = getEfaInstanceType(args.instanceTypes);
+    const instanceTypeInfo = aws.ec2.getInstanceTypeOutput(
+        {
+            instanceType,
+        },
+        args.opts,
+    );
+
+    // Instance types that support multiple network cards can be configured with one EFA per network card. All other supported instance types
+    // support only one EFA per instance.
+    // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-limits
+    const maximumNetworkCards = pulumi
+        .all([instanceTypeInfo.efaSupported, instanceType])
+        .apply(([efaSupported, instanceType]) => {
+            if (!efaSupported) {
+                throw new pulumi.InputPropertyError({
+                    propertyPath: args.instanceTypePropertyPath,
+                    reason: `The selected instance type '${instanceType}' does not support EFA.`,
+                });
+            }
+            return instanceTypeInfo.maximumNetworkCards.apply((cards) => {
+                return cards > 1 ? cards : 1;
+            });
+        });
+
+    const publicIpAssociation = args.associatePublicIpAddress
+        ? pulumi.output(args.associatePublicIpAddress).apply((str) => str.toString())
+        : undefined;
+
+    return maximumNetworkCards.apply((cards) => {
+        const interfaces: aws.types.input.ec2.LaunchTemplateNetworkInterface[] = [];
+        for (let i = 0; i < cards; i++) {
+            interfaces.push({
+                // The primary interface can have a public IP address, the secondary interfaces do not support IP networking.
+                associatePublicIpAddress: i === 0 ? publicIpAssociation : undefined,
+                deleteOnTermination: "true",
+                networkCardIndex: i,
+                // EFA requires the first interface to have device index 0, and all the secondary interfaces to have device index 1.
+                // see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-tempinstance
+                deviceIndex: i === 0 ? 0 : 1,
+                // The primary interface must be efa, the secondary interfaces can be efa or efa-only.
+                // We choose efa-only because it prevents exhausting the private IP address space and circumvents
+                // possibly routing conflicts, like source IP mismatch, or host name mapping problems.
+                interfaceType: i === 0 ? "efa" : "efa-only",
+                securityGroups: args.securityGroupIds,
+            });
+        }
+        return interfaces;
+    });
+}
+
+/**
+ * Filters the provided subnet IDs by the specified availability zone and instance type.
+ *
+ * @param subnetIds - An array of subnet IDs to filter.
+ * @param placementGroupAvailabilityZone - The availability zone to filter the subnets by.
+ * @param instanceTypes - An optional array of instance types to determine supported availability zones.
+ * @param opts - Options to control the behavior of the Pulumi invoke operation.
+ *
+ * @returns A Pulumi Output containing an array of subnet IDs that match the specified availability zone and instance type.
+ */
+export function filterEfaSubnets(
+    subnetIds: pulumi.Input<pulumi.Input<string>[]>,
+    placementGroupAvailabilityZone: pulumi.Input<string>,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    opts: pulumi.InvokeOptions,
+): pulumi.Output<string[]> {
+    const instanceType = getEfaInstanceType(instanceTypes);
+    const supportedAZs = getSupportedAZs(instanceType, opts);
+    // check if the provided availability zone is supported by the instance type
+    const zone = pulumi.all([placementGroupAvailabilityZone, supportedAZs]).apply(([zone, azs]) => {
+        if (azs.includes(zone)) {
+            return zone;
+        } else {
+            throw new pulumi.InputPropertyError({
+                propertyPath: "placementGroupAvailabilityZone",
+                reason: `The provided availability zone ('${zone}') is not supported by the instance type. Supported AZs: [${azs.join(
+                    ", ",
+                )}]`,
+            });
+        }
+    });
+
+    const filteredSubnets = aws.ec2.getSubnetsOutput(
+        {
+            filters: [
+                {
+                    name: "availability-zone",
+                    values: [zone],
+                },
+                {
+                    name: "subnet-id",
+                    values: subnetIds,
+                },
+            ],
+        },
+        opts,
+    );
+
+    return pulumi.all([filteredSubnets, supportedAZs]).apply(([subnets, azs]) => {
+        if (subnets.ids.length === 0) {
+            throw new pulumi.InputPropertyError({
+                propertyPath: "placementGroupAvailabilityZone",
+                reason: `None of the configured subnets are in the provided availability zone ('${zone}'). Choose a different availability zone or change the subnets. Supported AZs: [${azs.join(
+                    ", ",
+                )}]`,
+            });
+        }
+
+        return subnets.ids;
+    });
+}
+
+/**
+ * Gets the availability zones that support a specific EC2 instance type.
+ * @param instanceType The EC2 instance type to check availability for (e.g. "t3.micro")
+ * @param opts Options for the underlying invokes used to retrieve the information
+ * @returns A list of availability zone IDs where the instance type is available
+ */
+function getSupportedAZs(
+    instanceType: pulumi.Input<string>,
+    opts: pulumi.InvokeOutputOptions,
+): pulumi.Output<string[]> {
+    return aws.ec2.getInstanceTypeOfferingsOutput(
+        {
+            filters: [
+                {
+                    name: "instance-type",
+                    values: [instanceType],
+                },
+            ],
+            locationType: "availability-zone",
+        },
+        opts,
+    ).locations;
+}
+
+/**
+ * Gets the first instance type from a list of instance types, or returns a default instance type if none are provided.
+ * This is used to determine which instance type is configured for EFA.
+ *
+ * @param instanceTypes - list of EC2 instance types
+ * @returns The first instance type from the list, or "t3.medium" if no instance types are provided
+ */
+function getEfaInstanceType(
+    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+): pulumi.Output<string> {
+    return instanceTypes
+        ? pulumi.output(instanceTypes).apply((types) => {
+              return types.length > 0 ? types[0] : DEFAULT_INSTANCE_TYPE;
+          })
+        : pulumi.output(DEFAULT_INSTANCE_TYPE);
+}

--- a/nodejs/eks/nodes/nodegroup.test.ts
+++ b/nodejs/eks/nodes/nodegroup.test.ts
@@ -444,6 +444,37 @@ describe("createManagedNodeGroup", function () {
 
         expect(configuredVersion).toBeUndefined();
     });
+
+    test("should throw an error if placementGroupAvailabilityZone is not provided when enabling EFA support", async () => {
+        expect(() => {
+            ng.createManagedNodeGroup(
+                "test",
+                {
+                    nodeRoleArn: pulumi.output("nodeRoleArn"),
+                    enableEfaSupport: true,
+                },
+                pulumi.output({
+                    cluster: {
+                        version: pulumi.output("1.30"),
+                        accessConfig: pulumi.output({
+                            authenticationMode: "API",
+                        }),
+                    } as aws.eks.Cluster,
+                } as CoreData),
+                undefined as any,
+            );
+        }).toThrow(
+            new pulumi.InputPropertiesError({
+                message: "The input properties for the managed node group are invalid.",
+                errors: [
+                    {
+                        propertyPath: "placementGroupAvailabilityZone",
+                        reason: "You must specify placementGroupAvailabilityZone when enabling EFA support.",
+                    },
+                ],
+            }),
+        );
+    });
 });
 
 describe("resolveInstanceProfileName", function () {

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -829,9 +829,14 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 							TypeSpec:    schema.TypeSpec{Ref: awsRef("#/resources/aws:eks%2FnodeGroup:NodeGroup", dependencies.Aws)},
 							Description: "The AWS managed node group.",
 						},
+						"placementGroupName": {
+							TypeSpec: schema.TypeSpec{Type: "string"},
+							Description: "The name of the placement group created for the managed node group.",
+						},
 					},
 					Required: []string{
 						"nodeGroup",
+						"placementGroupName",
 					},
 				},
 				InputProperties: map[string]schema.PropertySpec{
@@ -1070,6 +1075,17 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 						},
 						Description: "Whether to ignore changes to the desired size of the Auto Scaling Group. This is useful when using Cluster Autoscaler.\n\n" +
 							"See [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details.",
+					},
+					"placementGroupAvailabilityZone": {
+						TypeSpec: schema.TypeSpec{
+							Type:  "string",
+						},
+						Description: "The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.",
+					},
+					"enableEfaSupport": {
+						TypeSpec: schema.TypeSpec{Type: "boolean", Plain: true},
+						Description: "Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, " +
+							"the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.",
 					},
 				},
 				RequiredInputs: []string{"cluster"},

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -830,7 +830,7 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 							Description: "The AWS managed node group.",
 						},
 						"placementGroupName": {
-							TypeSpec: schema.TypeSpec{Type: "string"},
+							TypeSpec:    schema.TypeSpec{Type: "string"},
 							Description: "The name of the placement group created for the managed node group.",
 						},
 					},
@@ -1078,7 +1078,7 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 					},
 					"placementGroupAvailabilityZone": {
 						TypeSpec: schema.TypeSpec{
-							Type:  "string",
+							Type: "string",
 						},
 						Description: "The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.",
 					},

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -1586,10 +1586,15 @@
                 "nodeGroup": {
                     "$ref": "/aws/v6.66.1/schema.json#/resources/aws:eks%2FnodeGroup:NodeGroup",
                     "description": "The AWS managed node group."
+                },
+                "placementGroupName": {
+                    "type": "string",
+                    "description": "The name of the placement group created for the managed node group."
                 }
             },
             "required": [
-                "nodeGroup"
+                "nodeGroup",
+                "placementGroupName"
             ],
             "inputProperties": {
                 "amiId": {
@@ -1634,6 +1639,11 @@
                 "diskSize": {
                     "type": "integer",
                     "description": "Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided."
+                },
+                "enableEfaSupport": {
+                    "type": "boolean",
+                    "plain": true,
+                    "description": "Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set."
                 },
                 "enableIMDSv2": {
                     "type": "boolean",
@@ -1702,6 +1712,10 @@
                 "operatingSystem": {
                     "$ref": "#/types/eks:index:OperatingSystem",
                     "description": "The type of OS to use for the node group. Will be used to determine the right EKS optimized AMI to use based on the instance types and gpu configuration.\nValid values are `RECOMMENDED`, `AL2`, `AL2023` and `Bottlerocket`.\n\nDefaults to the current recommended OS."
+                },
+                "placementGroupAvailabilityZone": {
+                    "type": "string",
+                    "description": "The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true."
                 },
                 "releaseVersion": {
                     "type": "string",

--- a/sdk/dotnet/ManagedNodeGroup.cs
+++ b/sdk/dotnet/ManagedNodeGroup.cs
@@ -24,6 +24,12 @@ namespace Pulumi.Eks
         [Output("nodeGroup")]
         public Output<Pulumi.Aws.Eks.NodeGroup> NodeGroup { get; private set; } = null!;
 
+        /// <summary>
+        /// The name of the placement group created for the managed node group.
+        /// </summary>
+        [Output("placementGroupName")]
+        public Output<string> PlacementGroupName { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a ManagedNodeGroup resource with the given unique name, arguments, and options.
@@ -124,6 +130,12 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("diskSize")]
         public Input<int>? DiskSize { get; set; }
+
+        /// <summary>
+        /// Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+        /// </summary>
+        [Input("enableEfaSupport")]
+        public bool? EnableEfaSupport { get; set; }
 
         /// <summary>
         /// Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
@@ -256,6 +268,12 @@ namespace Pulumi.Eks
         /// </summary>
         [Input("operatingSystem")]
         public Input<Pulumi.Eks.OperatingSystem>? OperatingSystem { get; set; }
+
+        /// <summary>
+        /// The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+        /// </summary>
+        [Input("placementGroupAvailabilityZone")]
+        public Input<string>? PlacementGroupAvailabilityZone { get; set; }
 
         /// <summary>
         /// AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.

--- a/sdk/go/eks/managedNodeGroup.go
+++ b/sdk/go/eks/managedNodeGroup.go
@@ -23,6 +23,8 @@ type ManagedNodeGroup struct {
 
 	// The AWS managed node group.
 	NodeGroup eks.NodeGroupOutput `pulumi:"nodeGroup"`
+	// The name of the placement group created for the managed node group.
+	PlacementGroupName pulumi.StringOutput `pulumi:"placementGroupName"`
 }
 
 // NewManagedNodeGroup registers a new resource with the given unique name, arguments, and options.
@@ -80,6 +82,8 @@ type managedNodeGroupArgs struct {
 	ClusterName *string `pulumi:"clusterName"`
 	// Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
 	DiskSize *int `pulumi:"diskSize"`
+	// Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+	EnableEfaSupport *bool `pulumi:"enableEfaSupport"`
 	// Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 	// Defaults to `false`.
 	//
@@ -138,6 +142,8 @@ type managedNodeGroupArgs struct {
 	//
 	// Defaults to the current recommended OS.
 	OperatingSystem *OperatingSystem `pulumi:"operatingSystem"`
+	// The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+	PlacementGroupAvailabilityZone *string `pulumi:"placementGroupAvailabilityZone"`
 	// AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
 	ReleaseVersion *string `pulumi:"releaseVersion"`
 	// Remote access settings.
@@ -206,6 +212,8 @@ type ManagedNodeGroupArgs struct {
 	ClusterName pulumi.StringPtrInput
 	// Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
 	DiskSize pulumi.IntPtrInput
+	// Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+	EnableEfaSupport *bool
 	// Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 	// Defaults to `false`.
 	//
@@ -264,6 +272,8 @@ type ManagedNodeGroupArgs struct {
 	//
 	// Defaults to the current recommended OS.
 	OperatingSystem OperatingSystemPtrInput
+	// The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+	PlacementGroupAvailabilityZone pulumi.StringPtrInput
 	// AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
 	ReleaseVersion pulumi.StringPtrInput
 	// Remote access settings.
@@ -385,6 +395,11 @@ func (o ManagedNodeGroupOutput) ToManagedNodeGroupOutputWithContext(ctx context.
 // The AWS managed node group.
 func (o ManagedNodeGroupOutput) NodeGroup() eks.NodeGroupOutput {
 	return o.ApplyT(func(v *ManagedNodeGroup) eks.NodeGroupOutput { return v.NodeGroup }).(eks.NodeGroupOutput)
+}
+
+// The name of the placement group created for the managed node group.
+func (o ManagedNodeGroupOutput) PlacementGroupName() pulumi.StringOutput {
+	return o.ApplyT(func(v *ManagedNodeGroup) pulumi.StringOutput { return v.PlacementGroupName }).(pulumi.StringOutput)
 }
 
 type ManagedNodeGroupArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroup.java
@@ -10,6 +10,7 @@ import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.eks.ManagedNodeGroupArgs;
 import com.pulumi.eks.Utilities;
+import java.lang.String;
 import javax.annotation.Nullable;
 
 /**
@@ -34,6 +35,20 @@ public class ManagedNodeGroup extends com.pulumi.resources.ComponentResource {
      */
     public Output<NodeGroup> nodeGroup() {
         return this.nodeGroup;
+    }
+    /**
+     * The name of the placement group created for the managed node group.
+     * 
+     */
+    @Export(name="placementGroupName", refs={String.class}, tree="[0]")
+    private Output<String> placementGroupName;
+
+    /**
+     * @return The name of the placement group created for the managed node group.
+     * 
+     */
+    public Output<String> placementGroupName() {
+        return this.placementGroupName;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ManagedNodeGroupArgs.java
@@ -190,6 +190,21 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
+     * Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+     * 
+     */
+    @Import(name="enableEfaSupport")
+    private @Nullable Boolean enableEfaSupport;
+
+    /**
+     * @return Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+     * 
+     */
+    public Optional<Boolean> enableEfaSupport() {
+        return Optional.ofNullable(this.enableEfaSupport);
+    }
+
+    /**
      * Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
      * Defaults to `false`.
      * 
@@ -460,6 +475,21 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
     }
 
     /**
+     * The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+     * 
+     */
+    @Import(name="placementGroupAvailabilityZone")
+    private @Nullable Output<String> placementGroupAvailabilityZone;
+
+    /**
+     * @return The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+     * 
+     */
+    public Optional<Output<String>> placementGroupAvailabilityZone() {
+        return Optional.ofNullable(this.placementGroupAvailabilityZone);
+    }
+
+    /**
      * AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
      * 
      */
@@ -610,6 +640,7 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
         this.cluster = $.cluster;
         this.clusterName = $.clusterName;
         this.diskSize = $.diskSize;
+        this.enableEfaSupport = $.enableEfaSupport;
         this.enableIMDSv2 = $.enableIMDSv2;
         this.forceUpdateVersion = $.forceUpdateVersion;
         this.gpu = $.gpu;
@@ -624,6 +655,7 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
         this.nodeRoleArn = $.nodeRoleArn;
         this.nodeadmExtraOptions = $.nodeadmExtraOptions;
         this.operatingSystem = $.operatingSystem;
+        this.placementGroupAvailabilityZone = $.placementGroupAvailabilityZone;
         this.releaseVersion = $.releaseVersion;
         this.remoteAccess = $.remoteAccess;
         this.scalingConfig = $.scalingConfig;
@@ -864,6 +896,17 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
          */
         public Builder diskSize(Integer diskSize) {
             return diskSize(Output.of(diskSize));
+        }
+
+        /**
+         * @param enableEfaSupport Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableEfaSupport(@Nullable Boolean enableEfaSupport) {
+            $.enableEfaSupport = enableEfaSupport;
+            return this;
         }
 
         /**
@@ -1212,6 +1255,27 @@ public final class ManagedNodeGroupArgs extends com.pulumi.resources.ResourceArg
          */
         public Builder operatingSystem(OperatingSystem operatingSystem) {
             return operatingSystem(Output.of(operatingSystem));
+        }
+
+        /**
+         * @param placementGroupAvailabilityZone The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder placementGroupAvailabilityZone(@Nullable Output<String> placementGroupAvailabilityZone) {
+            $.placementGroupAvailabilityZone = placementGroupAvailabilityZone;
+            return this;
+        }
+
+        /**
+         * @param placementGroupAvailabilityZone The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder placementGroupAvailabilityZone(String placementGroupAvailabilityZone) {
+            return placementGroupAvailabilityZone(Output.of(placementGroupAvailabilityZone));
         }
 
         /**

--- a/sdk/nodejs/managedNodeGroup.ts
+++ b/sdk/nodejs/managedNodeGroup.ts
@@ -37,6 +37,10 @@ export class ManagedNodeGroup extends pulumi.ComponentResource {
      * The AWS managed node group.
      */
     public /*out*/ readonly nodeGroup!: pulumi.Output<pulumiAws.eks.NodeGroup>;
+    /**
+     * The name of the placement group created for the managed node group.
+     */
+    public /*out*/ readonly placementGroupName!: pulumi.Output<string>;
 
     /**
      * Create a ManagedNodeGroup resource with the given unique name, arguments, and options.
@@ -60,6 +64,7 @@ export class ManagedNodeGroup extends pulumi.ComponentResource {
             resourceInputs["cluster"] = args ? args.cluster : undefined;
             resourceInputs["clusterName"] = args ? args.clusterName : undefined;
             resourceInputs["diskSize"] = args ? args.diskSize : undefined;
+            resourceInputs["enableEfaSupport"] = args ? args.enableEfaSupport : undefined;
             resourceInputs["enableIMDSv2"] = args ? args.enableIMDSv2 : undefined;
             resourceInputs["forceUpdateVersion"] = args ? args.forceUpdateVersion : undefined;
             resourceInputs["gpu"] = args ? args.gpu : undefined;
@@ -74,6 +79,7 @@ export class ManagedNodeGroup extends pulumi.ComponentResource {
             resourceInputs["nodeRoleArn"] = args ? args.nodeRoleArn : undefined;
             resourceInputs["nodeadmExtraOptions"] = args ? args.nodeadmExtraOptions : undefined;
             resourceInputs["operatingSystem"] = args ? args.operatingSystem : undefined;
+            resourceInputs["placementGroupAvailabilityZone"] = args ? args.placementGroupAvailabilityZone : undefined;
             resourceInputs["releaseVersion"] = args ? args.releaseVersion : undefined;
             resourceInputs["remoteAccess"] = args ? args.remoteAccess : undefined;
             resourceInputs["scalingConfig"] = args ? args.scalingConfig : undefined;
@@ -83,8 +89,10 @@ export class ManagedNodeGroup extends pulumi.ComponentResource {
             resourceInputs["userData"] = args ? args.userData : undefined;
             resourceInputs["version"] = args ? args.version : undefined;
             resourceInputs["nodeGroup"] = undefined /*out*/;
+            resourceInputs["placementGroupName"] = undefined /*out*/;
         } else {
             resourceInputs["nodeGroup"] = undefined /*out*/;
+            resourceInputs["placementGroupName"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(ManagedNodeGroup.__pulumiType, name, resourceInputs, opts, true /*remote*/);
@@ -146,6 +154,10 @@ export interface ManagedNodeGroupArgs {
      * Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
      */
     diskSize?: pulumi.Input<number>;
+    /**
+     * Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+     */
+    enableEfaSupport?: boolean;
     /**
      * Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
      * Defaults to `false`.
@@ -232,6 +244,10 @@ export interface ManagedNodeGroupArgs {
      * Defaults to the current recommended OS.
      */
     operatingSystem?: pulumi.Input<enums.OperatingSystem>;
+    /**
+     * The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+     */
+    placementGroupAvailabilityZone?: pulumi.Input<string>;
     /**
      * AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
      */

--- a/sdk/python/pulumi_eks/managed_node_group.py
+++ b/sdk/python/pulumi_eks/managed_node_group.py
@@ -33,6 +33,7 @@ class ManagedNodeGroupArgs:
                  capacity_type: Optional[pulumi.Input[str]] = None,
                  cluster_name: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[int]] = None,
+                 enable_efa_support: Optional[bool] = None,
                  enable_imd_sv2: Optional[bool] = None,
                  force_update_version: Optional[pulumi.Input[bool]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -47,6 +48,7 @@ class ManagedNodeGroupArgs:
                  node_role_arn: Optional[pulumi.Input[str]] = None,
                  nodeadm_extra_options: Optional[pulumi.Input[Sequence[pulumi.Input['NodeadmOptionsArgs']]]] = None,
                  operating_system: Optional[pulumi.Input['OperatingSystem']] = None,
+                 placement_group_availability_zone: Optional[pulumi.Input[str]] = None,
                  release_version: Optional[pulumi.Input[str]] = None,
                  remote_access: Optional[pulumi.Input['pulumi_aws.eks.NodeGroupRemoteAccessArgs']] = None,
                  scaling_config: Optional[pulumi.Input['pulumi_aws.eks.NodeGroupScalingConfigArgs']] = None,
@@ -84,6 +86,7 @@ class ManagedNodeGroupArgs:
         :param pulumi.Input[str] capacity_type: Type of capacity associated with the EKS Node Group. Valid values: `ON_DEMAND`, `SPOT`. This provider will only perform drift detection if a configuration value is provided.
         :param pulumi.Input[str] cluster_name: Name of the EKS Cluster.
         :param pulumi.Input[int] disk_size: Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
+        :param bool enable_efa_support: Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
         :param bool enable_imd_sv2: Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
                Defaults to `false`.
                
@@ -128,6 +131,7 @@ class ManagedNodeGroupArgs:
                Valid values are `RECOMMENDED`, `AL2`, `AL2023` and `Bottlerocket`.
                
                Defaults to the current recommended OS.
+        :param pulumi.Input[str] placement_group_availability_zone: The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
         :param pulumi.Input[str] release_version: AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
         :param pulumi.Input['pulumi_aws.eks.NodeGroupRemoteAccessArgs'] remote_access: Remote access settings.
         :param pulumi.Input['pulumi_aws.eks.NodeGroupScalingConfigArgs'] scaling_config: Scaling settings.
@@ -165,6 +169,8 @@ class ManagedNodeGroupArgs:
             pulumi.set(__self__, "cluster_name", cluster_name)
         if disk_size is not None:
             pulumi.set(__self__, "disk_size", disk_size)
+        if enable_efa_support is not None:
+            pulumi.set(__self__, "enable_efa_support", enable_efa_support)
         if enable_imd_sv2 is not None:
             pulumi.set(__self__, "enable_imd_sv2", enable_imd_sv2)
         if force_update_version is not None:
@@ -193,6 +199,8 @@ class ManagedNodeGroupArgs:
             pulumi.set(__self__, "nodeadm_extra_options", nodeadm_extra_options)
         if operating_system is not None:
             pulumi.set(__self__, "operating_system", operating_system)
+        if placement_group_availability_zone is not None:
+            pulumi.set(__self__, "placement_group_availability_zone", placement_group_availability_zone)
         if release_version is not None:
             pulumi.set(__self__, "release_version", release_version)
         if remote_access is not None:
@@ -324,6 +332,18 @@ class ManagedNodeGroupArgs:
     @disk_size.setter
     def disk_size(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "disk_size", value)
+
+    @property
+    @pulumi.getter(name="enableEfaSupport")
+    def enable_efa_support(self) -> Optional[bool]:
+        """
+        Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
+        """
+        return pulumi.get(self, "enable_efa_support")
+
+    @enable_efa_support.setter
+    def enable_efa_support(self, value: Optional[bool]):
+        pulumi.set(self, "enable_efa_support", value)
 
     @property
     @pulumi.getter(name="enableIMDSv2")
@@ -524,6 +544,18 @@ class ManagedNodeGroupArgs:
         pulumi.set(self, "operating_system", value)
 
     @property
+    @pulumi.getter(name="placementGroupAvailabilityZone")
+    def placement_group_availability_zone(self) -> Optional[pulumi.Input[str]]:
+        """
+        The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
+        """
+        return pulumi.get(self, "placement_group_availability_zone")
+
+    @placement_group_availability_zone.setter
+    def placement_group_availability_zone(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "placement_group_availability_zone", value)
+
+    @property
     @pulumi.getter(name="releaseVersion")
     def release_version(self) -> Optional[pulumi.Input[str]]:
         """
@@ -644,6 +676,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                  cluster: Optional[pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]]] = None,
                  cluster_name: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[int]] = None,
+                 enable_efa_support: Optional[bool] = None,
                  enable_imd_sv2: Optional[bool] = None,
                  force_update_version: Optional[pulumi.Input[bool]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -658,6 +691,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                  node_role_arn: Optional[pulumi.Input[str]] = None,
                  nodeadm_extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NodeadmOptionsArgs', 'NodeadmOptionsArgsDict']]]]] = None,
                  operating_system: Optional[pulumi.Input['OperatingSystem']] = None,
+                 placement_group_availability_zone: Optional[pulumi.Input[str]] = None,
                  release_version: Optional[pulumi.Input[str]] = None,
                  remote_access: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupRemoteAccessArgs']]] = None,
                  scaling_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupScalingConfigArgs']]] = None,
@@ -702,6 +736,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
         :param pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]] cluster: The target EKS cluster.
         :param pulumi.Input[str] cluster_name: Name of the EKS Cluster.
         :param pulumi.Input[int] disk_size: Disk size in GiB for worker nodes. Defaults to `20`. This provider will only perform drift detection if a configuration value is provided.
+        :param bool enable_efa_support: Determines whether to enable Elastic Fabric Adapter (EFA) support for the node group. If multiple different instance types are configured for the node group, the first one will be used to determine the network interfaces to use. Requires `placementGroupAvailabilityZone` to be set.
         :param bool enable_imd_sv2: Enables the ability to use EC2 Instance Metadata Service v2, which provides a more secure way to access instance metadata. For more information, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
                Defaults to `false`.
                
@@ -746,6 +781,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                Valid values are `RECOMMENDED`, `AL2`, `AL2023` and `Bottlerocket`.
                
                Defaults to the current recommended OS.
+        :param pulumi.Input[str] placement_group_availability_zone: The availability zone of the placement group for EFA support. Required if `enableEfaSupport` is true.
         :param pulumi.Input[str] release_version: AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
         :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupRemoteAccessArgs']] remote_access: Remote access settings.
         :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupScalingConfigArgs']] scaling_config: Scaling settings.
@@ -803,6 +839,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                  cluster: Optional[pulumi.Input[Union['Cluster', Union['CoreDataArgs', 'CoreDataArgsDict']]]] = None,
                  cluster_name: Optional[pulumi.Input[str]] = None,
                  disk_size: Optional[pulumi.Input[int]] = None,
+                 enable_efa_support: Optional[bool] = None,
                  enable_imd_sv2: Optional[bool] = None,
                  force_update_version: Optional[pulumi.Input[bool]] = None,
                  gpu: Optional[pulumi.Input[bool]] = None,
@@ -817,6 +854,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
                  node_role_arn: Optional[pulumi.Input[str]] = None,
                  nodeadm_extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NodeadmOptionsArgs', 'NodeadmOptionsArgsDict']]]]] = None,
                  operating_system: Optional[pulumi.Input['OperatingSystem']] = None,
+                 placement_group_availability_zone: Optional[pulumi.Input[str]] = None,
                  release_version: Optional[pulumi.Input[str]] = None,
                  remote_access: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupRemoteAccessArgs']]] = None,
                  scaling_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.NodeGroupScalingConfigArgs']]] = None,
@@ -846,6 +884,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
             __props__.__dict__["cluster"] = cluster
             __props__.__dict__["cluster_name"] = cluster_name
             __props__.__dict__["disk_size"] = disk_size
+            __props__.__dict__["enable_efa_support"] = enable_efa_support
             __props__.__dict__["enable_imd_sv2"] = enable_imd_sv2
             __props__.__dict__["force_update_version"] = force_update_version
             __props__.__dict__["gpu"] = gpu
@@ -860,6 +899,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
             __props__.__dict__["node_role_arn"] = node_role_arn
             __props__.__dict__["nodeadm_extra_options"] = nodeadm_extra_options
             __props__.__dict__["operating_system"] = operating_system
+            __props__.__dict__["placement_group_availability_zone"] = placement_group_availability_zone
             __props__.__dict__["release_version"] = release_version
             __props__.__dict__["remote_access"] = remote_access
             __props__.__dict__["scaling_config"] = scaling_config
@@ -869,6 +909,7 @@ class ManagedNodeGroup(pulumi.ComponentResource):
             __props__.__dict__["user_data"] = user_data
             __props__.__dict__["version"] = version
             __props__.__dict__["node_group"] = None
+            __props__.__dict__["placement_group_name"] = None
         super(ManagedNodeGroup, __self__).__init__(
             'eks:index:ManagedNodeGroup',
             resource_name,
@@ -883,4 +924,12 @@ class ManagedNodeGroup(pulumi.ComponentResource):
         The AWS managed node group.
         """
         return pulumi.get(self, "node_group")
+
+    @property
+    @pulumi.getter(name="placementGroupName")
+    def placement_group_name(self) -> pulumi.Output[str]:
+        """
+        The name of the placement group created for the managed node group.
+        """
+        return pulumi.get(self, "placement_group_name")
 

--- a/tests/nodejs_test.go
+++ b/tests/nodejs_test.go
@@ -1091,6 +1091,8 @@ func TestAccEfa(t *testing.T) {
 				"availabilityZones": strings.Join(supportedAZs, ","),
 			},
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				require.NotEmpty(t, info.Outputs["placementGroupName"])
+
 				// Verify that the cluster is working.
 				utils.ValidateClusters(t, info.Deployment.Resources, utils.WithKubeConfigs(info.Outputs["kubeconfig"]))
 

--- a/tests/nodejs_test.go
+++ b/tests/nodejs_test.go
@@ -1073,6 +1073,49 @@ func TestAccEksAutoModeUpgrade(t *testing.T) {
 	programTestWithExtraOptions(t, &test, nil)
 }
 
+func TestAccEfa(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	// this is one of the cheapest instances that support EFA
+	instanceType := "g6.8xlarge"
+	supportedAZs, err := utils.FindSupportedAZs(t, instanceType)
+	require.NoError(t, err)
+
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getExamples(t), "efa"),
+			Config: map[string]string{
+				"instanceType":      instanceType,
+				"availabilityZones": strings.Join(supportedAZs, ","),
+			},
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				// Verify that the cluster is working.
+				utils.ValidateClusters(t, info.Deployment.Resources, utils.WithKubeConfigs(info.Outputs["kubeconfig"]))
+
+				// verify that two nodes have EFA enabled
+				assert.NoError(t, utils.ValidateNodes(t, info.Outputs["kubeconfig"], func(nodes *corev1.NodeList) {
+					require.NotNil(t, nodes)
+					assert.NotEmpty(t, nodes.Items)
+
+					var foundNodes = 0
+					for _, node := range nodes.Items {
+						if efas, ok := node.Status.Capacity["vpc.amazonaws.com/efa"]; !ok {
+							continue
+						} else {
+							assert.True(t, efas.CmpInt64(1) == 0)
+							foundNodes++
+						}
+					}
+					assert.Equal(t, 2, foundNodes, "Expected %s nodes with EFA enabled", foundNodes)
+				}))
+			},
+		})
+
+	programTestWithExtraOptions(t, &test, nil)
+}
+
 func randomString(lenght int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 	random := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))

--- a/tests/validation_test.go
+++ b/tests/validation_test.go
@@ -8,37 +8,100 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/opttest"
+	utils "github.com/pulumi/pulumi-eks/tests/internal"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEksClusterInputValidations(t *testing.T) {
 	props := []string{"instanceRoles", "roleMappings", "userMappings"}
+	dir := filepath.Join(getTestPrograms(t), "cluster-input-validations")
 	for _, p := range props {
 		for n := 0; n < 2; n++ {
 			t.Run(fmt.Sprintf("%s_%d", p, n), func(t *testing.T) {
-				checkEksClusterInputValidations(t, p, n, n > 0)
+				checkEksClusterInputValidations(t, dir, func(pt *pulumitest.PulumiTest) {
+					pt.SetConfig(t, "property", p)
+					pt.SetConfig(t, "n", fmt.Sprintf("%d", n))
+				}, n > 0)
 			})
 		}
 	}
 }
 
-func checkEksClusterInputValidations(t *testing.T, property string, n int, expectFailure bool) {
+func TestEfaInputValidation(t *testing.T) {
+	azs, err := utils.ListAvailabilityZones(t)
+	require.NoError(t, err)
+
+	supportedAZs, err := utils.FindSupportedAZs(t, "g6.8xlarge")
+	require.NoError(t, err)
+
+	var unsupportedAZ []string
+	for _, az := range azs {
+		found := false
+		for _, supportedAZ := range supportedAZs {
+			if az == supportedAZ {
+				found = true
+				break
+			}
+		}
+		if !found {
+			unsupportedAZ = append(unsupportedAZ, az)
+		}
+	}
+	require.NotEmpty(t, unsupportedAZ, "Could not find an unsupported AZ")
+
+	tests := []struct {
+		name         string
+		instanceType string
+		azs          string
+		wantErr      bool
+	}{
+		{
+			name:         "valid instance type and azs",
+			instanceType: "g6.8xlarge",
+			azs:          strings.Join(supportedAZs, ","),
+			wantErr:      false,
+		},
+		{
+			name:         "unsupported instance type",
+			instanceType: "t3.medium",
+			azs:          strings.Join(supportedAZs, ","),
+			wantErr:      true,
+		},
+		{
+			name:         "unsupported az",
+			instanceType: "g6.8xlarge",
+			azs:          strings.Join(unsupportedAZ, ","),
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkEksClusterInputValidations(t, filepath.Join(getExamples(t), "efa"), func(pt *pulumitest.PulumiTest) {
+				pt.SetConfig(t, "instanceType", tt.instanceType)
+				pt.SetConfig(t, "availabilityZones", tt.azs)
+			}, tt.wantErr)
+		})
+	}
+}
+
+func checkEksClusterInputValidations(t *testing.T, testDir string, config func(pt *pulumitest.PulumiTest), expectFailure bool) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	dir := filepath.Join(getTestPrograms(t), "cluster-input-validations")
 	options := []opttest.Option{
 		opttest.LocalProviderPath("eks", filepath.Join(cwd, "..", "bin")),
 		opttest.YarnLink("@pulumi/eks"),
 	}
 	tw := &testWrapper{PT: t, expectFailure: expectFailure}
-	test := pulumitest.NewPulumiTest(tw, dir, options...)
-	test.SetConfig(t, "property", property)
-	test.SetConfig(t, "n", fmt.Sprintf("%d", n))
-	test.Preview(t)
+	test := pulumitest.NewPulumiTest(tw, testDir, options...)
+	config(test)
+
+	test.Preview(tw)
 	if expectFailure {
 		require.Truef(t, tw.failed, "Expected preview to fail due to invalid inputs but it succeeded")
 	}


### PR DESCRIPTION
### Proposed changes

This change adds support for configuring [EFA](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html) for Managed Node Groups. EFA is a high-speed network device for instance to instance communication, usually used in AI or HPC scenarios.

The change involves adding two new input properties:
- `enableEfaSupport`
- `placementGroupAvailabilityZone`

`placementGroupAvailabilityZone` is necessary because EFA does not work cross-AZ. We also cannot pick a random AZ based on the subnets because intersection of subnets and supported AZs (by the instance) is not stable.
When AWS adds support for certain instance types to new AZs this selection would change and cause a replacement of the whole node group.

Right now I made `placementGroupAvailabilityZone` a required input when `enableEfaSupport` is set to true. This way users will not be susceptible to this foot gun. This is in line with what other tools in the eco system are doing/planning to do (e.g. https://github.com/terraform-aws-modules/terraform-aws-eks/blob/50cb230c8a1793f5ef4cc52c4c789b656b141168/modules/eks-managed-node-group/main.tf#L645-L648).

### Related issues (optional)

Closes https://github.com/pulumi/pulumi-eks/issues/1564
