### PR TITLE
Support advanced Kubernetes control plane configuration

### DIFF
--- a/examples/cluster/index.ts
+++ b/examples/cluster/index.ts
@@ -55,6 +55,13 @@ const cluster3 = new eks.Cluster(`${projectName}-3`, {
     upgradePolicy: {
         supportType: "STANDARD",
     },
+    kubeSchedulerConfig: {
+        nodeResourcesFit: {
+            scoringStrategy: {
+                type: "MostAllocated",
+            },
+        },
+    },
 })
 
 // cluster4 is a graviton cluster to test the ARM64 architecture

--- a/nodejs/eks/cluster/cluster.ts
+++ b/nodejs/eks/cluster/cluster.ts
@@ -740,6 +740,9 @@ export function createCore(
                   }
                 : undefined,
             upgradePolicy: args.upgradePolicy,
+            kubeApiServerConfig: args.kubeApiServerConfig,
+            kubeControllerManagerConfig: args.kubeControllerManagerConfig,
+            kubeSchedulerConfig: args.kubeSchedulerConfig,
             deletionProtection: args.deletionProtection,
         },
         {
@@ -1921,6 +1924,28 @@ export interface ClusterOptions {
     upgradePolicy?: aws.types.input.eks.ClusterUpgradePolicy;
 
     /**
+     * Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+     *
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     */
+    kubeApiServerConfig?: aws.types.input.eks.ClusterKubeApiServerConfig;
+
+    /**
+     * Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31
+     * or later, and a cluster using EKS Provisioned Control Plane.
+     *
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     */
+    kubeControllerManagerConfig?: aws.types.input.eks.ClusterKubeControllerManagerConfig;
+
+    /**
+     * Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+     *
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     */
+    kubeSchedulerConfig?: aws.types.input.eks.ClusterKubeSchedulerConfig;
+
+    /**
      * Whether to enable deletion protection for the cluster. When enabled, the cluster cannot be deleted unless deletion protection is first disabled. Default: `false`.
      */
     deletionProtection?: pulumi.Input<boolean>;
@@ -2081,6 +2106,9 @@ export interface ClusterResult {
     oidcIssuer: pulumi.Output<string>;
     autoModeNodeRoleName: pulumi.Output<string>;
     upgradePolicy: pulumi.Output<aws.types.output.eks.ClusterUpgradePolicy>;
+    kubeApiServerConfig: pulumi.Output<aws.types.output.eks.ClusterKubeApiServerConfig>;
+    kubeControllerManagerConfig: pulumi.Output<aws.types.output.eks.ClusterKubeControllerManagerConfig>;
+    kubeSchedulerConfig: pulumi.Output<aws.types.output.eks.ClusterKubeSchedulerConfig>;
 }
 
 /** @internal */
@@ -2211,6 +2239,9 @@ export function createCluster(
         oidcIssuer: oidcIssuerUrl.apply((url) => url.replace("https://", "")),
         autoModeNodeRoleName: core.autoModeNodeRoleName,
         upgradePolicy: core.cluster.upgradePolicy,
+        kubeApiServerConfig: core.cluster.kubeApiServerConfig,
+        kubeControllerManagerConfig: core.cluster.kubeControllerManagerConfig,
+        kubeSchedulerConfig: core.cluster.kubeSchedulerConfig,
     };
 }
 

--- a/nodejs/eks/nodes/instances.ts
+++ b/nodejs/eks/nodes/instances.ts
@@ -19,7 +19,7 @@ export const DEFAULT_INSTANCE_TYPE = "t3.medium";
 
 export interface GetEfaNetworkInterfacesArgs {
     // The instance types configured for the node group.
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined;
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined;
     // The security group IDs to associate with the network interfaces.
     securityGroupIds: pulumi.Input<pulumi.Input<string>[]>;
     // The property path to use for the instance type in error messages.
@@ -118,7 +118,7 @@ export function getEfaNetworkInterfaces(
 export function filterEfaSubnets(
     subnetIds: pulumi.Input<pulumi.Input<string>[]>,
     placementGroupAvailabilityZone: pulumi.Input<string>,
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined,
     opts: pulumi.InvokeOptions,
 ): pulumi.Output<string[]> {
     const instanceType = getEfaInstanceType(instanceTypes);
@@ -199,11 +199,11 @@ function getSupportedAZs(
  * @returns The first instance type from the list, or "t3.medium" if no instance types are provided
  */
 function getEfaInstanceType(
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined,
 ): pulumi.Output<string> {
     return instanceTypes
         ? pulumi.output(instanceTypes).apply((types) => {
-              return types.length > 0 ? types[0] : DEFAULT_INSTANCE_TYPE;
+              return types && types.length > 0 ? types[0] : DEFAULT_INSTANCE_TYPE;
           })
         : pulumi.output(DEFAULT_INSTANCE_TYPE);
 }

--- a/nodejs/eks/nodes/nodegroup.ts
+++ b/nodejs/eks/nodes/nodegroup.ts
@@ -2156,7 +2156,7 @@ function createMNGCustomLaunchTemplate(
 
     const taints = args.taints
         ? pulumi.output(args.taints).apply((taints) => {
-              return taints
+              return (taints ?? [])
                   .map((taint) => {
                       return {
                           [taint.key]: {
@@ -2351,7 +2351,7 @@ function getRecommendedAMI(
     k8sVersion: pulumi.Output<string>,
     parent: pulumi.Resource | undefined,
 ): pulumi.Input<string> {
-    let instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined;
+    let instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined;
     let instanceTypesPropertyPath: string = "";
     if ("instanceType" in args && args.instanceType) {
         instanceTypes = [args.instanceType];
@@ -2369,7 +2369,7 @@ function getRecommendedAMI(
 
     const amiType = args.amiType
         ? pulumi.output(args.amiType).apply((amiType) => {
-              const resolvedType = toAmiType(amiType);
+              const resolvedType = amiType === undefined ? undefined : toAmiType(amiType);
               if (resolvedType === undefined) {
                   throw new pulumi.InputPropertyError({
                       propertyPath: "amiType",
@@ -2381,7 +2381,9 @@ function getRecommendedAMI(
         : determineAmiType(os, args.gpu, instanceTypes, instanceTypesPropertyPath, parent);
 
     // if specified use the version from the args, otherwise use the version from the cluster.
-    const version = args.version ? args.version : k8sVersion;
+    const version = pulumi
+        .all([args.version, k8sVersion])
+        .apply(([version, clusterVersion]) => version ?? clusterVersion);
 
     return pulumi.all([amiType, version]).apply(([amiType, version]) => {
         const parameterName = getAmiMetadata(amiType).ssmParameterName(version);
@@ -2430,7 +2432,7 @@ export function isGravitonInstance(instanceType: string, propertyPath: string): 
 function determineAmiType(
     os: pulumi.Input<OperatingSystem>,
     gpu: pulumi.Input<boolean> | undefined,
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined,
     instanceTypesPropertyPath: string,
     parent: pulumi.Resource | undefined,
 ): pulumi.Output<AmiType> {

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -27,7 +27,7 @@
     "bugs": "https://github.com/pulumi/pulumi-eks/issues",
     "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/pulumi": "^3.143.0",
         "https-proxy-agent": "^5.0.1",

--- a/nodejs/eks/yarn.lock
+++ b/nodejs/eks/yarn.lock
@@ -1763,10 +1763,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/aws@7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.25.0.tgz#d831f99e4e5faac496d36b3f3726b50cc1bba818"
-  integrity sha512-qP2ikhFJrw/NrizaOBWiAGkHe003+fPT5Blsc4X1q8uQ0CpmjnPAbbsotpI13hVBU4a2sflIX4GkHcXzRU9QQw==
+"@pulumi/aws@7.43.0":
+  version "7.43.0"
+  resolved "https://ironsrc.jfrog.io/artifactory/api/npm/npm-virtual/@pulumi/aws/-/aws-7.43.0.tgz#84e4d90e83ebf32e05c64a2bf15c51aeee86d1ae"
+  integrity sha512-UCZCrOBn1xVu5CSfd9I3FNZCPkdEcXaB6XNacTj0wVB9iPj8Ma6dLnbfLsUT2ceGsmSMrhwOMvnacOrrhG722A==
   dependencies:
     "@pulumi/pulumi" "^3.142.0"
     mime "^2.0.0"

--- a/provider/cmd/pulumi-gen-eks/main.go
+++ b/provider/cmd/pulumi-gen-eks/main.go
@@ -845,6 +845,21 @@ func generateSchema(version semver.Version, outdir string) schema.PackageSpec {
 						TypeSpec:    schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FClusterUpgradePolicy:ClusterUpgradePolicy", dependencies.Aws)},
 						Description: `The cluster's upgrade policy. Valid support types are "STANDARD" and "EXTENDED". Defaults to "EXTENDED".`,
 					},
+					"kubeApiServerConfig": {
+						TypeSpec: schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FClusterKubeApiServerConfig:ClusterKubeApiServerConfig", dependencies.Aws)},
+						Description: "Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.\n\n" +
+							"For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html",
+					},
+					"kubeControllerManagerConfig": {
+						TypeSpec: schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FClusterKubeControllerManagerConfig:ClusterKubeControllerManagerConfig", dependencies.Aws)},
+						Description: "Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.\n\n" +
+							"For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html",
+					},
+					"kubeSchedulerConfig": {
+						TypeSpec: schema.TypeSpec{Ref: awsRef("#/types/aws:eks%2FClusterKubeSchedulerConfig:ClusterKubeSchedulerConfig", dependencies.Aws)},
+						Description: "Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.\n\n" +
+							"For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html",
+					},
 					"deletionProtection": {
 						TypeSpec:    schema.TypeSpec{Type: "boolean"},
 						Description: "Whether to enable deletion protection for the cluster. When enabled, the cluster cannot be deleted unless deletion protection is first disabled. Default: `false`.",

--- a/provider/cmd/pulumi-resource-eks/schema.json
+++ b/provider/cmd/pulumi-resource-eks/schema.json
@@ -29,13 +29,13 @@
         },
         "java": {
             "dependencies": {
-                "com.pulumi:aws": "7.14.0",
+                "com.pulumi:aws": "7.43.0",
                 "com.pulumi:kubernetes": "4.19.0"
             }
         },
         "nodejs": {
             "dependencies": {
-                "@pulumi/aws": "^7.14.0",
+                "@pulumi/aws": "^7.43.0",
                 "@pulumi/kubernetes": "^4.19.0",
                 "https-proxy-agent": "^5.0.1",
                 "js-yaml": "^4.1.0",
@@ -60,7 +60,7 @@
             },
             "readme": "Pulumi Amazon Web Services (AWS) EKS Components.",
             "requires": {
-                "pulumi-aws": "\u003e=7.14.0,\u003c8.0.0",
+                "pulumi-aws": "\u003e=7.43.0,\u003c8.0.0",
                 "pulumi-kubernetes": "\u003e=4.19.0,\u003c5.0.0"
             },
             "respectSchemaVersion": true,
@@ -147,7 +147,7 @@
             "description": "Associates an access policy and its scope to an IAM principal.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/access-entries.html",
             "properties": {
                 "accessScope": {
-                    "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FAccessPolicyAssociationAccessScope:AccessPolicyAssociationAccessScope",
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FAccessPolicyAssociationAccessScope:AccessPolicyAssociationAccessScope",
                     "description": "The scope of the access policy association. This controls whether the access policy is scoped to the cluster or to a particular namespace."
                 },
                 "policyArn": {
@@ -311,7 +311,7 @@
                     "description": "The tags to apply to the CloudFormation Stack of the Worker NodeGroup.\n\nNote: Given the inheritance of auto-generated CF tags and `cloudFormationTags`, you should either supply the tag in `autoScalingGroupTags` or `cloudFormationTags`, but not both."
                 },
                 "clusterIngressRule": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access."
                 },
                 "clusterIngressRuleId": {
@@ -333,7 +333,7 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
@@ -347,7 +347,7 @@
                     "description": "Whether to ignore changes to the desired size of the Auto Scaling Group. This is useful when using Cluster Autoscaler.\n\nSee [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details."
                 },
                 "instanceProfile": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
                     "plain": true,
                     "description": "The IAM InstanceProfile to use on the NodeGroup. Properties instanceProfile and instanceProfileName are mutually exclusive."
                 },
@@ -377,7 +377,7 @@
                 "launchTemplateTagSpecifications": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/types/aws:ec2%2FLaunchTemplateTagSpecification:LaunchTemplateTagSpecification"
+                        "$ref": "/aws/v7.43.0/schema.json#/types/aws:ec2%2FLaunchTemplateTagSpecification:LaunchTemplateTagSpecification"
                     },
                     "description": "The tag specifications to apply to the launch template."
                 },
@@ -426,7 +426,7 @@
                     "description": "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSecurityGroupId": {
@@ -504,36 +504,36 @@
                     "description": "The access entries added to the cluster."
                 },
                 "awsProvider": {
-                    "$ref": "/aws/v7.14.0/schema.json#/provider"
+                    "$ref": "/aws/v7.43.0/schema.json#/provider"
                 },
                 "cluster": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:eks%2Fcluster:Cluster"
                 },
                 "clusterIamRole": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role",
                     "description": "The IAM Role attached to the EKS Cluster"
                 },
                 "clusterSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                 },
                 "eksNodeAccess": {
                     "$ref": "/kubernetes/v4.19.0/schema.json#/resources/kubernetes:core%2Fv1:ConfigMap"
                 },
                 "encryptionConfig": {
-                    "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FClusterEncryptionConfig:ClusterEncryptionConfig"
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FClusterEncryptionConfig:ClusterEncryptionConfig"
                 },
                 "endpoint": {
                     "type": "string",
                     "description": "The EKS cluster's Kubernetes API server endpoint."
                 },
                 "fargateProfile": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:eks%2FfargateProfile:FargateProfile",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:eks%2FfargateProfile:FargateProfile",
                     "description": "The Fargate profile used to manage which pods run on Fargate."
                 },
                 "instanceRoles": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role"
                     },
                     "description": "The IAM instance roles for the cluster's nodes."
                 },
@@ -553,7 +553,7 @@
                     "description": "Tags attached to the security groups associated with the cluster's worker nodes."
                 },
                 "oidcProvider": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2FopenIdConnectProvider:OpenIdConnectProvider"
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2FopenIdConnectProvider:OpenIdConnectProvider"
                 },
                 "privateSubnetIds": {
                     "type": "array",
@@ -654,11 +654,11 @@
             "description": "Contains the AWS Role and Provider necessary to override the `[system:master]` entity ARN. This is an optional argument used when creating `Cluster`. Read more: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html\n\nNote: This option is only supported with Pulumi nodejs programs. Please use `ProviderCredentialOpts` as an alternative instead.",
             "properties": {
                 "provider": {
-                    "$ref": "/aws/v7.14.0/schema.json#/provider",
+                    "$ref": "/aws/v7.43.0/schema.json#/provider",
                     "plain": true
                 },
                 "role": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role",
                     "plain": true
                 }
             },
@@ -678,7 +678,7 @@
                 "selectors": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FFargateProfileSelector:FargateProfileSelector"
+                        "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FFargateProfileSelector:FargateProfileSelector"
                     },
                     "description": "Specify the namespace and label selectors to use for launching pods into Fargate."
                 },
@@ -745,18 +745,18 @@
             "description": "NodeGroupData describes the resources created for the given NodeGroup.",
             "properties": {
                 "autoScalingGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:autoscaling%2Fgroup:Group",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:autoscaling%2Fgroup:Group",
                     "description": "The AutoScalingGroup for the node group."
                 },
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "description": "The additional security groups for the node group that captures user-specific rules."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the node group to communicate with the cluster."
                 }
             },
@@ -1155,7 +1155,7 @@
                     "description": "The name of the IAM role created for nodes managed by EKS Auto Mode. Defaults to an empty string."
                 },
                 "awsProvider": {
-                    "$ref": "/aws/v7.14.0/schema.json#/provider",
+                    "$ref": "/aws/v7.43.0/schema.json#/provider",
                     "description": "The AWS resource provider."
                 },
                 "clusterIngressRuleId": {
@@ -1163,7 +1163,7 @@
                     "description": "The ID of the security group rule that gives node group access to the cluster API server. Defaults to an empty string if `skipDefaultSecurityGroups` is set to true."
                 },
                 "clusterSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the EKS cluster."
                 },
                 "clusterSecurityGroupId": {
@@ -1183,11 +1183,11 @@
                     "description": "The name of the default node group's AutoScaling Group. Defaults to an empty string if `skipDefaultNodeGroup` is set to true."
                 },
                 "eksCluster": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
                     "description": "The EKS cluster."
                 },
                 "eksClusterIngressRule": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access to cluster API server."
                 },
                 "fargateProfileId": {
@@ -1201,7 +1201,7 @@
                 "instanceRoles": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role"
                     },
                     "description": "The service roles used by the EKS cluster. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`."
                 },
@@ -1214,7 +1214,7 @@
                     "description": "A kubeconfig that can be used to connect to the EKS cluster as a JSON string."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the cluster's nodes."
                 },
                 "nodeSecurityGroupId": {
@@ -1277,7 +1277,7 @@
                     "description": "Install default unmanaged add-ons, such as `aws-cni`, `kube-proxy`, and CoreDNS during cluster creation. If `false`, you must manually install desired add-ons. Changing this value will force a new cluster to be created. Defaults to `true`"
                 },
                 "clusterSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group to use for the cluster API endpoint. If not provided, a new security group will be created with full internet egress and ingress from node groups.\n\nNote: The security group resource should not contain any inline ingress or egress rules."
                 },
                 "clusterSecurityGroupTags": {
@@ -1364,13 +1364,13 @@
                     "description": "The default IAM InstanceProfile to use on the Worker NodeGroups, if one is not already set in the NodeGroup."
                 },
                 "instanceRole": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role",
                     "description": "This enables the simple case of only registering a *single* IAM instance role with the cluster, that is required to be shared by *all* node groups in their instance profiles.\n\nNote: options `instanceRole` and `instanceRoles` are mutually exclusive."
                 },
                 "instanceRoles": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role"
                     },
                     "description": "This enables the advanced case of registering *many* IAM instance roles with the cluster for per node group IAM, instead of the simpler, shared case of `instanceRole`.\n\nNote: options `instanceRole` and `instanceRoles` are mutually exclusive."
                 },
@@ -1383,10 +1383,22 @@
                     "description": "The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.\nYou can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.",
                     "replaceOnChanges": true
                 },
