### PR TITLE
Use a mix of instance types for EFA test

### DIFF
--- a/examples/efa/index.ts
+++ b/examples/efa/index.ts
@@ -5,7 +5,7 @@ import * as k8s from "@pulumi/kubernetes";
 import * as iam from "./iam";
 
 const config = new pulumi.Config();
-const instanceType = config.require("instanceType");
+const instanceTypes = config.require("instanceTypes").split(",");
 const availabilityZones = config.require("availabilityZones").split(",");
 
 const eksVpc = new awsx.ec2.Vpc("efa", {
@@ -54,7 +54,7 @@ const efaDevicePlugin = new k8s.helm.v3.Release("efa-device-plugin", {
 // node group to run EFA enabled workloads
 const efaMng = new eks.ManagedNodeGroup("efa-mng", {
     cluster: cluster,
-    instanceTypes: [instanceType],
+    instanceTypes: instanceTypes,
     // EFA needs at least 2 instances, otherwise there's nothing to communicate with
     scalingConfig: {
         minSize: 2,

--- a/tests/nodejs_test.go
+++ b/tests/nodejs_test.go
@@ -1078,16 +1078,16 @@ func TestAccEfa(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	// this is one of the cheapest instances that support EFA
-	instanceType := "g6.8xlarge"
-	supportedAZs, err := utils.FindSupportedAZs(t, instanceType)
+	// these are the cheapest instances that support EFA. We're using a mix of instance types to ensure availability
+	instanceTypes := []string{"g6.8xlarge", "g4dn.8xlarge", "gr6.8xlarge", "g5.8xlarge", "g6.16xlarge"}
+	supportedAZs, err := utils.FindSupportedAZs(t, instanceTypes)
 	require.NoError(t, err)
 
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getExamples(t), "efa"),
 			Config: map[string]string{
-				"instanceType":      instanceType,
+				"instanceTypes":     strings.Join(instanceTypes, ","),
 				"availabilityZones": strings.Join(supportedAZs, ","),
 			},
 			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
@@ -1124,19 +1124,19 @@ func TestAccAutoModeCustomRole(t *testing.T) {
 	}
 
 	test := getJSBaseOptions(t).
-	With(integration.ProgramTestOptions{
-		Dir: path.Join(getTestPrograms(t), "auto-mode-custom-role"),
-		ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
-			utils.ValidateClusters(t, info.Deployment.Resources,
-				utils.WithKubeConfigs(info.Outputs["kubeconfig"]),
-				utils.ValidateDaemonSets(), // no daemonsets in auto mode
-				utils.ValidateDeployments(
-					utils.KubernetesResource{Name: "nginx", Namespace: "nginx"},
-					utils.KubernetesResource{Name: "coredns", Namespace: "kube-system"},
-				),
-			)
-		},
-	})
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getTestPrograms(t), "auto-mode-custom-role"),
+			ExtraRuntimeValidation: func(t *testing.T, info integration.RuntimeValidationStackInfo) {
+				utils.ValidateClusters(t, info.Deployment.Resources,
+					utils.WithKubeConfigs(info.Outputs["kubeconfig"]),
+					utils.ValidateDaemonSets(), // no daemonsets in auto mode
+					utils.ValidateDeployments(
+						utils.KubernetesResource{Name: "nginx", Namespace: "nginx"},
+						utils.KubernetesResource{Name: "coredns", Namespace: "kube-system"},
+					),
+				)
+			},
+		})
 
 	programTestWithExtraOptions(t, &test, nil)
 }

--- a/tests/validation_test.go
+++ b/tests/validation_test.go
@@ -36,7 +36,7 @@ func TestEfaInputValidation(t *testing.T) {
 	azs, err := utils.ListAvailabilityZones(t)
 	require.NoError(t, err)
 
-	supportedAZs, err := utils.FindSupportedAZs(t, "g6.8xlarge")
+	supportedAZs, err := utils.FindSupportedAZs(t, []string{"g6.8xlarge"})
 	require.NoError(t, err)
 
 	var unsupportedAZ []string
@@ -83,7 +83,7 @@ func TestEfaInputValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkEksClusterInputValidations(t, filepath.Join(getExamples(t), "efa"), func(pt *pulumitest.PulumiTest) {
-				pt.SetConfig(t, "instanceType", tt.instanceType)
+				pt.SetConfig(t, "instanceTypes", tt.instanceType)
 				pt.SetConfig(t, "availabilityZones", tt.azs)
 			}, tt.wantErr)
 		})


### PR DESCRIPTION
GPU instances seem to be in high demand. To make sure the EFA tests have a higher chance of passing, we can use a mix of instance types.

Fixes https://github.com/pulumi/pulumi-eks/issues/1607
