### PR TITLE
revert Service role dns suffix on eks service

### DIFF
--- a/nodejs/eks/cluster/cluster.ts
+++ b/nodejs/eks/cluster/cluster.ts
@@ -528,7 +528,7 @@ export function createCore(
         eksServiceRole = new ServiceRole(
             `${name}-eksRole`,
             {
-                service: pulumi.interpolate`eks.${dnsSuffix}`,
+                service: "eks.amazonaws.com",
                 description: "Allows EKS to manage clusters on your behalf.",
                 managedPolicyArns: managedPolicies.map((policy) => ({
                     id: `arn:aws:iam::aws:policy/${policy}`,


### PR DESCRIPTION
Proposed change for fixing issue on: https://github.com/pulumi/pulumi-eks/issues/1861