### PR TITLE
Remove non-existant `subnetIds` field from `TestIgnoringScalingChanges`

### DIFF
--- a/tests/testdata/programs/ignore-scaling-changes/index.ts
+++ b/tests/testdata/programs/ignore-scaling-changes/index.ts
@@ -61,4 +61,5 @@ const ngV2 = new eks.NodeGroupV2("ignore-scaling-config-ngv2", {
   operatingSystem: eks.OperatingSystem.AL2023,
   instanceProfile: new aws.iam.InstanceProfile("ignore-scaling-config-ngv2", {role: ngV2Role}),
   ignoreScalingChanges: true,
+  nodeSubnetIds: eksVpc.privateSubnetIds,
 });

--- a/tests/testdata/programs/ignore-scaling-changes/index.ts
+++ b/tests/testdata/programs/ignore-scaling-changes/index.ts
@@ -61,5 +61,4 @@ const ngV2 = new eks.NodeGroupV2("ignore-scaling-config-ngv2", {
   operatingSystem: eks.OperatingSystem.AL2023,
   instanceProfile: new aws.iam.InstanceProfile("ignore-scaling-config-ngv2", {role: ngV2Role}),
   ignoreScalingChanges: true,
-  subnetIds: eksVpc.privateSubnetIds,
 });


### PR DESCRIPTION
### Proposed changes

Fixes the `TestIgnoringScalingChanges`. Previously, the following ` Object literal may only specify known properties, and 'subnetIds' does not exist in type 'NodeGroupV2Args'.` error occurs when running the upgrade test.

### Related issues (optional)

Fixes: #1601 