+                "kubeApiServerConfig": {
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FClusterKubeApiServerConfig:ClusterKubeApiServerConfig",
+                    "description": "Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.\n\nFor more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html"
+                },
+                "kubeControllerManagerConfig": {
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FClusterKubeControllerManagerConfig:ClusterKubeControllerManagerConfig",
+                    "description": "Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.\n\nFor more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html"
+                },
                 "kubeProxyAddonOptions": {
                     "$ref": "#/types/eks:index:KubeProxyAddonOptions",
                     "plain": true,
                     "description": "Options for managing the `kube-proxy` addon."
+                },
+                "kubeSchedulerConfig": {
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FClusterKubeSchedulerConfig:ClusterKubeSchedulerConfig",
+                    "description": "Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.\n\nFor more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html"
                 },
                 "kubernetesServiceIpAddressRange": {
                     "type": "string",
@@ -1486,7 +1498,7 @@
                     "description": "Optional mappings from AWS IAM roles to Kubernetes users and groups. Only supported with authentication mode `CONFIG_MAP` or `API_AND_CONFIG_MAP`"
                 },
                 "serviceRole": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role",
                     "description": "IAM Service Role for EKS to use to manage the cluster."
                 },
                 "skipDefaultNodeGroup": {
@@ -1532,7 +1544,7 @@
                     "description": "Key-value mapping of tags that are automatically applied to all AWS resources directly under management with this cluster, which support tagging."
                 },
                 "upgradePolicy": {
-                    "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FClusterUpgradePolicy:ClusterUpgradePolicy",
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FClusterUpgradePolicy:ClusterUpgradePolicy",
                     "description": "The cluster's upgrade policy. Valid support types are \"STANDARD\" and \"EXTENDED\". Defaults to \"EXTENDED\"."
                 },
                 "useDefaultVpcCni": {
@@ -1570,7 +1582,7 @@
             "description": "ClusterCreationRoleProvider is a component that wraps creating a role provider that can be passed to the `Cluster`'s `creationRoleProvider`. This can be used to provide a specific role to use for the creation of the EKS cluster different from the role being used to run the Pulumi deployment.",
             "properties": {
                 "role": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role"
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role"
                 }
             },
             "required": [
@@ -1590,7 +1602,7 @@
             "description": "Manages an EKS Node Group, which can provision and optionally update an Auto Scaling Group of Kubernetes worker nodes compatible with EKS. Additional documentation about this functionality can be found in the [EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).\n\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n### Basic Managed Node Group\nThis example demonstrates creating a managed node group with typical defaults. The node group uses the latest EKS-optimized Amazon Linux AMI, creates 2 nodes, and runs on t3.medium instances. Instance security groups are automatically configured.\n\n\n```yaml\nresources:\n  eks-vpc:\n    type: awsx:ec2:Vpc\n    properties:\n      enableDnsHostnames: true\n      cidrBlock: 10.0.0.0/16\n  eks-cluster:\n    type: eks:Cluster\n    properties:\n      vpcId: ${eks-vpc.vpcId}\n      authenticationMode: API\n      publicSubnetIds: ${eks-vpc.publicSubnetIds}\n      privateSubnetIds: ${eks-vpc.privateSubnetIds}\n      skipDefaultNodeGroup: true\n  node-role:\n    type: aws:iam:Role\n    properties:\n      assumeRolePolicy:\n        fn::toJSON:\n          Version: 2012-10-17\n          Statement:\n            - Action: sts:AssumeRole\n              Effect: Allow\n              Sid: \"\"\n              Principal:\n                Service: ec2.amazonaws.com\n  worker-node-policy:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${node-role.name}\n      policyArn: \"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\"\n  cni-policy:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${node-role.name}\n      policyArn: \"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\"\n  registry-policy:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${node-role.name}\n      policyArn: \"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\"\n  node-group:\n    type: eks:ManagedNodeGroup\n    properties:\n      cluster: ${eks-cluster}\n      nodeRole: ${node-role}\n\n```\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as awsx from \"@pulumi/awsx\";\nimport * as eks from \"@pulumi/eks\";\n\nconst eksVpc = new awsx.ec2.Vpc(\"eks-vpc\", {\n    enableDnsHostnames: true,\n    cidrBlock: \"10.0.0.0/16\",\n});\nconst eksCluster = new eks.Cluster(\"eks-cluster\", {\n    vpcId: eksVpc.vpcId,\n    authenticationMode: eks.AuthenticationMode.Api,\n    publicSubnetIds: eksVpc.publicSubnetIds,\n    privateSubnetIds: eksVpc.privateSubnetIds,\n    skipDefaultNodeGroup: true,\n});\nconst nodeRole = new aws.iam.Role(\"node-role\", {assumeRolePolicy: JSON.stringify({\n    Version: \"2012-10-17\",\n    Statement: [{\n        Action: \"sts:AssumeRole\",\n        Effect: \"Allow\",\n        Sid: \"\",\n        Principal: {\n            Service: \"ec2.amazonaws.com\",\n        },\n    }],\n})});\nconst workerNodePolicy = new aws.iam.RolePolicyAttachment(\"worker-node-policy\", {\n    role: nodeRole.name,\n    policyArn: \"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\",\n});\nconst cniPolicy = new aws.iam.RolePolicyAttachment(\"cni-policy\", {\n    role: nodeRole.name,\n    policyArn: \"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\",\n});\nconst registryPolicy = new aws.iam.RolePolicyAttachment(\"registry-policy\", {\n    role: nodeRole.name,\n    policyArn: \"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\",\n});\nconst nodeGroup = new eks.ManagedNodeGroup(\"node-group\", {\n    cluster: eksCluster,\n    nodeRole: nodeRole,\n});\n\n```\n\n```python\nimport pulumi\nimport json\nimport pulumi_aws as aws\nimport pulumi_awsx as awsx\nimport pulumi_eks as eks\n\neks_vpc = awsx.ec2.Vpc(\"eks-vpc\",\n    enable_dns_hostnames=True,\n    cidr_block=\"10.0.0.0/16\")\neks_cluster = eks.Cluster(\"eks-cluster\",\n    vpc_id=eks_vpc.vpc_id,\n    authentication_mode=eks.AuthenticationMode.API,\n    public_subnet_ids=eks_vpc.public_subnet_ids,\n    private_subnet_ids=eks_vpc.private_subnet_ids,\n    skip_default_node_group=True)\nnode_role = aws.iam.Role(\"node-role\", assume_role_policy=json.dumps({\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [{\n        \"Action\": \"sts:AssumeRole\",\n        \"Effect\": \"Allow\",\n        \"Sid\": \"\",\n        \"Principal\": {\n            \"Service\": \"ec2.amazonaws.com\",\n        },\n    }],\n}))\nworker_node_policy = aws.iam.RolePolicyAttachment(\"worker-node-policy\",\n    role=node_role.name,\n    policy_arn=\"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\")\ncni_policy = aws.iam.RolePolicyAttachment(\"cni-policy\",\n    role=node_role.name,\n    policy_arn=\"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\")\nregistry_policy = aws.iam.RolePolicyAttachment(\"registry-policy\",\n    role=node_role.name,\n    policy_arn=\"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\")\nnode_group = eks.ManagedNodeGroup(\"node-group\",\n    cluster=eks_cluster,\n    node_role=node_role)\n\n```\n\n```go\npackage main\n\nimport (\n\t\"encoding/json\"\n\n\t\"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam\"\n\t\"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ec2\"\n\t\"github.com/pulumi/pulumi-eks/sdk/v4/go/eks\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\teksVpc, err := ec2.NewVpc(ctx, \"eks-vpc\", \u0026ec2.VpcArgs{\n\t\t\tEnableDnsHostnames: pulumi.Bool(true),\n\t\t\tCidrBlock:          \"10.0.0.0/16\",\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\teksCluster, err := eks.NewCluster(ctx, \"eks-cluster\", \u0026eks.ClusterArgs{\n\t\t\tVpcId:                eksVpc.VpcId,\n\t\t\tAuthenticationMode:   eks.AuthenticationModeApi,\n\t\t\tPublicSubnetIds:      eksVpc.PublicSubnetIds,\n\t\t\tPrivateSubnetIds:     eksVpc.PrivateSubnetIds,\n\t\t\tSkipDefaultNodeGroup: true,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\ttmpJSON0, err := json.Marshal(map[string]interface{}{\n\t\t\t\"Version\": \"2012-10-17\",\n\t\t\t\"Statement\": []map[string]interface{}{\n\t\t\t\tmap[string]interface{}{\n\t\t\t\t\t\"Action\": \"sts:AssumeRole\",\n\t\t\t\t\t\"Effect\": \"Allow\",\n\t\t\t\t\t\"Sid\":    \"\",\n\t\t\t\t\t\"Principal\": map[string]interface{}{\n\t\t\t\t\t\t\"Service\": \"ec2.amazonaws.com\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tjson0 := string(tmpJSON0)\n\t\tnodeRole, err := iam.NewRole(ctx, \"node-role\", \u0026iam.RoleArgs{\n\t\t\tAssumeRolePolicy: pulumi.String(json0),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = iam.NewRolePolicyAttachment(ctx, \"worker-node-policy\", \u0026iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      nodeRole.Name,\n\t\t\tPolicyArn: pulumi.String(\"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = iam.NewRolePolicyAttachment(ctx, \"cni-policy\", \u0026iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      nodeRole.Name,\n\t\t\tPolicyArn: pulumi.String(\"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = iam.NewRolePolicyAttachment(ctx, \"registry-policy\", \u0026iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      nodeRole.Name,\n\t\t\tPolicyArn: pulumi.String(\"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = eks.NewManagedNodeGroup(ctx, \"node-group\", \u0026eks.ManagedNodeGroupArgs{\n\t\t\tCluster:  eksCluster,\n\t\t\tNodeRole: nodeRole,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n\n```\n\n```csharp\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text.Json;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Awsx = Pulumi.Awsx;\nusing Eks = Pulumi.Eks;\n\nreturn await Deployment.RunAsync(() =\u003e \n{\n    var eksVpc = new Awsx.Ec2.Vpc(\"eks-vpc\", new()\n    {\n        EnableDnsHostnames = true,\n        CidrBlock = \"10.0.0.0/16\",\n    });\n\n    var eksCluster = new Eks.Cluster(\"eks-cluster\", new()\n    {\n        VpcId = eksVpc.VpcId,\n        AuthenticationMode = Eks.AuthenticationMode.Api,\n        PublicSubnetIds = eksVpc.PublicSubnetIds,\n        PrivateSubnetIds = eksVpc.PrivateSubnetIds,\n        SkipDefaultNodeGroup = true,\n    });\n\n    var nodeRole = new Aws.Iam.Role(\"node-role\", new()\n    {\n        AssumeRolePolicy = JsonSerializer.Serialize(new Dictionary\u003cstring, object?\u003e\n        {\n            [\"Version\"] = \"2012-10-17\",\n            [\"Statement\"] = new[]\n            {\n                new Dictionary\u003cstring, object?\u003e\n                {\n                    [\"Action\"] = \"sts:AssumeRole\",\n                    [\"Effect\"] = \"Allow\",\n                    [\"Sid\"] = \"\",\n                    [\"Principal\"] = new Dictionary\u003cstring, object?\u003e\n                    {\n                        [\"Service\"] = \"ec2.amazonaws.com\",\n                    },\n                },\n            },\n        }),\n    });\n\n    var workerNodePolicy = new Aws.Iam.RolePolicyAttachment(\"worker-node-policy\", new()\n    {\n        Role = nodeRole.Name,\n        PolicyArn = \"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\",\n    });\n\n    var cniPolicy = new Aws.Iam.RolePolicyAttachment(\"cni-policy\", new()\n    {\n        Role = nodeRole.Name,\n        PolicyArn = \"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\",\n    });\n\n    var registryPolicy = new Aws.Iam.RolePolicyAttachment(\"registry-policy\", new()\n    {\n        Role = nodeRole.Name,\n        PolicyArn = \"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\",\n    });\n\n    var nodeGroup = new Eks.ManagedNodeGroup(\"node-group\", new()\n    {\n        Cluster = eksCluster,\n        NodeRole = nodeRole,\n    });\n\n    return new Dictionary\u003cstring, object?\u003e{};\n});\n\n```\n\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.awsx.ec2.Vpc;\nimport com.pulumi.awsx.ec2.VpcArgs;\nimport com.pulumi.eks.Cluster;\nimport com.pulumi.eks.ClusterArgs;\nimport com.pulumi.aws.iam.Role;\nimport com.pulumi.aws.iam.RoleArgs;\nimport com.pulumi.aws.iam.RolePolicyAttachment;\nimport com.pulumi.aws.iam.RolePolicyAttachmentArgs;\nimport com.pulumi.eks.ManagedNodeGroup;\nimport com.pulumi.eks.ManagedNodeGroupArgs;\nimport static com.pulumi.codegen.internal.Serialization.*;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var eksVpc = new Vpc(\"eksVpc\", VpcArgs.builder()\n            .enableDnsHostnames(true)\n            .cidrBlock(\"10.0.0.0/16\")\n            .build());\n\n        var eksCluster = new Cluster(\"eksCluster\", ClusterArgs.builder()\n            .vpcId(eksVpc.vpcId())\n            .authenticationMode(\"API\")\n            .publicSubnetIds(eksVpc.publicSubnetIds())\n            .privateSubnetIds(eksVpc.privateSubnetIds())\n            .skipDefaultNodeGroup(true)\n            .build());\n\n        var nodeRole = new Role(\"nodeRole\", RoleArgs.builder()\n            .assumeRolePolicy(serializeJson(\n                jsonObject(\n                    jsonProperty(\"Version\", \"2012-10-17\"),\n                    jsonProperty(\"Statement\", jsonArray(jsonObject(\n                        jsonProperty(\"Action\", \"sts:AssumeRole\"),\n                        jsonProperty(\"Effect\", \"Allow\"),\n                        jsonProperty(\"Sid\", \"\"),\n                        jsonProperty(\"Principal\", jsonObject(\n                            jsonProperty(\"Service\", \"ec2.amazonaws.com\")\n                        ))\n                    )))\n                )))\n            .build());\n\n        var workerNodePolicy = new RolePolicyAttachment(\"workerNodePolicy\", RolePolicyAttachmentArgs.builder()\n            .role(nodeRole.name())\n            .policyArn(\"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\")\n            .build());\n\n        var cniPolicy = new RolePolicyAttachment(\"cniPolicy\", RolePolicyAttachmentArgs.builder()\n            .role(nodeRole.name())\n            .policyArn(\"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\")\n            .build());\n\n        var registryPolicy = new RolePolicyAttachment(\"registryPolicy\", RolePolicyAttachmentArgs.builder()\n            .role(nodeRole.name())\n            .policyArn(\"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\")\n            .build());\n\n        var nodeGroup = new ManagedNodeGroup(\"nodeGroup\", ManagedNodeGroupArgs.builder()\n            .cluster(eksCluster)\n            .nodeRole(nodeRole)\n            .build());\n    }\n}\n```\n{{% /example %}}\n\n{{% example %}}\n### Enabling EFA Support\n\nEnabling EFA support for a node group will do the following:\n- All EFA interfaces supported by the instance will be exposed on the launch template used by the node group\n- A `clustered` placement group will be created and passed to the launch template\n- Checks will be performed to ensure that the instance type supports EFA and that the specified AZ is supported by the chosen instance type\n\nThe GPU optimized AMIs include all necessary drivers and libraries to support EFA. If you're choosing an instance type without GPU acceleration you will need to install the drivers and libraries manually and bake a custom AMI.\n\nYou can use the [aws-efa-k8s-device-plugin](https://github.com/aws/eks-charts/tree/master/stable/aws-efa-k8s-device-plugin) Helm chart to expose the EFA interfaces on the nodes as an extended resource, and allow pods to request these interfaces to be mounted to their containers.\nYour application container will need to have the necessary libraries and runtimes in order to leverage the EFA interfaces (e.g. libfabric).\n\n```yaml\nname: eks-mng-docs\ndescription: A Pulumi YAML program to deploy a Kubernetes cluster on AWS\nruntime: yaml\nresources:\n  eks-vpc:\n    type: awsx:ec2:Vpc\n    properties:\n      enableDnsHostnames: true\n      cidrBlock: 10.0.0.0/16\n  eks-cluster:\n    type: eks:Cluster\n    properties:\n      vpcId: ${eks-vpc.vpcId}\n      authenticationMode: API\n      publicSubnetIds: ${eks-vpc.publicSubnetIds}\n      privateSubnetIds: ${eks-vpc.privateSubnetIds}\n      skipDefaultNodeGroup: true\n  k8sProvider:\n    type: pulumi:providers:kubernetes\n    properties:\n      kubeconfig: ${eks-cluster.kubeconfig}\n  node-role:\n    type: aws:iam:Role\n    properties:\n      assumeRolePolicy:\n        fn::toJSON:\n          Version: 2012-10-17\n          Statement:\n            - Action: sts:AssumeRole\n              Effect: Allow\n              Sid: \"\"\n              Principal:\n                Service: ec2.amazonaws.com\n  worker-node-policy:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${node-role.name}\n      policyArn: \"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\"\n  cni-policy:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${node-role.name}\n      policyArn: \"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\"\n  registry-policy:\n    type: aws:iam:RolePolicyAttachment\n    properties:\n      role: ${node-role.name}\n      policyArn: \"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\"\n  \n  # The node group for running system pods (e.g. coredns, etc.)\n  system-node-group:\n    type: eks:ManagedNodeGroup\n    properties:\n      cluster: ${eks-cluster}\n      nodeRole: ${node-role}\n\n  # EFA device plugin for exposing EFA interfaces as extended resources\n  device-plugin:\n    type: kubernetes:helm.sh/v3:Release\n    properties:\n      version: \"0.5.7\"\n      repositoryOpts:\n        repo: \"https://aws.github.io/eks-charts\"\n      chart: \"aws-efa-k8s-device-plugin\"\n      namespace: \"kube-system\"\n      atomic: true\n      values:\n        tolerations:\n          - key: \"efa-enabled\"\n            operator: \"Exists\"\n            effect: \"NoExecute\"\n    options:\n      provider: ${k8sProvider}\n\n  # The node group for running EFA enabled workloads\n  efa-node-group:\n    type: eks:ManagedNodeGroup\n    properties:\n      cluster: ${eks-cluster}\n      nodeRole: ${node-role}\n      instanceTypes: [\"g6.8xlarge\"]\n      gpu: true\n      scalingConfig:\n        minSize: 2\n        desiredSize: 2\n        maxSize: 4\n      enableEfaSupport: true\n      placementGroupAvailabilityZone: \"us-west-2b\"\n      # Taint the nodes so that only pods with the efa-enabled label can be scheduled on them\n      taints:\n        - key: \"efa-enabled\"\n          value: \"true\"\n          effect: \"NO_EXECUTE\"\n      # Instances with GPUs usually have nvme instance store volumes, so we can mount them in RAID-0 for kubelet and containerd\n      # These are faster than the regular EBS volumes\n      nodeadmExtraOptions:\n        - contentType: \"application/node.eks.aws\"\n          content: |\n            apiVersion: node.eks.aws/v1alpha1\n            kind: NodeConfig\n            spec:\n              instance:\n                localStorage:\n                  strategy: RAID0\n\n```\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as awsx from \"@pulumi/awsx\";\nimport * as eks from \"@pulumi/eks\";\nimport * as kubernetes from \"@pulumi/kubernetes\";\n\nconst eksVpc = new awsx.ec2.Vpc(\"eks-vpc\", {\n    enableDnsHostnames: true,\n    cidrBlock: \"10.0.0.0/16\",\n});\nconst eksCluster = new eks.Cluster(\"eks-cluster\", {\n    vpcId: eksVpc.vpcId,\n    authenticationMode: eks.AuthenticationMode.Api,\n    publicSubnetIds: eksVpc.publicSubnetIds,\n    privateSubnetIds: eksVpc.privateSubnetIds,\n    skipDefaultNodeGroup: true,\n});\nconst k8SProvider = new kubernetes.Provider(\"k8sProvider\", {kubeconfig: eksCluster.kubeconfig});\nconst nodeRole = new aws.iam.Role(\"node-role\", {assumeRolePolicy: JSON.stringify({\n    Version: \"2012-10-17\",\n    Statement: [{\n        Action: \"sts:AssumeRole\",\n        Effect: \"Allow\",\n        Sid: \"\",\n        Principal: {\n            Service: \"ec2.amazonaws.com\",\n        },\n    }],\n})});\nconst workerNodePolicy = new aws.iam.RolePolicyAttachment(\"worker-node-policy\", {\n    role: nodeRole.name,\n    policyArn: \"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\",\n});\nconst cniPolicy = new aws.iam.RolePolicyAttachment(\"cni-policy\", {\n    role: nodeRole.name,\n    policyArn: \"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\",\n});\nconst registryPolicy = new aws.iam.RolePolicyAttachment(\"registry-policy\", {\n    role: nodeRole.name,\n    policyArn: \"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\",\n});\n\n// The node group for running system pods (e.g. coredns, etc.)\nconst systemNodeGroup = new eks.ManagedNodeGroup(\"system-node-group\", {\n    cluster: eksCluster,\n    nodeRole: nodeRole,\n});\n\n// The EFA device plugin for exposing EFA interfaces as extended resources\nconst devicePlugin = new kubernetes.helm.v3.Release(\"device-plugin\", {\n    version: \"0.5.7\",\n    repositoryOpts: {\n        repo: \"https://aws.github.io/eks-charts\",\n    },\n    chart: \"aws-efa-k8s-device-plugin\",\n    namespace: \"kube-system\",\n    atomic: true,\n    values: {\n        tolerations: [{\n            key: \"efa-enabled\",\n            operator: \"Exists\",\n            effect: \"NoExecute\",\n        }],\n    },\n}, {\n    provider: k8SProvider,\n});\n\n// The node group for running EFA enabled workloads\nconst efaNodeGroup = new eks.ManagedNodeGroup(\"efa-node-group\", {\n    cluster: eksCluster,\n    nodeRole: nodeRole,\n    instanceTypes: [\"g6.8xlarge\"],\n    gpu: true,\n    scalingConfig: {\n        minSize: 2,\n        desiredSize: 2,\n        maxSize: 4,\n    },\n    enableEfaSupport: true,\n    placementGroupAvailabilityZone: \"us-west-2b\",\n\n    // Taint the nodes so that only pods with the efa-enabled label can be scheduled on them\n    taints: [{\n        key: \"efa-enabled\",\n        value: \"true\",\n        effect: \"NO_EXECUTE\",\n    }],\n\n    // Instances with GPUs usually have nvme instance store volumes, so we can mount them in RAID-0 for kubelet and containerd\n    // These are faster than the regular EBS volumes\n    nodeadmExtraOptions: [{\n        contentType: \"application/node.eks.aws\",\n        content: `apiVersion: node.eks.aws/v1alpha1\nkind: NodeConfig\nspec:\n  instance:\n    localStorage:\n      strategy: RAID0\n`,\n    }],\n});\n\n```\n\n```python\nimport pulumi\nimport json\nimport pulumi_aws as aws\nimport pulumi_awsx as awsx\nimport pulumi_eks as eks\nimport pulumi_kubernetes as kubernetes\n\neks_vpc = awsx.ec2.Vpc(\"eks-vpc\",\n    enable_dns_hostnames=True,\n    cidr_block=\"10.0.0.0/16\")\neks_cluster = eks.Cluster(\"eks-cluster\",\n    vpc_id=eks_vpc.vpc_id,\n    authentication_mode=eks.AuthenticationMode.API,\n    public_subnet_ids=eks_vpc.public_subnet_ids,\n    private_subnet_ids=eks_vpc.private_subnet_ids,\n    skip_default_node_group=True)\nk8_s_provider = kubernetes.Provider(\"k8sProvider\", kubeconfig=eks_cluster.kubeconfig)\nnode_role = aws.iam.Role(\"node-role\", assume_role_policy=json.dumps({\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [{\n        \"Action\": \"sts:AssumeRole\",\n        \"Effect\": \"Allow\",\n        \"Sid\": \"\",\n        \"Principal\": {\n            \"Service\": \"ec2.amazonaws.com\",\n        },\n    }],\n}))\nworker_node_policy = aws.iam.RolePolicyAttachment(\"worker-node-policy\",\n    role=node_role.name,\n    policy_arn=\"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\")\ncni_policy = aws.iam.RolePolicyAttachment(\"cni-policy\",\n    role=node_role.name,\n    policy_arn=\"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\")\nregistry_policy = aws.iam.RolePolicyAttachment(\"registry-policy\",\n    role=node_role.name,\n    policy_arn=\"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\")\n\n# The node group for running system pods (e.g. coredns, etc.)\nsystem_node_group = eks.ManagedNodeGroup(\"system-node-group\",\n    cluster=eks_cluster,\n    node_role=node_role)\n\n# The EFA device plugin for exposing EFA interfaces as extended resources\ndevice_plugin = kubernetes.helm.v3.Release(\"device-plugin\",\n    version=\"0.5.7\",\n    repository_opts={\n        \"repo\": \"https://aws.github.io/eks-charts\",\n    },\n    chart=\"aws-efa-k8s-device-plugin\",\n    namespace=\"kube-system\",\n    atomic=True,\n    values={\n        \"tolerations\": [{\n            \"key\": \"efa-enabled\",\n            \"operator\": \"Exists\",\n            \"effect\": \"NoExecute\",\n        }],\n    },\n    opts = pulumi.ResourceOptions(provider=k8_s_provider))\n\n# The node group for running EFA enabled workloads\nefa_node_group = eks.ManagedNodeGroup(\"efa-node-group\",\n    cluster=eks_cluster,\n    node_role=node_role,\n    instance_types=[\"g6.8xlarge\"],\n    gpu=True,\n    scaling_config={\n        \"min_size\": 2,\n        \"desired_size\": 2,\n        \"max_size\": 4,\n    },\n    enable_efa_support=True,\n    placement_group_availability_zone=\"us-west-2b\",\n\n    # Taint the nodes so that only pods with the efa-enabled label can be scheduled on them\n    taints=[{\n        \"key\": \"efa-enabled\",\n        \"value\": \"true\",\n        \"effect\": \"NO_EXECUTE\",\n    }],\n\n    # Instances with GPUs usually have nvme instance store volumes, so we can mount them in RAID-0 for kubelet and containerd\n    # These are faster than the regular EBS volumes\n    nodeadm_extra_options=[{\n        \"content_type\": \"application/node.eks.aws\",\n        \"content\": \"\"\"apiVersion: node.eks.aws/v1alpha1\nkind: NodeConfig\nspec:\n  instance:\n    localStorage:\n      strategy: RAID0\n\"\"\",\n    }])\n\n```\n\n```go\npackage main\n\nimport (\n\t\"encoding/json\"\n\n\tawseks \"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/eks\"\n\t\"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam\"\n\t\"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ec2\"\n\t\"github.com/pulumi/pulumi-eks/sdk/v4/go/eks\"\n\t\"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes\"\n\thelmv3 \"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\teksVpc, err := ec2.NewVpc(ctx, \"eks-vpc\", \u0026ec2.VpcArgs{\n\t\t\tEnableDnsHostnames: pulumi.Bool(true),\n\t\t\tCidrBlock:          \"10.0.0.0/16\",\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\teksCluster, err := eks.NewCluster(ctx, \"eks-cluster\", \u0026eks.ClusterArgs{\n\t\t\tVpcId:                eksVpc.VpcId,\n\t\t\tAuthenticationMode:   eks.AuthenticationModeApi,\n\t\t\tPublicSubnetIds:      eksVpc.PublicSubnetIds,\n\t\t\tPrivateSubnetIds:     eksVpc.PrivateSubnetIds,\n\t\t\tSkipDefaultNodeGroup: true,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tk8SProvider, err := kubernetes.NewProvider(ctx, \"k8sProvider\", \u0026kubernetes.ProviderArgs{\n\t\t\tKubeconfig: eksCluster.Kubeconfig,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\ttmpJSON0, err := json.Marshal(map[string]interface{}{\n\t\t\t\"Version\": \"2012-10-17\",\n\t\t\t\"Statement\": []map[string]interface{}{\n\t\t\t\tmap[string]interface{}{\n\t\t\t\t\t\"Action\": \"sts:AssumeRole\",\n\t\t\t\t\t\"Effect\": \"Allow\",\n\t\t\t\t\t\"Sid\":    \"\",\n\t\t\t\t\t\"Principal\": map[string]interface{}{\n\t\t\t\t\t\t\"Service\": \"ec2.amazonaws.com\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tjson0 := string(tmpJSON0)\n\t\tnodeRole, err := iam.NewRole(ctx, \"node-role\", \u0026iam.RoleArgs{\n\t\t\tAssumeRolePolicy: pulumi.String(json0),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = iam.NewRolePolicyAttachment(ctx, \"worker-node-policy\", \u0026iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      nodeRole.Name,\n\t\t\tPolicyArn: pulumi.String(\"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = iam.NewRolePolicyAttachment(ctx, \"cni-policy\", \u0026iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      nodeRole.Name,\n\t\t\tPolicyArn: pulumi.String(\"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = iam.NewRolePolicyAttachment(ctx, \"registry-policy\", \u0026iam.RolePolicyAttachmentArgs{\n\t\t\tRole:      nodeRole.Name,\n\t\t\tPolicyArn: pulumi.String(\"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n        // The node group for running system pods (e.g. coredns, etc.)\n\t\t_, err = eks.NewManagedNodeGroup(ctx, \"system-node-group\", \u0026eks.ManagedNodeGroupArgs{\n\t\t\tCluster:  eksCluster,\n\t\t\tNodeRole: nodeRole,\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n        // The EFA device plugin for exposing EFA interfaces as extended resources\n\t\t_, err = helmv3.NewRelease(ctx, \"device-plugin\", \u0026helmv3.ReleaseArgs{\n\t\t\tVersion: pulumi.String(\"0.5.7\"),\n\t\t\tRepositoryOpts: \u0026helmv3.RepositoryOptsArgs{\n\t\t\t\tRepo: pulumi.String(\"https://aws.github.io/eks-charts\"),\n\t\t\t},\n\t\t\tChart:     pulumi.String(\"aws-efa-k8s-device-plugin\"),\n\t\t\tNamespace: pulumi.String(\"kube-system\"),\n\t\t\tAtomic:    pulumi.Bool(true),\n\t\t\tValues: pulumi.Map{\n\t\t\t\t\"tolerations\": pulumi.Any{\n\t\t\t\t\t[]map[string]interface{}{\n                        {\n                            \"key\":      \"efa-enabled\",\n                            \"operator\": \"Exists\",\n                            \"effect\":   \"NoExecute\",\n                        }\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t}, pulumi.Provider(k8SProvider))\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n        // The node group for running EFA enabled workloads\n\t\t_, err = eks.NewManagedNodeGroup(ctx, \"efa-node-group\", \u0026eks.ManagedNodeGroupArgs{\n\t\t\tCluster:  eksCluster,\n\t\t\tNodeRole: nodeRole,\n\t\t\tInstanceTypes: pulumi.StringArray{\n\t\t\t\tpulumi.String(\"g6.8xlarge\"),\n\t\t\t},\n\t\t\tGpu: pulumi.Bool(true),\n\t\t\tScalingConfig: \u0026eks.NodeGroupScalingConfigArgs{\n\t\t\t\tMinSize:     pulumi.Int(2),\n\t\t\t\tDesiredSize: pulumi.Int(2),\n\t\t\t\tMaxSize:     pulumi.Int(4),\n\t\t\t},\n\t\t\tEnableEfaSupport:               true,\n\t\t\tPlacementGroupAvailabilityZone: pulumi.String(\"us-west-2b\"),\n\n            // Taint the nodes so that only pods with the efa-enabled label can be scheduled on them\n\t\t\tTaints: eks.NodeGroupTaintArray{\n\t\t\t\t\u0026eks.NodeGroupTaintArgs{\n\t\t\t\t\tKey:    pulumi.String(\"efa-enabled\"),\n\t\t\t\t\tValue:  pulumi.String(\"true\"),\n\t\t\t\t\tEffect: pulumi.String(\"NO_EXECUTE\"),\n\t\t\t\t},\n\t\t\t},\n\n            // Instances with GPUs usually have nvme instance store volumes, so we can mount them in RAID-0 for kubelet and containerd\n            // These are faster than the regular EBS volumes\n\t\t\tNodeadmExtraOptions: eks.NodeadmOptionsArray{\n\t\t\t\t\u0026eks.NodeadmOptionsArgs{\n\t\t\t\t\tContentType: pulumi.String(\"application/node.eks.aws\"),\n\t\t\t\t\tContent: pulumi.String(`apiVersion: node.eks.aws/v1alpha1\nkind: NodeConfig\nspec:\n  instance:\n    localStorage:\n      strategy: RAID0\n`),\n\t\t\t\t},\n\t\t\t},\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\treturn nil\n\t})\n}\n\n```\n\n```csharp\nusing System.Collections.Generic;\nusing System.Linq;\nusing System.Text.Json;\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Awsx = Pulumi.Awsx;\nusing Eks = Pulumi.Eks;\nusing Kubernetes = Pulumi.Kubernetes;\n\nreturn await Deployment.RunAsync(() =\u003e \n{\n    var eksVpc = new Awsx.Ec2.Vpc(\"eks-vpc\", new()\n    {\n        EnableDnsHostnames = true,\n        CidrBlock = \"10.0.0.0/16\",\n    });\n\n    var eksCluster = new Eks.Cluster(\"eks-cluster\", new()\n    {\n        VpcId = eksVpc.VpcId,\n        AuthenticationMode = Eks.AuthenticationMode.Api,\n        PublicSubnetIds = eksVpc.PublicSubnetIds,\n        PrivateSubnetIds = eksVpc.PrivateSubnetIds,\n        SkipDefaultNodeGroup = true,\n    });\n\n    var k8SProvider = new Kubernetes.Provider.Provider(\"k8sProvider\", new()\n    {\n        KubeConfig = eksCluster.Kubeconfig,\n    });\n\n    var nodeRole = new Aws.Iam.Role(\"node-role\", new()\n    {\n        AssumeRolePolicy = JsonSerializer.Serialize(new Dictionary\u003cstring, object?\u003e\n        {\n            [\"Version\"] = \"2012-10-17\",\n            [\"Statement\"] = new[]\n            {\n                new Dictionary\u003cstring, object?\u003e\n                {\n                    [\"Action\"] = \"sts:AssumeRole\",\n                    [\"Effect\"] = \"Allow\",\n                    [\"Sid\"] = \"\",\n                    [\"Principal\"] = new Dictionary\u003cstring, object?\u003e\n                    {\n                        [\"Service\"] = \"ec2.amazonaws.com\",\n                    },\n                },\n            },\n        }),\n    });\n\n    var workerNodePolicy = new Aws.Iam.RolePolicyAttachment(\"worker-node-policy\", new()\n    {\n        Role = nodeRole.Name,\n        PolicyArn = \"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy\",\n    });\n\n    var cniPolicy = new Aws.Iam.RolePolicyAttachment(\"cni-policy\", new()\n    {\n        Role = nodeRole.Name,\n        PolicyArn = \"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy\",\n    });\n\n    var registryPolicy = new Aws.Iam.RolePolicyAttachment(\"registry-policy\", new()\n    {\n        Role = nodeRole.Name,\n        PolicyArn = \"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly\",\n    });\n\n    // The node group for running system pods (e.g. coredns, etc.)\n    var systemNodeGroup = new Eks.ManagedNodeGroup(\"system-node-group\", new()\n    {\n        Cluster = eksCluster,\n        NodeRole = nodeRole,\n    });\n\n    // The EFA device plugin for exposing EFA interfaces as extended resources\n    var devicePlugin = new Kubernetes.Helm.V3.Release(\"device-plugin\", new()\n    {\n        Version = \"0.5.7\",\n        RepositoryOpts = new Kubernetes.Types.Inputs.Helm.V3.RepositoryOptsArgs\n        {\n            Repo = \"https://aws.github.io/eks-charts\",\n        },\n        Chart = \"aws-efa-k8s-device-plugin\",\n        Namespace = \"kube-system\",\n        Atomic = true,\n        Values = \n        {\n            { \"tolerations\", new[]\n            {\n                \n                {\n                    { \"key\", \"efa-enabled\" },\n                    { \"operator\", \"Exists\" },\n                    { \"effect\", \"NoExecute\" },\n                },\n            } },\n        },\n    }, new CustomResourceOptions\n    {\n        Provider = k8SProvider,\n    });\n\n    // The node group for running EFA enabled workloads\n    var efaNodeGroup = new Eks.ManagedNodeGroup(\"efa-node-group\", new()\n    {\n        Cluster = eksCluster,\n        NodeRole = nodeRole,\n        InstanceTypes = new[]\n        {\n            \"g6.8xlarge\",\n        },\n        Gpu = true,\n        ScalingConfig = new Aws.Eks.Inputs.NodeGroupScalingConfigArgs\n        {\n            MinSize = 2,\n            DesiredSize = 2,\n            MaxSize = 4,\n        },\n        EnableEfaSupport = true,\n        PlacementGroupAvailabilityZone = \"us-west-2b\",\n\n        // Taint the nodes so that only pods with the efa-enabled label can be scheduled on them\n        Taints = new[]\n        {\n            new Aws.Eks.Inputs.NodeGroupTaintArgs\n            {\n                Key = \"efa-enabled\",\n                Value = \"true\",\n                Effect = \"NO_EXECUTE\",\n            },\n        },\n\n        // Instances with GPUs usually have nvme instance store volumes, so we can mount them in RAID-0 for kubelet and containerd\n        NodeadmExtraOptions = new[]\n        {\n            new Eks.Inputs.NodeadmOptionsArgs\n            {\n                ContentType = \"application/node.eks.aws\",\n                Content = @\"apiVersion: node.eks.aws/v1alpha1\nkind: NodeConfig\nspec:\n  instance:\n    localStorage:\n      strategy: RAID0\n\",\n            },\n        },\n    });\n\n});\n\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
             "properties": {
                 "nodeGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:eks%2FnodeGroup:NodeGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:eks%2FnodeGroup:NodeGroup",
                     "description": "The AWS managed node group."
                 },
                 "placementGroupName": {
@@ -1689,7 +1701,7 @@
                     "description": "Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed."
                 },
                 "launchTemplate": {
-                    "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate",
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FNodeGroupLaunchTemplate:NodeGroupLaunchTemplate",
                     "description": "Launch Template settings.\n\nNote: This field is mutually exclusive with `kubeletExtraArgs` and `bootstrapExtraArgs`."
                 },
                 "nodeGroupName": {
@@ -1701,7 +1713,7 @@
                     "description": "Creates a unique name beginning with the specified prefix. Conflicts with `nodeGroupName`."
                 },
                 "nodeRole": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2Frole:Role",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2Frole:Role",
                     "description": "The IAM Role that provides permissions for the EKS Node Group.\n\nNote, `nodeRole` and `nodeRoleArn` are mutually exclusive, and a single option must be used."
                 },
                 "nodeRoleArn": {
@@ -1728,11 +1740,11 @@
                     "description": "AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version."
                 },
                 "remoteAccess": {
-                    "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FNodeGroupRemoteAccess:NodeGroupRemoteAccess",
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FNodeGroupRemoteAccess:NodeGroupRemoteAccess",
                     "description": "Remote access settings."
                 },
                 "scalingConfig": {
-                    "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FNodeGroupScalingConfig:NodeGroupScalingConfig",
+                    "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FNodeGroupScalingConfig:NodeGroupScalingConfig",
                     "description": "Scaling settings.\n\nDefault scaling amounts of the node group autoscaling group are:\n  - desiredSize: 2\n  - minSize: 1\n  - maxSize: 2"
                 },
                 "subnetIds": {
@@ -1752,7 +1764,7 @@
                 "taints": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/types/aws:eks%2FNodeGroupTaint:NodeGroupTaint"
+                        "$ref": "/aws/v7.43.0/schema.json#/types/aws:eks%2FNodeGroupTaint:NodeGroupTaint"
                     },
                     "description": "The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group."
                 },
