### PR TITLE
Bump examples and test programs to Node.js 22 and TypeScript 5

### DIFF
--- a/examples/authentication-mode/package.json
+++ b/examples/authentication-mode/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-cluster",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/aws-profile-role/package.json
+++ b/examples/aws-profile-role/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-aws-profile-role",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/aws": "7.25.0",

--- a/examples/aws-profile/package.json
+++ b/examples/aws-profile/package.json
@@ -1,7 +1,8 @@
 {
     "name": "example-aws-profile",
     "devDependencies": {
-        "typescript": "^4.0.0"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/cluster-with-serviceiprange/package.json
+++ b/examples/cluster-with-serviceiprange/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-cluster-with-serviceiprange",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/cluster/package.json
+++ b/examples/cluster/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-cluster",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/custom-managed-nodegroup/package.json
+++ b/examples/custom-managed-nodegroup/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-managed-nodegroups",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "3.5.0",

--- a/examples/deletion-policy/package.json
+++ b/examples/deletion-policy/package.json
@@ -1,8 +1,8 @@
 {
     "name": "deletion-policy",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/efa/package.json
+++ b/examples/efa/package.json
@@ -1,8 +1,8 @@
 {
     "name": "efa",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/eks-auto-mode/package.json
+++ b/examples/eks-auto-mode/package.json
@@ -1,8 +1,8 @@
 {
     "name": "eks-auto-mode",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/encryption-provider/package.json
+++ b/examples/encryption-provider/package.json
@@ -1,7 +1,8 @@
 {
     "name": "encryption-provider",
     "devDependencies": {
-        "typescript": "^4.0.0"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/ensure-cni-upgrade/package.json
+++ b/examples/ensure-cni-upgrade/package.json
@@ -1,8 +1,8 @@
 {
     "name": "ensure-cni-upgrade",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/extra-sg/package.json
+++ b/examples/extra-sg/package.json
@@ -1,7 +1,8 @@
 {
     "name": "extra-sg",
     "devDependencies": {
-        "typescript": "^4.0.0"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/fargate/package.json
+++ b/examples/fargate/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-cluster",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/managed-nodegroups/package.json
+++ b/examples/managed-nodegroups/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-managed-nodegroups",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "3.5.0",

--- a/examples/modify-default-eks-sg/package.json
+++ b/examples/modify-default-eks-sg/package.json
@@ -1,8 +1,8 @@
 {
     "name": "modify-default-eks-sg",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/network-policies/package.json
+++ b/examples/network-policies/package.json
@@ -1,8 +1,8 @@
 {
     "name": "network-policies",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/examples/nodegroup/package.json
+++ b/examples/nodegroup/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-nodegroup",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/oidc-iam-sa/package.json
+++ b/examples/oidc-iam-sa/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-oidc-iam-sa",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/aws": "7.25.0",

--- a/examples/pod-security-groups/package.json
+++ b/examples/pod-security-groups/package.json
@@ -1,8 +1,8 @@
 {
     "name": "pod-security-groups",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/examples/scoped-kubeconfigs/package.json
+++ b/examples/scoped-kubeconfigs/package.json
@@ -1,7 +1,8 @@
 {
     "name": "scoped-kubeconfigs",
     "devDependencies": {
-        "typescript": "^4.0.0"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/aws": "7.25.0",

--- a/examples/storage-classes/package.json
+++ b/examples/storage-classes/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-storage-classes",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/eks": "latest",

--- a/examples/subnet-tags/package.json
+++ b/examples/subnet-tags/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-subnet-tags",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/examples/tags/package.json
+++ b/examples/tags/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-tags",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",

--- a/tests/testdata/programs/authentication-mode-migration/step1/package.json
+++ b/tests/testdata/programs/authentication-mode-migration/step1/package.json
@@ -1,8 +1,8 @@
 {
     "name": "example-cluster",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/auto-mode-custom-role/package.json
+++ b/tests/testdata/programs/auto-mode-custom-role/package.json
@@ -1,8 +1,8 @@
 {
     "name": "auto-mode-custom-role",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/awsx": "^2.0.2",

--- a/tests/testdata/programs/auto-mode-preview/package.json
+++ b/tests/testdata/programs/auto-mode-preview/package.json
@@ -1,8 +1,8 @@
 {
     "name": "auto-mode-preview",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/awsx": "^2.0.2",

--- a/tests/testdata/programs/auto-mode-upgrade/package.json
+++ b/tests/testdata/programs/auto-mode-upgrade/package.json
@@ -1,8 +1,8 @@
 {
     "name": "eks-auto-mode",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/cluster-addons/package.json
+++ b/tests/testdata/programs/cluster-addons/package.json
@@ -1,8 +1,8 @@
 {
     "name": "cluster-addons",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/tests/testdata/programs/cluster-input-validations/package.json
+++ b/tests/testdata/programs/cluster-input-validations/package.json
@@ -2,7 +2,7 @@
     "name": "cluster-input-validations",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^18",
+        "@types/node": "^22",
         "typescript": "^5.0.0"
     },
     "dependencies": {

--- a/tests/testdata/programs/default-instance-role/package.json
+++ b/tests/testdata/programs/default-instance-role/package.json
@@ -1,8 +1,8 @@
 {
     "name": "default-instance-role",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/tests/testdata/programs/ignore-scaling-changes/package.json
+++ b/tests/testdata/programs/ignore-scaling-changes/package.json
@@ -1,8 +1,8 @@
 {
     "name": "ignore-scaling-changes",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/tests/testdata/programs/managed-ng-aws-auth/package.json
+++ b/tests/testdata/programs/managed-ng-aws-auth/package.json
@@ -1,8 +1,8 @@
 {
     "name": "managed-ng-aws-auth",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/managed-ng-disk-size/package.json
+++ b/tests/testdata/programs/managed-ng-disk-size/package.json
@@ -1,8 +1,8 @@
 {
     "name": "managed-ng-disk-size",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/managed-ng-missing-role/package.json
+++ b/tests/testdata/programs/managed-ng-missing-role/package.json
@@ -1,8 +1,8 @@
 {
     "name": "managed-ng-missing-role",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/managed-ng-os/package.json
+++ b/tests/testdata/programs/managed-ng-os/package.json
@@ -1,8 +1,8 @@
 {
     "name": "managed-ng-os",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/tests/testdata/programs/managed-ng-with-version/package.json
+++ b/tests/testdata/programs/managed-ng-with-version/package.json
@@ -1,8 +1,8 @@
 {
     "name": "managed-ng-with-version",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/multi-role/package.json
+++ b/tests/testdata/programs/multi-role/package.json
@@ -1,8 +1,8 @@
 {
     "name": "multi-role",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/replace-cluster-add-subnets/package.json
+++ b/tests/testdata/programs/replace-cluster-add-subnets/package.json
@@ -1,8 +1,8 @@
 {
     "name": "test-replace-cluster-add-subnets",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",

--- a/tests/testdata/programs/scalar-types/package.json
+++ b/tests/testdata/programs/scalar-types/package.json
@@ -1,8 +1,8 @@
 {
     "name": "scalar-types",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/tests/testdata/programs/self-managed-ng-instanceProfile/package.json
+++ b/tests/testdata/programs/self-managed-ng-instanceProfile/package.json
@@ -1,8 +1,8 @@
 {
     "name": "self-managed-ng-os",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^2.0.0",

--- a/tests/testdata/programs/self-managed-ng-os/package.json
+++ b/tests/testdata/programs/self-managed-ng-os/package.json
@@ -1,8 +1,8 @@
 {
     "name": "self-managed-ng-os",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^2.0.0",

--- a/tests/testdata/programs/skip-default-security-groups/package.json
+++ b/tests/testdata/programs/skip-default-security-groups/package.json
@@ -1,8 +1,8 @@
 {
     "name": "skip-default-security-groups",
     "devDependencies": {
-        "@types/node": "latest",
-        "typescript": "^4.0.0"
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",

--- a/tests/testdata/programs/tag-input-types/package.json
+++ b/tests/testdata/programs/tag-input-types/package.json
@@ -1,8 +1,8 @@
 {
     "name": "test-tag-input-types",
     "devDependencies": {
-        "typescript": "^4.0.0",
-        "@types/node": "latest"
+        "typescript": "^5.0.0",
+        "@types/node": "^22"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",


### PR DESCRIPTION
## Summary

The `examples/` and `tests/testdata/programs/` projects floated `@types/node` to `"latest"`, which now resolves to type definitions using `const` type parameters (`ffi.d.ts`) that TypeScript `^4.0.0` cannot parse, breaking `tsc` in the acceptance tests. This pins `@types/node` to `^22` and `typescript` to `^5.0.0` across all 43 example and test-program `package.json` files, matching the pin the SDK already uses (`@types/node@^18`).

Verified locally that `examples/cluster` compiles cleanly under TypeScript 5.9.3 + `@types/node@22.20.0` against `@pulumi/eks`. The remaining projects are exercised by CI.

Part of #2319
