### PR TITLE
Update to pulumi 3.215

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pulumi/pulumi-aws/sdk/v7 v7.1.0
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.9.1
-	github.com/pulumi/pulumi/sdk/v3 v3.175.0
+	github.com/pulumi/pulumi/sdk/v3 v3.215.0
 )
 
 require (


### PR DESCRIPTION
Current working hypothesis: When we replaced the pulumi mise version from `latest` to the one provider by `vfox-pulumi`, `pulumi-eks` started picked version 3.175 which is set on the `go.mod` file. This results in tests running using an old Pulumi version.

Related PR: #2069

Part of: #2052