@@ -1777,18 +1789,18 @@
                     "description": "The AutoScalingGroup name for the Node group."
                 },
                 "cfnStack": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:cloudformation%2Fstack:Stack",
                     "description": "The CloudFormation Stack which defines the Node AutoScalingGroup."
                 },
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "description": "The additional security groups for the node group that captures user-specific rules."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`."
                 },
                 "nodeSecurityGroupId": {
@@ -1848,7 +1860,7 @@
                     "description": "The target EKS cluster."
                 },
                 "clusterIngressRule": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access."
                 },
                 "clusterIngressRuleId": {
@@ -1870,7 +1882,7 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
@@ -1879,7 +1891,7 @@
                     "description": "Use the latest recommended EKS Optimized Linux AMI with GPU support for the worker nodes from the AWS Systems Manager Parameter Store.\n\nDefaults to false.\n\nNote: `gpu` and `amiId` are mutually exclusive.\n\nSee for more details:\n- https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html\n- https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html"
                 },
                 "instanceProfile": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
                     "plain": true,
                     "description": "The IAM InstanceProfile to use on the NodeGroup. Properties instanceProfile and instanceProfileName are mutually exclusive."
                 },
@@ -1947,7 +1959,7 @@
                     "description": "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSecurityGroupId": {
@@ -2006,11 +2018,11 @@
             "description": "NodeGroupSecurityGroup is a component that wraps creating a security group for node groups with the default ingress \u0026 egress rules required to connect and work with the EKS cluster security group.",
             "properties": {
                 "securityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for node groups with the default ingress \u0026 egress rules required to connect and work with the EKS cluster security group."
                 },
                 "securityGroupRule": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The EKS cluster ingress rule."
                 }
             },
@@ -2020,11 +2032,11 @@
             ],
             "inputProperties": {
                 "clusterSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group associated with the EKS cluster."
                 },
                 "eksCluster": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:eks%2Fcluster:Cluster",
                     "description": "The EKS cluster associated with the worker node group"
                 },
                 "tags": {
@@ -2050,18 +2062,18 @@
             "description": "NodeGroup is a component that wraps the AWS EC2 instances that provide compute capacity for an EKS cluster.",
             "properties": {
                 "autoScalingGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:autoscaling%2Fgroup:Group",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:autoscaling%2Fgroup:Group",
                     "description": "The AutoScalingGroup for the Node group."
                 },
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "description": "The additional security groups for the node group that captures user-specific rules."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the node group to communicate with the cluster, or undefined if using `nodeSecurityGroupId`."
                 },
                 "nodeSecurityGroupId": {
@@ -2120,7 +2132,7 @@
                     "description": "The target EKS cluster."
                 },
                 "clusterIngressRule": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroupRule:SecurityGroupRule",
                     "description": "The ingress rule that gives node group access."
                 },
                 "clusterIngressRuleId": {
@@ -2142,7 +2154,7 @@
                 "extraNodeSecurityGroups": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
+                        "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup"
                     },
                     "description": "Extra security groups to attach on all nodes in this worker node group.\n\nThis additional set of security groups captures any user application rules that will be needed for the nodes."
                 },
@@ -2156,7 +2168,7 @@
                     "description": "Whether to ignore changes to the desired size of the Auto Scaling Group. This is useful when using Cluster Autoscaler.\n\nSee [EKS best practices](https://aws.github.io/aws-eks-best-practices/cluster-autoscaling/) for more details."
                 },
                 "instanceProfile": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:iam%2FinstanceProfile:InstanceProfile",
                     "plain": true,
                     "description": "The IAM InstanceProfile to use on the NodeGroup. Properties instanceProfile and instanceProfileName are mutually exclusive."
                 },
@@ -2186,7 +2198,7 @@
                 "launchTemplateTagSpecifications": {
                     "type": "array",
                     "items": {
-                        "$ref": "/aws/v7.14.0/schema.json#/types/aws:ec2%2FLaunchTemplateTagSpecification:LaunchTemplateTagSpecification"
+                        "$ref": "/aws/v7.43.0/schema.json#/types/aws:ec2%2FLaunchTemplateTagSpecification:LaunchTemplateTagSpecification"
                     },
                     "description": "The tag specifications to apply to the launch template."
                 },
@@ -2235,7 +2247,7 @@
                     "description": "Configured EBS type for a cluster node's root volume. Default is 'gp2'. Supported values are 'standard', 'gp2', 'gp3', 'st1', 'sc1', 'io1'."
                 },
                 "nodeSecurityGroup": {
-                    "$ref": "/aws/v7.14.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
+                    "$ref": "/aws/v7.43.0/schema.json#/resources/aws:ec2%2FsecurityGroup:SecurityGroup",
                     "description": "The security group for the worker node group to communicate with the cluster.\n\nThis security group requires specific inbound and outbound rules.\n\nSee for more details:\nhttps://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html\n\nNote: The `nodeSecurityGroup` option and the cluster option`nodeSecurityGroupTags` are mutually exclusive."
                 },
                 "nodeSecurityGroupId": {

--- a/sdk/dotnet/Cluster.cs
+++ b/sdk/dotnet/Cluster.cs
@@ -427,10 +427,34 @@ namespace Pulumi.Eks
         public Input<string>? IpFamily { get; set; }
 
         /// <summary>
+        /// Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+        /// 
+        /// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        /// </summary>
+        [Input("kubeApiServerConfig")]
+        public Input<Pulumi.Aws.Eks.Inputs.ClusterKubeApiServerConfigArgs>? KubeApiServerConfig { get; set; }
+
+        /// <summary>
+        /// Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+        /// 
+        /// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        /// </summary>
+        [Input("kubeControllerManagerConfig")]
+        public Input<Pulumi.Aws.Eks.Inputs.ClusterKubeControllerManagerConfigArgs>? KubeControllerManagerConfig { get; set; }
+
+        /// <summary>
         /// Options for managing the `kube-proxy` addon.
         /// </summary>
         [Input("kubeProxyAddonOptions")]
         public Inputs.KubeProxyAddonOptionsArgs? KubeProxyAddonOptions { get; set; }
+
+        /// <summary>
+        /// Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+        /// 
+        /// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        /// </summary>
+        [Input("kubeSchedulerConfig")]
+        public Input<Pulumi.Aws.Eks.Inputs.ClusterKubeSchedulerConfigArgs>? KubeSchedulerConfig { get; set; }
 
         /// <summary>
         /// The CIDR block to assign Kubernetes service IP addresses from. If you don't

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -4,7 +4,7 @@ go 1.25.11
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/pulumi/pulumi-aws/sdk/v7 v7.1.0
+	github.com/pulumi/pulumi-aws/sdk/v7 v7.43.0
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.9.1
 	github.com/pulumi/pulumi/sdk/v3 v3.256.0
 )

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -168,8 +168,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435cARxCW6q9gc0S/Yxz7Mkd38pOb0=
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
-github.com/pulumi/pulumi-aws/sdk/v7 v7.1.0 h1:Sh7P36gsoofcl3DI54nRODKcZCNAiTirFghekJCFtG4=
-github.com/pulumi/pulumi-aws/sdk/v7 v7.1.0/go.mod h1:+H62XwnzP7yBbBt+ytoZNwcZjdjCJA7tRP5zNdcDuMw=
+github.com/pulumi/pulumi-aws/sdk/v7 v7.43.0 h1:Z5+wr3Po7dlgIH1EX8JdYpTSuwHuq9lQl611kgyk8Ow=
+github.com/pulumi/pulumi-aws/sdk/v7 v7.43.0/go.mod h1:wImO2X5EeAVjuNtyJF/W/N96Q73tEO9t1Ne9Uqa50Ps=
 github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.9.1 h1:dgazi5bI3Vxz+aLuH+DxRqKxPWGaFIkT3fIepHr7h0g=
 github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.9.1/go.mod h1:O8hanLXCEXiyzA8gIeME5o/SmJ39Vyy9wLcBYCFpOp0=
 github.com/pulumi/pulumi/sdk/v3 v3.256.0 h1:OrkIu7Iw3HUcMtoEy2uzpD21C32B5EYBLBgBoh/uQPM=

--- a/sdk/go/eks/cluster.go
+++ b/sdk/go/eks/cluster.go
@@ -215,8 +215,20 @@ type clusterArgs struct {
 	// The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
 	// You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
 	IpFamily *string `pulumi:"ipFamily"`
+	// Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+	//
+	// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+	KubeApiServerConfig *eks.ClusterKubeApiServerConfig `pulumi:"kubeApiServerConfig"`
+	// Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+	//
+	// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+	KubeControllerManagerConfig *eks.ClusterKubeControllerManagerConfig `pulumi:"kubeControllerManagerConfig"`
 	// Options for managing the `kube-proxy` addon.
 	KubeProxyAddonOptions *KubeProxyAddonOptions `pulumi:"kubeProxyAddonOptions"`
+	// Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+	//
+	// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+	KubeSchedulerConfig *eks.ClusterKubeSchedulerConfig `pulumi:"kubeSchedulerConfig"`
 	// The CIDR block to assign Kubernetes service IP addresses from. If you don't
 	// specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or
 	// 172.20.0.0/16 CIDR blocks. This setting only applies to IPv4 clusters. We recommend that you specify a block
@@ -464,8 +476,20 @@ type ClusterArgs struct {
 	// The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
 	// You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
 	IpFamily pulumi.StringPtrInput
+	// Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+	//
+	// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+	KubeApiServerConfig eks.ClusterKubeApiServerConfigPtrInput
+	// Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+	//
+	// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+	KubeControllerManagerConfig eks.ClusterKubeControllerManagerConfigPtrInput
 	// Options for managing the `kube-proxy` addon.
 	KubeProxyAddonOptions *KubeProxyAddonOptionsArgs
+	// Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+	//
+	// For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+	KubeSchedulerConfig eks.ClusterKubeSchedulerConfigPtrInput
 	// The CIDR block to assign Kubernetes service IP addresses from. If you don't
 	// specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or
 	// 172.20.0.0/16 CIDR blocks. This setting only applies to IPv4 clusters. We recommend that you specify a block

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -45,7 +45,7 @@ repositories {
 dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("com.google.code.gson:gson:2.8.9")
-    implementation("com.pulumi:aws:7.14.0")
+    implementation("com.pulumi:aws:7.43.0")
     implementation("com.pulumi:kubernetes:4.19.0")
     implementation("com.pulumi:pulumi:1.0.0")
 }

--- a/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/eks/ClusterArgs.java
@@ -4,6 +4,9 @@
 package com.pulumi.eks;
 
 import com.pulumi.aws.ec2.SecurityGroup;
+import com.pulumi.aws.eks.inputs.ClusterKubeApiServerConfigArgs;
+import com.pulumi.aws.eks.inputs.ClusterKubeControllerManagerConfigArgs;
+import com.pulumi.aws.eks.inputs.ClusterKubeSchedulerConfigArgs;
 import com.pulumi.aws.eks.inputs.ClusterUpgradePolicyArgs;
 import com.pulumi.aws.iam.Role;
 import com.pulumi.core.Either;
@@ -496,6 +499,44 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Advanced configuration for the cluster&#39;s Kubernetes API server. Requires Kubernetes version 1.31 or later.
+     * 
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     * 
+     */
+    @Import(name="kubeApiServerConfig")
+    private @Nullable Output<ClusterKubeApiServerConfigArgs> kubeApiServerConfig;
+
+    /**
+     * @return Advanced configuration for the cluster&#39;s Kubernetes API server. Requires Kubernetes version 1.31 or later.
+     * 
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     * 
+     */
+    public Optional<Output<ClusterKubeApiServerConfigArgs>> kubeApiServerConfig() {
+        return Optional.ofNullable(this.kubeApiServerConfig);
+    }
+
+    /**
+     * Advanced configuration for the cluster&#39;s Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+     * 
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     * 
+     */
+    @Import(name="kubeControllerManagerConfig")
+    private @Nullable Output<ClusterKubeControllerManagerConfigArgs> kubeControllerManagerConfig;
+
+    /**
+     * @return Advanced configuration for the cluster&#39;s Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+     * 
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     * 
+     */
+    public Optional<Output<ClusterKubeControllerManagerConfigArgs>> kubeControllerManagerConfig() {
+        return Optional.ofNullable(this.kubeControllerManagerConfig);
+    }
+
+    /**
      * Options for managing the `kube-proxy` addon.
      * 
      */
@@ -508,6 +549,25 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<KubeProxyAddonOptionsArgs> kubeProxyAddonOptions() {
         return Optional.ofNullable(this.kubeProxyAddonOptions);
+    }
+
+    /**
+     * Advanced configuration for the cluster&#39;s Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+     * 
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     * 
+     */
+    @Import(name="kubeSchedulerConfig")
+    private @Nullable Output<ClusterKubeSchedulerConfigArgs> kubeSchedulerConfig;
+
+    /**
+     * @return Advanced configuration for the cluster&#39;s Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+     * 
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     * 
+     */
+    public Optional<Output<ClusterKubeSchedulerConfigArgs>> kubeSchedulerConfig() {
+        return Optional.ofNullable(this.kubeSchedulerConfig);
     }
 
     /**
@@ -1181,7 +1241,10 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         this.instanceRoles = $.instanceRoles;
         this.instanceType = $.instanceType;
         this.ipFamily = $.ipFamily;
+        this.kubeApiServerConfig = $.kubeApiServerConfig;
+        this.kubeControllerManagerConfig = $.kubeControllerManagerConfig;
         this.kubeProxyAddonOptions = $.kubeProxyAddonOptions;
+        this.kubeSchedulerConfig = $.kubeSchedulerConfig;
         this.kubernetesServiceIpAddressRange = $.kubernetesServiceIpAddressRange;
         this.maxSize = $.maxSize;
         this.minSize = $.minSize;
@@ -1813,6 +1876,56 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param kubeApiServerConfig Advanced configuration for the cluster&#39;s Kubernetes API server. Requires Kubernetes version 1.31 or later.
+         * 
+         * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeApiServerConfig(@Nullable Output<ClusterKubeApiServerConfigArgs> kubeApiServerConfig) {
+            $.kubeApiServerConfig = kubeApiServerConfig;
+            return this;
+        }
+
+        /**
+         * @param kubeApiServerConfig Advanced configuration for the cluster&#39;s Kubernetes API server. Requires Kubernetes version 1.31 or later.
+         * 
+         * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeApiServerConfig(ClusterKubeApiServerConfigArgs kubeApiServerConfig) {
+            return kubeApiServerConfig(Output.of(kubeApiServerConfig));
+        }
+
+        /**
+         * @param kubeControllerManagerConfig Advanced configuration for the cluster&#39;s Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+         * 
+         * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeControllerManagerConfig(@Nullable Output<ClusterKubeControllerManagerConfigArgs> kubeControllerManagerConfig) {
+            $.kubeControllerManagerConfig = kubeControllerManagerConfig;
+            return this;
+        }
+
+        /**
+         * @param kubeControllerManagerConfig Advanced configuration for the cluster&#39;s Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+         * 
+         * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeControllerManagerConfig(ClusterKubeControllerManagerConfigArgs kubeControllerManagerConfig) {
+            return kubeControllerManagerConfig(Output.of(kubeControllerManagerConfig));
+        }
+
+        /**
          * @param kubeProxyAddonOptions Options for managing the `kube-proxy` addon.
          * 
          * @return builder
@@ -1821,6 +1934,31 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         public Builder kubeProxyAddonOptions(@Nullable KubeProxyAddonOptionsArgs kubeProxyAddonOptions) {
             $.kubeProxyAddonOptions = kubeProxyAddonOptions;
             return this;
+        }
+
+        /**
+         * @param kubeSchedulerConfig Advanced configuration for the cluster&#39;s Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+         * 
+         * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeSchedulerConfig(@Nullable Output<ClusterKubeSchedulerConfigArgs> kubeSchedulerConfig) {
+            $.kubeSchedulerConfig = kubeSchedulerConfig;
+            return this;
+        }
+
+        /**
+         * @param kubeSchedulerConfig Advanced configuration for the cluster&#39;s Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+         * 
+         * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+         * 
+         * @return builder
+         * 
+         */
+        public Builder kubeSchedulerConfig(ClusterKubeSchedulerConfigArgs kubeSchedulerConfig) {
+            return kubeSchedulerConfig(Output.of(kubeSchedulerConfig));
         }
 
         /**

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -166,7 +166,10 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["instanceRoles"] = args?.instanceRoles;
             resourceInputs["instanceType"] = args?.instanceType;
             resourceInputs["ipFamily"] = args?.ipFamily;
+            resourceInputs["kubeApiServerConfig"] = args?.kubeApiServerConfig;
+            resourceInputs["kubeControllerManagerConfig"] = args?.kubeControllerManagerConfig;
             resourceInputs["kubeProxyAddonOptions"] = args ? (args.kubeProxyAddonOptions ? inputs.kubeProxyAddonOptionsArgsProvideDefaults(args.kubeProxyAddonOptions) : undefined) : undefined;
+            resourceInputs["kubeSchedulerConfig"] = args?.kubeSchedulerConfig;
             resourceInputs["kubernetesServiceIpAddressRange"] = args?.kubernetesServiceIpAddressRange;
             resourceInputs["maxSize"] = args?.maxSize;
             resourceInputs["minSize"] = args?.minSize;
@@ -409,9 +412,27 @@ export interface ClusterArgs {
      */
     ipFamily?: pulumi.Input<string>;
     /**
+     * Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+     *
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     */
+    kubeApiServerConfig?: pulumi.Input<pulumiAws.types.input.eks.ClusterKubeApiServerConfig>;
+    /**
+     * Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+     *
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     */
+    kubeControllerManagerConfig?: pulumi.Input<pulumiAws.types.input.eks.ClusterKubeControllerManagerConfig>;
+    /**
      * Options for managing the `kube-proxy` addon.
      */
     kubeProxyAddonOptions?: inputs.KubeProxyAddonOptionsArgs;
+    /**
+     * Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+     *
+     * For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+     */
+    kubeSchedulerConfig?: pulumi.Input<pulumiAws.types.input.eks.ClusterKubeSchedulerConfig>;
     /**
      * The CIDR block to assign Kubernetes service IP addresses from. If you don't
      * specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -4,7 +4,8 @@
     "keywords": [
         "pulumi",
         "aws",
-        "eks"
+        "eks",
+        "kind/component"
     ],
     "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-eks",
@@ -13,7 +14,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^7.14.0",
+        "@pulumi/aws": "^7.43.0",
         "@pulumi/kubernetes": "^4.19.0",
         "@pulumi/pulumi": "^3.142.0",
         "https-proxy-agent": "^5.0.1",

--- a/sdk/python/pulumi_eks/cluster.py
+++ b/sdk/python/pulumi_eks/cluster.py
@@ -50,7 +50,10 @@ class ClusterArgs:
                  instance_roles: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.iam.Role']]]] = None,
                  instance_type: Optional[pulumi.Input[_builtins.str]] = None,
                  ip_family: Optional[pulumi.Input[_builtins.str]] = None,
+                 kube_api_server_config: Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeApiServerConfigArgs']] = None,
+                 kube_controller_manager_config: Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs']] = None,
                  kube_proxy_addon_options: Optional['KubeProxyAddonOptionsArgs'] = None,
+                 kube_scheduler_config: Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs']] = None,
                  kubernetes_service_ip_address_range: Optional[pulumi.Input[_builtins.str]] = None,
                  max_size: Optional[pulumi.Input[_builtins.int]] = None,
                  min_size: Optional[pulumi.Input[_builtins.int]] = None,
@@ -151,7 +154,16 @@ class ClusterArgs:
         :param pulumi.Input[_builtins.str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[_builtins.str] ip_family: The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
                You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
+        :param pulumi.Input['pulumi_aws.eks.ClusterKubeApiServerConfigArgs'] kube_api_server_config: Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+               
+               For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        :param pulumi.Input['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs'] kube_controller_manager_config: Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+               
+               For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
         :param 'KubeProxyAddonOptionsArgs' kube_proxy_addon_options: Options for managing the `kube-proxy` addon.
+        :param pulumi.Input['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs'] kube_scheduler_config: Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+               
+               For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
         :param pulumi.Input[_builtins.str] kubernetes_service_ip_address_range: The CIDR block to assign Kubernetes service IP addresses from. If you don't
                specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or
                172.20.0.0/16 CIDR blocks. This setting only applies to IPv4 clusters. We recommend that you specify a block
@@ -323,8 +335,14 @@ class ClusterArgs:
             pulumi.set(__self__, "instance_type", instance_type)
         if ip_family is not None:
             pulumi.set(__self__, "ip_family", ip_family)
+        if kube_api_server_config is not None:
+            pulumi.set(__self__, "kube_api_server_config", kube_api_server_config)
+        if kube_controller_manager_config is not None:
+            pulumi.set(__self__, "kube_controller_manager_config", kube_controller_manager_config)
         if kube_proxy_addon_options is not None:
             pulumi.set(__self__, "kube_proxy_addon_options", kube_proxy_addon_options)
+        if kube_scheduler_config is not None:
+            pulumi.set(__self__, "kube_scheduler_config", kube_scheduler_config)
         if kubernetes_service_ip_address_range is not None:
             pulumi.set(__self__, "kubernetes_service_ip_address_range", kubernetes_service_ip_address_range)
         if max_size is not None:
@@ -731,6 +749,34 @@ class ClusterArgs:
         pulumi.set(self, "ip_family", value)
 
     @_builtins.property
+    @pulumi.getter(name="kubeApiServerConfig")
+    def kube_api_server_config(self) -> Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeApiServerConfigArgs']]:
+        """
+        Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+
+        For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        """
+        return pulumi.get(self, "kube_api_server_config")
+
+    @kube_api_server_config.setter
+    def kube_api_server_config(self, value: Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeApiServerConfigArgs']]):
+        pulumi.set(self, "kube_api_server_config", value)
+
+    @_builtins.property
+    @pulumi.getter(name="kubeControllerManagerConfig")
+    def kube_controller_manager_config(self) -> Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs']]:
+        """
+        Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+
+        For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        """
+        return pulumi.get(self, "kube_controller_manager_config")
+
+    @kube_controller_manager_config.setter
+    def kube_controller_manager_config(self, value: Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs']]):
+        pulumi.set(self, "kube_controller_manager_config", value)
+
+    @_builtins.property
     @pulumi.getter(name="kubeProxyAddonOptions")
     def kube_proxy_addon_options(self) -> Optional['KubeProxyAddonOptionsArgs']:
         """
@@ -741,6 +787,20 @@ class ClusterArgs:
     @kube_proxy_addon_options.setter
     def kube_proxy_addon_options(self, value: Optional['KubeProxyAddonOptionsArgs']):
         pulumi.set(self, "kube_proxy_addon_options", value)
+
+    @_builtins.property
+    @pulumi.getter(name="kubeSchedulerConfig")
+    def kube_scheduler_config(self) -> Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs']]:
+        """
+        Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+
+        For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        """
+        return pulumi.get(self, "kube_scheduler_config")
+
+    @kube_scheduler_config.setter
+    def kube_scheduler_config(self, value: Optional[pulumi.Input['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs']]):
+        pulumi.set(self, "kube_scheduler_config", value)
 
     @_builtins.property
     @pulumi.getter(name="kubernetesServiceIpAddressRange")
@@ -1235,7 +1295,10 @@ class Cluster(pulumi.ComponentResource):
                  instance_roles: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.iam.Role']]]] = None,
                  instance_type: Optional[pulumi.Input[_builtins.str]] = None,
                  ip_family: Optional[pulumi.Input[_builtins.str]] = None,
+                 kube_api_server_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeApiServerConfigArgs']]] = None,
+                 kube_controller_manager_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs']]] = None,
                  kube_proxy_addon_options: Optional[Union['KubeProxyAddonOptionsArgs', 'KubeProxyAddonOptionsArgsDict']] = None,
+                 kube_scheduler_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs']]] = None,
                  kubernetes_service_ip_address_range: Optional[pulumi.Input[_builtins.str]] = None,
                  max_size: Optional[pulumi.Input[_builtins.int]] = None,
                  min_size: Optional[pulumi.Input[_builtins.int]] = None,
@@ -1358,7 +1421,16 @@ class Cluster(pulumi.ComponentResource):
         :param pulumi.Input[_builtins.str] instance_type: The instance type to use for the cluster's nodes. Defaults to "t3.medium".
         :param pulumi.Input[_builtins.str] ip_family: The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`.
                You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
