### PR TITLE
Add kind/component keyword so the registry lists eks as a component

### DIFF
--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -192,7 +192,7 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 		Name:        "eks",
 		Description: "Pulumi Amazon Web Services (AWS) EKS Components.",
 		License:     "Apache-2.0",
-		Keywords:    []string{"pulumi", "aws", "eks"},
+		Keywords:    []string{"pulumi", "aws", "eks", "kind/component"},
 		Homepage:    "https://pulumi.com",
 		Repository:  "https://github.com/pulumi/pulumi-eks",
 

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -4,7 +4,8 @@
     "keywords": [
         "pulumi",
         "aws",
-        "eks"
+        "eks",
+        "kind/component"
     ],
     "homepage": "https://pulumi.com",
     "license": "Apache-2.0",


### PR DESCRIPTION
The registry marks a package as a component only when its schema keywords contain kind/component. Without it, eks was listed as a native provider.

Closes #2270

~~Blocked by https://github.com/pulumi/pulumi-eks/issues/2243 (CI failures)~~ Fix merged and this PR has been rebased to get the fixes