### PR TITLE
chore: temporarily disable renovate automerge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,5 +12,6 @@
         executionMode: "branch", // Only run once.
       },
     },
-  ]
+  ],
+  automerge: false
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

https://github.com/pulumi/pulumi-eks/pull/1576 merged where it shouldn't have.

Looks like failures in `make renovate` do not block renovate merges.

Another problem  is that CI regressed on having checks that ensure the generated SDKs are up to date.

While we fix these issues I suggest we disable renovate auto-merges.



<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