+        :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeApiServerConfigArgs']] kube_api_server_config: Advanced configuration for the cluster's Kubernetes API server. Requires Kubernetes version 1.31 or later.
+               
+               For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
+        :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs']] kube_controller_manager_config: Advanced configuration for the cluster's Kubernetes controller manager. Requires Kubernetes version 1.31 or later, and a cluster using EKS Provisioned Control Plane.
+               
+               For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
         :param Union['KubeProxyAddonOptionsArgs', 'KubeProxyAddonOptionsArgsDict'] kube_proxy_addon_options: Options for managing the `kube-proxy` addon.
+        :param pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs']] kube_scheduler_config: Advanced configuration for the cluster's Kubernetes scheduler. Requires Kubernetes version 1.31 or later.
+               
+               For more information, see: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html
         :param pulumi.Input[_builtins.str] kubernetes_service_ip_address_range: The CIDR block to assign Kubernetes service IP addresses from. If you don't
                specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or
                172.20.0.0/16 CIDR blocks. This setting only applies to IPv4 clusters. We recommend that you specify a block
@@ -1547,7 +1619,10 @@ class Cluster(pulumi.ComponentResource):
                  instance_roles: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.iam.Role']]]] = None,
                  instance_type: Optional[pulumi.Input[_builtins.str]] = None,
                  ip_family: Optional[pulumi.Input[_builtins.str]] = None,
