### PR TITLE
Use correct ec2 service for NodeRole

### DIFF
--- a/nodejs/eks/cluster/cluster.ts
+++ b/nodejs/eks/cluster/cluster.ts
@@ -628,7 +628,8 @@ export function createCore(
         eksAutoNodeRole = new ServiceRole(
             `${name}-nodeRole`,
             {
-                service: pulumi.interpolate`ec2.${dnsSuffix}`,
+                // All aws partitions use same service for ec2
+                service: "ec2.amazonaws.com",
                 managedPolicyArns: [
                     {
                         id: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodeMinimalPolicy",
@@ -947,7 +948,8 @@ export function createCore(
         const instanceRole = new ServiceRole(
             `${name}-instanceRole`,
             {
-                service: pulumi.interpolate`ec2.${dnsSuffix}`,
+                // All aws partitions use same service for ec2
+                service: "ec2.amazonaws.com",
                 managedPolicyArns: [
                     {
                         id: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",


### PR DESCRIPTION
All partitions use "ec2.amazonaws.com" as the service endpoint.

Fixes #2341
