### PR TITLE
chore: script make renovate

### DIFF
--- a/scripts/renovate.sh
+++ b/scripts/renovate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+make generate
+yarn --cwd nodejs/eks install --frozen-lockfile
+yarn --cwd nodejs/eks dedupe-deps


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

After recent changes, Renovate bot invokes `make renovate` that delegates to ./script/renovate.sh but we omitted checking that in. Here is a version adapted from pulumi-awsx that should re-generate the dependencies and dedup the deps.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