+                 kube_api_server_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeApiServerConfigArgs']]] = None,
+                 kube_controller_manager_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeControllerManagerConfigArgs']]] = None,
                  kube_proxy_addon_options: Optional[Union['KubeProxyAddonOptionsArgs', 'KubeProxyAddonOptionsArgsDict']] = None,
+                 kube_scheduler_config: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.eks.ClusterKubeSchedulerConfigArgs']]] = None,
                  kubernetes_service_ip_address_range: Optional[pulumi.Input[_builtins.str]] = None,
                  max_size: Optional[pulumi.Input[_builtins.int]] = None,
                  min_size: Optional[pulumi.Input[_builtins.int]] = None,
@@ -1615,7 +1690,10 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["instance_roles"] = instance_roles
             __props__.__dict__["instance_type"] = instance_type
             __props__.__dict__["ip_family"] = ip_family
+            __props__.__dict__["kube_api_server_config"] = kube_api_server_config
+            __props__.__dict__["kube_controller_manager_config"] = kube_controller_manager_config
             __props__.__dict__["kube_proxy_addon_options"] = kube_proxy_addon_options
+            __props__.__dict__["kube_scheduler_config"] = kube_scheduler_config
             __props__.__dict__["kubernetes_service_ip_address_range"] = kubernetes_service_ip_address_range
             __props__.__dict__["max_size"] = max_size
             __props__.__dict__["min_size"] = min_size

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
   name = "pulumi_eks"
   description = "Pulumi Amazon Web Services (AWS) EKS Components."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "pulumi-aws>=7.14.0,<8.0.0", "pulumi-kubernetes>=4.19.0,<5.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
