### PR TITLE
Configure update schedule for Pulumi dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,6 +24,19 @@
         executionMode: "branch", // Only run once.
       },
     },
+    {
+      // Override first-party Pulumi dependencies to update only between 12am and 3am
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/pulumi/**", "!github.com/pulumi/terraform-plugin-sdk/v2"],
+      ignoreUnstable: false, // Accept latest.
+      matchDepTypes: ["require", "indirect"], // pkg can sometimes be an indirect dependency.
+
+      groupName: "first-party Pulumi dependencies",
+      groupSlug: "pulumi",
+      dependencyDashboardApproval: false,
+      "schedule": ["* 0-3 * * *"], // 
+      "updateNotScheduled": false,
+    },
   ],
   automerge: false
 }


### PR DESCRIPTION
Fixes #2122

See: https://docs.renovatebot.com/configuration-options/#updatenotscheduled
Original snippet we are overriding: https://github.com/pulumi/renovate-config/blob/main/default.json5#L144C1-L154C7

Added configuration to update first-party Pulumi dependencies between 12am and 3am. This should prevent the eternal cancellation of run acceptance tests that is making us hit AWS account limits.

