### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/.github/actions/esc-action/index.js
+++ b/.github/actions/esc-action/index.js
@@ -3,7 +3,24 @@ const fs = require("fs");
 const file = process.env["GITHUB_OUTPUT"];
 var stream = fs.createWriteStream(file, { flags: "a" });
 
-for (const [name, value] of Object.entries(process.env)) {
+const outputNames = (process.env["INPUT_OUTPUTS"] || "")
+  .split(",")
+  .map((name) => name.trim())
+  .filter(Boolean);
+
+const sensitivePrefixes = ["SECRET", "TOKEN", "KEY", "PASSWORD", "CREDENTIAL"];
+
+for (const name of outputNames) {
+  const value = process.env[name];
+
+  if (value === undefined) {
+    continue;
+  }
+
+  if (sensitivePrefixes.some((prefix) => name.toUpperCase().startsWith(prefix))) {
+    continue;
+  }
+
   try {
     stream.write(`${name}<<EEEOOOFFF\n${value}\nEEEOOOFFF\n`); // << syntax accommodates multiline strings.
   } catch (err) {


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `.github/actions/esc-action/index.js:L6`

The custom action iterates over all environment variables and writes each one to `GITHUB_OUTPUT`. This can unintentionally expose sensitive values (for example, tokens, cloud credentials, CI secrets) to downstream workflow steps as outputs, expanding the blast radius if any later step is compromised or untrusted.

## Solution

Do not export all environment variables. Use an explicit allowlist of safe variable names to output. Exclude known sensitive prefixes (`SECRET`, `TOKEN`, `KEY`, `PASSWORD`, etc.) and avoid propagating credentials through `GITHUB_OUTPUT` entirely.

## Changes

- `.github/actions/esc-action/index.js` (modified)