### PR TITLE
Fix cron job make entrypoints

### DIFF
--- a/.github/workflows/eks-cron.yml
+++ b/.github/workflows/eks-cron.yml
@@ -541,6 +541,9 @@ jobs:
         run: cd tests && go test -tags=go -count=1 -cover -timeout 3h -parallel 6 .
 name: cron
 "on":
+  push:
+    branches:
+      - rquitales/fix-cron
   schedule:
     # Run every day at 06:00AM UTC
     - cron: "0 6 * * *"

--- a/.github/workflows/eks-cron.yml
+++ b/.github/workflows/eks-cron.yml
@@ -48,7 +48,7 @@ jobs:
           echo "$HOME/.yarn/bin" >> "$GITHUB_PATH"
           echo "$HOME/.config/yarn/global/node_modules/.bin" >> "$GITHUB_PATH"
       - name: Run nodejs linter
-        run: make lint
+        run: yarn --cwd nodejs/eks install --frozen-lockfile && yarn --cwd nodejs/eks lint-check
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -56,7 +56,7 @@ jobs:
           args: -c ../.golangci.yml
           working-directory: provider
       - name: Run unit tests
-        run: make test_unit_tests
+        run: yarn --cwd nodejs/eks install --frozen-lockfile && yarn --cwd nodejs/eks run test
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
@@ -440,7 +440,6 @@ jobs:
         run: tar -zxf ${{ github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
       - name: Install dependencies
         run: make install_dotnet_sdk
-      - run: dotnet nuget add source ${{ github.workspace }}/nuget
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/eks-cron.yml
+++ b/.github/workflows/eks-cron.yml
@@ -541,9 +541,6 @@ jobs:
         run: cd tests && go test -tags=go -count=1 -cover -timeout 3h -parallel 6 .
 name: cron
 "on":
-  push:
-    branches:
-      - rquitales/fix-cron
   schedule:
     # Run every day at 06:00AM UTC
     - cron: "0 6 * * *"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

When onboarding pulumi-eks to ci-mgmt, our make targets were updated to be uniform with other providers. This requires us to update our existing, self-managed, cron job workflow to be updated as well.

A [successful test run of the cron job](https://github.com/pulumi/pulumi-eks/actions/runs/13082831233) against this PR was run to validate that this work will unblock CI.

### Related issues (optional)

Fixes: #1605 