### PR TITLE
Fix AMI

### DIFF
--- a/examples/custom-managed-nodegroup/index.ts
+++ b/examples/custom-managed-nodegroup/index.ts
@@ -36,7 +36,7 @@ export const defaultInstanceRoles = cluster.instanceRoles;
 // Export the cluster's kubeconfig.
 export const kubeconfig = cluster.kubeconfig;
 
-const ami = pulumi.interpolate`/aws/service/eks/optimized-ami/${cluster.core.cluster.version}/amazon-linux-2/recommended/image_id`.apply(name =>
+const ami = pulumi.interpolate`/aws/service/eks/optimized-ami/${cluster.core.cluster.version}/amazon-linux-2023/x86_64/standard/recommended/image_id`.apply(name =>
   aws.ssm.getParameter({ name }, { async: true })
 ).apply(result => result.value);
 


### PR DESCRIPTION
amazon-linux-2 is deprecated and isn't available for recent k8s releases.