-  keywords = ["pulumi", "aws", "eks"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "pulumi-aws>=7.43.0,<8.0.0", "pulumi-kubernetes>=4.19.0,<5.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  keywords = ["pulumi", "aws", "eks", "kind/component"]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "4.0.0a0+dev"


### PR DESCRIPTION
### Proposed changes

Adds `kubeSchedulerConfig`, `kubeApiServerConfig` and `kubeControllerManagerConfig` to `eks.Cluster`, passed straight through to `aws.eks.Cluster`. This exposes AWS's [advanced Kubernetes control plane configuration](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-configuration.html) to clusters created through this component.

All three are optional with no default, so leaving them unset sends nothing and AWS's own defaults apply — no change for existing users. I followed `upgradePolicy` (#1787) file-for-file, including exposing them on `ClusterResult`.

These types only exist in `@pulumi/aws` 7.42.0+, so this bumps `nodejs/eks` from 7.25.0 to 7.43.0 (and `sdk/go.mod` to match, or the Go SDK doesn't compile). That bump surfaces 7 pre-existing type errors in `nodegroup.ts`, because optional list and string inputs are now typed `Input<T | undefined>` rather than `Input<T> | undefined`. **This is the same breakage currently blocking #2209**, so this PR should unblock that too. I fixed them by widening the affected signatures and guarding the resolved values rather than casting, so runtime behaviour is unchanged — with one deliberate exception, called out in its own commit: in `getRecommendedAMI`, `version` now falls back with `version ?? clusterVersion`. Previously an `args.version` that *resolved* to `undefined` was passed straight into `ssmParameterName`, producing a malformed SSM parameter path.

Regenerating the schema also flips 57 `/aws/v7.14.0` refs to `v7.43.0`. That's pre-existing drift the regen picks up, purely mechanical.

The example sets `kubeSchedulerConfig` only. `kubeControllerManagerConfig` requires EKS Provisioned Control Plane, so it would fail on the test cluster.

Split into three commits — the `nodegroup.ts` type fixes, the dependency bump, then the feature plus regenerated schema and SDKs — in case you'd rather take them separately.

Verified locally: `tsc` clean, 417/417 unit tests with snapshots, `make build_nodejs`, `go build ./go/...`, `make provider` and the provider tests. dotnet, java and python SDKs are regenerated but I can't build those here. I did not run the integration tests, since they create real EKS clusters.

One thing to watch: regenerating the nodejs SDK on my machine rewrites the `sdk/nodejs/types/*.ts` imports from `../utilities` to `./utilities`, which doesn't compile. I reproduced that on an unmodified `master`, so it isn't coming from this change, and I reverted those files (along with `sdk/java/settings.gradle` and the version stamp in `build.gradle`) to keep the diff to what this change actually needs. If `build_sdk (nodejs)` disagrees, take CI's version of those files.

### Related issues

Fixes #2367
