### PR TITLE
Guard against an unparseable aws CLI version

### DIFF
--- a/nodejs/eks/dependencies.test.ts
+++ b/nodejs/eks/dependencies.test.ts
@@ -93,4 +93,32 @@ describe("assertCompatibleAWSCLIExists", () => {
         expect(which.sync).toHaveBeenCalledTimes(1);
         expect(child_process.execSync).toHaveBeenCalledTimes(1);
     });
+
+    it("should throw an actionable error if the version is not valid semver", () => {
+        (child_process.execSync as jest.Mock).mockImplementation(() => fakeAwsVersion("2.15"));
+
+        expect(() => {
+            assertCompatibleAWSCLIExists();
+        }).toThrow("Could not determine the aws CLI version");
+    });
+
+    it("should include the raw output when the version cannot be parsed", () => {
+        (child_process.execSync as jest.Mock).mockImplementation(
+            () => "aws-cli/0.0.0-unknown+$Format:%H$ Python/3.8.8 Linux/6.1.0 source/x86_64",
+        );
+
+        expect(() => {
+            assertCompatibleAWSCLIExists();
+        }).toThrow(/aws-cli\/0\.0\.0-unknown/);
+    });
+
+    it("should throw an actionable error if `aws --version` returns unexpected output", () => {
+        (child_process.execSync as jest.Mock).mockImplementation(
+            () => "usage: aws [options] <command> <subcommand> [parameters]",
+        );
+
+        expect(() => {
+            assertCompatibleAWSCLIExists();
+        }).toThrow("Could not determine the aws CLI version");
+    });
 });

--- a/nodejs/eks/dependencies.ts
+++ b/nodejs/eks/dependencies.ts
@@ -36,9 +36,19 @@ export function assertCompatibleAWSCLIExists() {
     const semverCleaned = semver.clean(version, {
         loose: true,
     });
-    switch (semver.major(semverCleaned!)) {
+    // `semver.clean` returns null for anything it cannot parse, and passing that null on to
+    // `semver.major`/`semver.lt` throws `Invalid version. Must be a string. Got type "object"`
+    // (because `typeof null === "object"`), which tells the user nothing about what went wrong.
+    if (semverCleaned === null) {
+        throw new Error(
+            `Could not determine the aws CLI version. \`aws --version\` returned: ${awscli.trim()}.` +
+                ` At least v${minAWSCLIV1Version} (aws-cli v1) or v${minAWSCLIV2Version} (aws-cli v2) is required.` +
+                ` See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html for installation instructions.`,
+        );
+    }
+    switch (semver.major(semverCleaned)) {
         case 1:
-            if (semver.lt(semverCleaned!, minAWSCLIV1Version)) {
+            if (semver.lt(semverCleaned, minAWSCLIV1Version)) {
                 throw new Error(
                     `At least v${minAWSCLIV1Version} of aws-cli is required.` +
                         ` Current version is: ${semverCleaned}. See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html for installation instructions.`,
@@ -46,7 +56,7 @@ export function assertCompatibleAWSCLIExists() {
             }
             break;
         default:
-            if (semver.lt(semverCleaned!, minAWSCLIV2Version)) {
+            if (semver.lt(semverCleaned, minAWSCLIV2Version)) {
                 throw new Error(
                     `At least v${minAWSCLIV2Version} of aws-cli is required.` +
                         ` Current version is: ${semverCleaned}. See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html for installation instructions.`,


### PR DESCRIPTION
### Proposed changes

`semver.clean()` returns `null` for input it cannot parse rather than throwing.
`assertCompatibleAWSCLIExists` passed that `null` straight into `semver.major()`/`semver.lt()`
behind a `!` non-null assertion, which satisfies the compiler but not the runtime:

```
TypeError: Invalid version. Must be a string. Got type "object".
```

Because `typeof null === "object"`, that message sends you looking for an *object* being passed
where a version string belongs — it never mentions the aws CLI, so it gives no hint where to look.
When this surfaces through a component's `Construct` it reads as a Pulumi plugin/version-plumbing
bug, which is an expensive place to start debugging.

This adds an explicit `null` check that reports the raw `aws --version` output and the required
minimums, and drops the two now-unnecessary non-null assertions.

Before / after, for an aws CLI reporting an unparseable version:

```
- Invalid version. Must be a string. Got type "object".
+ Could not determine the aws CLI version. `aws --version` returned: aws-cli/2.15 Python/3.8.8
+ Linux/6.1.0 source/x86_64. At least v1.24.0 (aws-cli v1) or v2.7.0 (aws-cli v2) is required.
+ See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html for
+ installation instructions.
```

Three tests are added covering a truncated version (`2.15`), an unstamped build string, and
unexpected `aws --version` output. I confirmed all three fail on `master` with the
`Invalid version. Must be a string. Got type "object".` TypeError before the fix, and pass after.
`yarn test` in `nodejs/eks` is green (420 tests), and `prettier --list-different` reports no
changes.

Note `eslint` does not run in this repo as checked out — it ships `.eslintrc*` while resolving
ESLint 9, which requires flat config. That is pre-existing and unrelated to this change.

### Related issues (optional)

Fixes #2360.

The originally reported case was `assertCompatibleKubectlVersionExists`, which had exactly this
bug and has since been removed from `master`; the same defect remains in the aws CLI check, which
is what this PR fixes. The report has the full trace from the kubectl instance, where the trigger
was a `kubectl` reporting `gitVersion: "v0.0.0-master+$Format:%H$"` (see
pulumi/pulumi-docker-containers#776).
