### PR TITLE
Fix EKS autoMode preview with unknown values

### DIFF
--- a/tests/testdata/programs/auto-mode-custom-role/Pulumi.yaml
+++ b/tests/testdata/programs/auto-mode-custom-role/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: auto-mode-custom-role
+description: EKS Cluster in auto mode with custom node role
+runtime: nodejs

--- a/tests/testdata/programs/auto-mode-custom-role/index.ts
+++ b/tests/testdata/programs/auto-mode-custom-role/index.ts
@@ -1,0 +1,51 @@
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as aws from "@pulumi/aws";
+
+const eksVpc = new awsx.ec2.Vpc("auto-mode-custom-role", {
+    enableDnsHostnames: true,
+    cidrBlock: "10.0.0.0/16",
+    numberOfAvailabilityZones: 2,
+    subnetStrategy: "Auto",
+});
+
+const nodeRole = new aws.iam.Role("auto-mode-custom-role", {
+    assumeRolePolicy: aws.iam.getPolicyDocumentOutput({
+        version: "2012-10-17",
+        statements: [{
+            effect: "Allow",
+            principals: [{
+                type: "Service",
+                identifiers: ["ec2.amazonaws.com"]
+            }],
+            actions: ["sts:AssumeRole", "sts:TagSession"]
+        }]
+    }).json
+});
+
+const attachments = [
+    new aws.iam.RolePolicyAttachment("eks-node-role-policy-worker-node-minimal", {
+        role: nodeRole,
+        policyArn: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy",
+    }),
+    new aws.iam.RolePolicyAttachment("eks-node-role-policy-ecr-pull", {
+        role: nodeRole,
+        policyArn: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly",
+    }),
+];
+
+const cluster = new eks.Cluster("auto-mode-custom-role", {
+    vpcId: eksVpc.vpcId,
+    authenticationMode: eks.AuthenticationMode.Api,
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    privateSubnetIds: eksVpc.privateSubnetIds,
+    autoMode: {
+        enabled: true,
+        createNodeRole: false,
+        computeConfig: {
+            nodeRoleArn: nodeRole.arn,
+        }
+    }
+}, { dependsOn: [...attachments] });
+
+export const kubeconfig = cluster.kubeconfig;

--- a/tests/testdata/programs/auto-mode-custom-role/package.json
+++ b/tests/testdata/programs/auto-mode-custom-role/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "auto-mode-custom-role",
+    "devDependencies": {
+        "typescript": "^4.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/eks": "^3.0.0",
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/tests/testdata/programs/auto-mode-custom-role/tsconfig.json
+++ b/tests/testdata/programs/auto-mode-custom-role/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/testdata/programs/auto-mode-preview/Pulumi.yaml
+++ b/tests/testdata/programs/auto-mode-preview/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: auto-mode-preview
+description: EKS Cluster in auto mode
+runtime: nodejs

--- a/tests/testdata/programs/auto-mode-preview/index.ts
+++ b/tests/testdata/programs/auto-mode-preview/index.ts
@@ -1,0 +1,82 @@
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+import * as aws from "@pulumi/aws";
+import * as random from "@pulumi/random";
+
+const eksVpc = new awsx.ec2.Vpc("eks-vpc", {
+    enableDnsHostnames: true,
+    cidrBlock: "10.0.0.0/16",
+    numberOfAvailabilityZones: 2,
+    subnetStrategy: "Auto",
+});
+
+const nodeRole = new aws.iam.Role("eks-node-role", {
+    assumeRolePolicy: aws.iam.getPolicyDocumentOutput({
+        version: "2012-10-17",
+        statements: [{
+            effect: "Allow",
+            principals: [{
+                type: "Service",
+                identifiers: ["ec2.amazonaws.com"]
+            }],
+            actions: ["sts:AssumeRole", "sts:TagSession"]
+        }]
+    }).json
+});
+
+const attachments = [
+    new aws.iam.RolePolicyAttachment("eks-node-role-policy-worker-node-minimal", {
+        role: nodeRole,
+        policyArn: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy",
+    }),
+    new aws.iam.RolePolicyAttachment("eks-node-role-policy-ecr-pull", {
+        role: nodeRole,
+        policyArn: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly",
+    }),
+];
+
+const randomId = new random.RandomId("random-id", {
+    byteLength: 8,
+});
+
+new eks.Cluster("eks-cluster-unknown-compute-config", {
+    vpcId: eksVpc.vpcId,
+    authenticationMode: eks.AuthenticationMode.Api,
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    privateSubnetIds: eksVpc.privateSubnetIds,
+    autoMode: {
+        enabled: true,
+        createNodeRole: false,
+        computeConfig: {
+            nodeRoleArn: nodeRole.arn,
+        }
+    }
+}, { dependsOn: [...attachments] });
+
+new eks.Cluster("eks-cluster-unknown-ip-family", {
+    vpcId: eksVpc.vpcId,
+    authenticationMode: eks.AuthenticationMode.Api,
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    privateSubnetIds: eksVpc.privateSubnetIds,
+    ipFamily: randomId.dec.apply(_ => "ipv4"),
+    autoMode: {
+        enabled: true,
+    }
+});
+
+new eks.Cluster("auto-mode", {
+    vpcId: eksVpc.vpcId,
+    authenticationMode: eks.AuthenticationMode.Api,
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    privateSubnetIds: eksVpc.privateSubnetIds,
+    autoMode: {
+        enabled: true,
+    }
+});
+
+new eks.Cluster("regular-cluster", {
+    vpcId: eksVpc.vpcId,
+    authenticationMode: eks.AuthenticationMode.Api,
+    publicSubnetIds: eksVpc.publicSubnetIds,
+    privateSubnetIds: eksVpc.privateSubnetIds,
+});

--- a/tests/testdata/programs/auto-mode-preview/package.json
+++ b/tests/testdata/programs/auto-mode-preview/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "auto-mode-preview",
+    "devDependencies": {
+        "typescript": "^4.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/eks": "^3.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "@pulumi/random": "^4.17.0"
+    }
+}

--- a/tests/testdata/programs/auto-mode-preview/tsconfig.json
+++ b/tests/testdata/programs/auto-mode-preview/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
The diff customizer of the upstream provider is not taking possibly unknown values into account (see https://github.com/hashicorp/terraform-provider-aws/blob/ae93494f39ba70fe442e891caf05f8df21bde1ac/internal/service/eks/cluster.go#L1776-L1791), which causes failures like this one:
```
* compute_config.enabled, kubernetes_networking_config.elastic_load_balancing.enabled, and storage_config.block_storage.enabled must all be set to either true or false
```
This happens because `unknown` attributes just default to their empty values in a diff customizer if they're unknown .

This change acts a hot fix until we can properly fix upstream's behavior here. The current diff for auto mode is quite broken and needs some more involved fixes (see https://github.com/hashicorp/terraform-provider-aws/issues/40582).

Fixes https://github.com/pulumi/pulumi-eks/issues/1597