### PR TITLE
Remove brace formatting from eslint

### DIFF
--- a/nodejs/eks/.eslintrc.js
+++ b/nodejs/eks/.eslintrc.js
@@ -87,7 +87,6 @@ module.exports = {
             },
         ],
         "arrow-parens": ["off", "always"],
-        "brace-style": ["error", "1tbs"],
         "comma-dangle": ["error", "always-multiline"],
         curly: "error",
         "default-case": "error",


### PR DESCRIPTION
#1868 didn't do the trick because eslint and prettier have different opinions about how braces should look.

Let's just let prettier handle it.

Fixes #1870.