### PR TITLE
Allow `pulumi.Output` in EKS Addon `configurationValues`

### DIFF
--- a/nodejs/eks/addons/addon.ts
+++ b/nodejs/eks/addons/addon.ts
@@ -24,7 +24,7 @@ import { Cluster } from "../cluster";
 export interface AddonOptions
     extends Omit<aws.eks.AddonArgs, "resolveConflicts" | "clusterName" | "configurationValues"> {
     cluster: Cluster;
-    configurationValues?: object;
+    configurationValues?: pulumi.Input<object>;
 }
 
 /**
@@ -47,7 +47,7 @@ export class Addon extends pulumi.ComponentResource {
             {
                 ...args,
                 clusterName: cluster.core.cluster.name,
-                configurationValues: JSON.stringify(args.configurationValues),
+                configurationValues: pulumi.output(args.configurationValues).apply(JSON.stringify),
             },
             { parent: this, provider: opts?.provider },
         );

--- a/nodejs/eks/addons/addon.ts
+++ b/nodejs/eks/addons/addon.ts
@@ -47,7 +47,7 @@ export class Addon extends pulumi.ComponentResource {
             {
                 ...args,
                 clusterName: cluster.core.cluster.name,
-                configurationValues: pulumi.output(args.configurationValues).apply(JSON.stringify),
+                configurationValues: stringifyAddonConfiguration(args.configurationValues),
             },
             { parent: this, provider: opts?.provider },
         );

--- a/nodejs/eks/addons/addon.ts
+++ b/nodejs/eks/addons/addon.ts
@@ -37,10 +37,9 @@ export class Addon extends pulumi.ComponentResource {
     constructor(name: string, args: AddonOptions, opts?: pulumi.CustomResourceOptions) {
         const cluster = args.cluster;
 
-        super("eks:index:Addon", name, args, {
-            ...opts,
+        super("eks:index:Addon", name, args, pulumi.mergeOptions(opts, {
             parent: cluster,
-        });
+        }));
 
         const addon = new aws.eks.Addon(
             name,

--- a/nodejs/eks/addons/addon.ts
+++ b/nodejs/eks/addons/addon.ts
@@ -46,7 +46,9 @@ export class Addon extends pulumi.ComponentResource {
             {
                 ...args,
                 clusterName: cluster.core.cluster.name,
-                configurationValues: stringifyAddonConfiguration(args.configurationValues),
+                configurationValues: args.configurationValues
+                    ? pulumi.jsonStringify(args.configurationValues)
+                    : undefined,
             },
             { parent: this, provider: opts?.provider },
         );


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Someone went through the effort of creating a stringify function and forgot to use it 😁 

**Edit by @guineveresaenger:** To preserve ordering I took the author's suggestion and used `pulumi.jsonStringify`. This should fix up the PR enough to be mergeable. If a reviewer would like ordering-specific testing, we can do so; however this is a minor enough refactor that I do not think explicit test is warranted.

