### PR TITLE
Added support for Cluster deletionProtection

### DIFF
--- a/nodejs/eks/cluster/cluster.ts
+++ b/nodejs/eks/cluster/cluster.ts
@@ -739,6 +739,7 @@ export function createCore(
                   }
                 : undefined,
             upgradePolicy: args.upgradePolicy,
+            deletionProtection: args.deletionProtection,
         },
         {
             parent,
@@ -1916,6 +1917,11 @@ export interface ClusterOptions {
      * The cluster's upgrade policy. Valid values are "STANDARD" and "EXTENDED". Defaults to "EXTENDED".
      */
     upgradePolicy?: aws.types.input.eks.ClusterUpgradePolicy;
+
+    /**
+     * Whether to enable deletion protection for the cluster. When enabled, the cluster cannot be deleted unless deletion protection is first disabled. Default: `false`.
+     */
+    deletionProtection?: boolean;
 }
 
 /**

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -27,7 +27,7 @@
     "bugs": "https://github.com/pulumi/pulumi-eks/issues",
     "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@pulumi/aws": "7.1.0",
+        "@pulumi/aws": "7.10.0",
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/pulumi": "^3.143.0",
         "https-proxy-agent": "^5.0.1",
@@ -86,5 +86,6 @@
         ".eslintrc.js",
         "babel.config.js",
         "bin"
-    ]
+    ],
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/nodejs/eks/yarn.lock
+++ b/nodejs/eks/yarn.lock
@@ -1723,10 +1723,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/aws@7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.1.0.tgz#e72c74419b1e81e3e50dfac877e5be37608774d1"
-  integrity sha512-zloUYR9eID6eLmMBVhqdZl9Yo0kKhv4qk9vY6ij56oD3MuERs97q++xiTCHCP4ATLZM6rlh0EBKxET7ujpb24Q==
+"@pulumi/aws@7.10.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.10.0.tgz#1696b16f5c3b7ca887447c4174f32d525db9e79d"
+  integrity sha512-1ykqa7bRcXv7iAmfBdfLckVwbaORsZbOHsqyHZk8A0gcM0RVrv38u3EagQTq13yNjZCaYdfzM2zTYpim2fDUVQ==
   dependencies:
     "@pulumi/pulumi" "^3.142.0"
     mime "^2.0.0"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Add support for passing the deletion protection flag to the `aws.eks.Cluster`, introduced with [pulumi.aws 7.5.0](https://github.com/pulumi/pulumi-aws/releases/tag/v7.5.0) via [terraform-provider-aws#43779](https://github.com/hashicorp/terraform-provider-aws/pull/43779) (Released in v6.9.0)

### Related issues (optional)

