### PR TITLE
fix service url for eks

### DIFF
--- a/nodejs/eks/cluster/cluster.ts
+++ b/nodejs/eks/cluster/cluster.ts
@@ -528,7 +528,8 @@ export function createCore(
         eksServiceRole = new ServiceRole(
             `${name}-eksRole`,
             {
-                service: pulumi.interpolate`eks.${dnsSuffix}`,
+                // All aws partitions use same service for eks
+                service: "eks.amazonaws.com",
                 description: "Allows EKS to manage clusters on your behalf.",
                 managedPolicyArns: managedPolicies.map((policy) => ({
                     id: `arn:aws:iam::aws:policy/${policy}`,
@@ -1117,7 +1118,8 @@ export function createCore(
                     new ServiceRole(
                         `${name}-podExecutionRole`,
                         {
-                            service: pulumi.interpolate`eks-fargate-pods.${dnsSuffix}`,
+                            // // All aws partitions use same service for eks fargate pod
+                            service: "eks-fargate-pods.amazonaws.com",
                             managedPolicyArns: [
                                 {
                                     id: "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy",


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
fix error in CN region:
```
error:   sdk-v2/provider2.go:566: sdk.helper_schema: updating IAM Role (services-eksRole-role-ce1c4be) assume role policy: operation error IAM: UpdateAssumeRolePolicy, https response error StatusCode: 400, RequestID: 13b4dfa8-d76f-49bd-a40d-xxxxxxx, MalformedPolicyDocument: Invalid principal in policy: "SERVICE":"eks.amazonaws.com.cn": provider=aws@6.79.1
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
