### PR TITLE
Update dependency @pulumi/aws to v7.43.0 and fix nodegroup input types

### DIFF
--- a/examples/aws-profile-role/package.json
+++ b/examples/aws-profile-role/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^22"
     },
     "dependencies": {
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/awsx": "^3.0.0",
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/eks": "latest"

--- a/examples/cluster/package.json
+++ b/examples/cluster/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
         "@pulumi/awsx": "^3.0.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     },
     "scripts": {

--- a/examples/deletion-policy/package.json
+++ b/examples/deletion-policy/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
         "@pulumi/awsx": "3.5.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     },
     "scripts": {

--- a/examples/encryption-provider/package.json
+++ b/examples/encryption-provider/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/kubernetesx": "0.1.6",
         "@pulumi/random": "4.16.8",
         "@pulumi/eks": "latest"

--- a/examples/ensure-cni-upgrade/package.json
+++ b/examples/ensure-cni-upgrade/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
         "@pulumi/awsx": "^3.0.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/examples/extra-sg/package.json
+++ b/examples/extra-sg/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/examples/modify-default-eks-sg/package.json
+++ b/examples/modify-default-eks-sg/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/examples/network-policies/package.json
+++ b/examples/network-policies/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest",
         "@pulumi/pulumi": "3.144.1"
     }

--- a/examples/nodegroup/package.json
+++ b/examples/nodegroup/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/examples/oidc-iam-sa/package.json
+++ b/examples/oidc-iam-sa/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^22"
     },
     "dependencies": {
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest",
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/pulumi": "3.144.1"

--- a/examples/pod-security-groups/package.json
+++ b/examples/pod-security-groups/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/awsx": "^3.0.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest",
         "@pulumi/pulumi": "3.144.1"
     }

--- a/examples/scoped-kubeconfigs/package.json
+++ b/examples/scoped-kubeconfigs/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^22"
     },
     "dependencies": {
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest",
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/pulumi": "3.144.1"

--- a/examples/tags/package.json
+++ b/examples/tags/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "3.144.1",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/eks": "latest"
     }
 }

--- a/nodejs/eks/nodes/instances.ts
+++ b/nodejs/eks/nodes/instances.ts
@@ -19,7 +19,7 @@ export const DEFAULT_INSTANCE_TYPE = "t3.medium";
 
 export interface GetEfaNetworkInterfacesArgs {
     // The instance types configured for the node group.
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined;
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined;
     // The security group IDs to associate with the network interfaces.
     securityGroupIds: pulumi.Input<pulumi.Input<string>[]>;
     // The property path to use for the instance type in error messages.
@@ -118,7 +118,7 @@ export function getEfaNetworkInterfaces(
 export function filterEfaSubnets(
     subnetIds: pulumi.Input<pulumi.Input<string>[]>,
     placementGroupAvailabilityZone: pulumi.Input<string>,
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined,
     opts: pulumi.InvokeOptions,
 ): pulumi.Output<string[]> {
     const instanceType = getEfaInstanceType(instanceTypes);
@@ -199,11 +199,11 @@ function getSupportedAZs(
  * @returns The first instance type from the list, or "t3.medium" if no instance types are provided
  */
 function getEfaInstanceType(
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined,
 ): pulumi.Output<string> {
     return instanceTypes
         ? pulumi.output(instanceTypes).apply((types) => {
-              return types.length > 0 ? types[0] : DEFAULT_INSTANCE_TYPE;
+              return types && types.length > 0 ? types[0] : DEFAULT_INSTANCE_TYPE;
           })
         : pulumi.output(DEFAULT_INSTANCE_TYPE);
 }

--- a/nodejs/eks/nodes/nodegroup.ts
+++ b/nodejs/eks/nodes/nodegroup.ts
@@ -2156,7 +2156,7 @@ function createMNGCustomLaunchTemplate(
 
     const taints = args.taints
         ? pulumi.output(args.taints).apply((taints) => {
-              return taints
+              return (taints ?? [])
                   .map((taint) => {
                       return {
                           [taint.key]: {
@@ -2351,7 +2351,7 @@ function getRecommendedAMI(
     k8sVersion: pulumi.Output<string>,
     parent: pulumi.Resource | undefined,
 ): pulumi.Input<string> {
-    let instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined;
+    let instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined;
     let instanceTypesPropertyPath: string = "";
     if ("instanceType" in args && args.instanceType) {
         instanceTypes = [args.instanceType];
@@ -2369,7 +2369,7 @@ function getRecommendedAMI(
 
     const amiType = args.amiType
         ? pulumi.output(args.amiType).apply((amiType) => {
-              const resolvedType = toAmiType(amiType);
+              const resolvedType = amiType === undefined ? undefined : toAmiType(amiType);
               if (resolvedType === undefined) {
                   throw new pulumi.InputPropertyError({
                       propertyPath: "amiType",
@@ -2381,7 +2381,9 @@ function getRecommendedAMI(
         : determineAmiType(os, args.gpu, instanceTypes, instanceTypesPropertyPath, parent);
 
     // if specified use the version from the args, otherwise use the version from the cluster.
-    const version = args.version ? args.version : k8sVersion;
+    const version = pulumi
+        .all([args.version, k8sVersion])
+        .apply(([version, clusterVersion]) => version ?? clusterVersion);
 
     return pulumi.all([amiType, version]).apply(([amiType, version]) => {
         const parameterName = getAmiMetadata(amiType).ssmParameterName(version);
@@ -2430,7 +2432,7 @@ export function isGravitonInstance(instanceType: string, propertyPath: string): 
 function determineAmiType(
     os: pulumi.Input<OperatingSystem>,
     gpu: pulumi.Input<boolean> | undefined,
-    instanceTypes: pulumi.Input<pulumi.Input<string>[]> | undefined,
+    instanceTypes: pulumi.Input<pulumi.Input<string>[] | undefined> | undefined,
     instanceTypesPropertyPath: string,
     parent: pulumi.Resource | undefined,
 ): pulumi.Output<AmiType> {

--- a/nodejs/eks/package.json
+++ b/nodejs/eks/package.json
@@ -27,7 +27,7 @@
     "bugs": "https://github.com/pulumi/pulumi-eks/issues",
     "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@pulumi/aws": "7.25.0",
+        "@pulumi/aws": "7.43.0",
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/pulumi": "^3.143.0",
         "https-proxy-agent": "^5.0.1",

--- a/nodejs/eks/yarn.lock
+++ b/nodejs/eks/yarn.lock
@@ -1763,10 +1763,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/aws@7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.25.0.tgz#d831f99e4e5faac496d36b3f3726b50cc1bba818"
-  integrity sha512-qP2ikhFJrw/NrizaOBWiAGkHe003+fPT5Blsc4X1q8uQ0CpmjnPAbbsotpI13hVBU4a2sflIX4GkHcXzRU9QQw==
+"@pulumi/aws@7.43.0":
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.43.0.tgz#84e4d90e83ebf32e05c64a2bf15c51aeee86d1ae"
+  integrity sha512-UCZCrOBn1xVu5CSfd9I3FNZCPkdEcXaB6XNacTj0wVB9iPj8Ma6dLnbfLsUT2ceGsmSMrhwOMvnacOrrhG722A==
   dependencies:
     "@pulumi/pulumi" "^3.142.0"
     mime "^2.0.0"


### PR DESCRIPTION
### TL;DR

`@pulumi/aws` v7.30.0 moved `undefined` inside the `Input<>` wrapper for optional inputs
SDK-wide. `nodegroup.ts` doesn't compile against that, which is why the bump in #2209 fails
`build_provider`. This PR does the bump **and** the type fix together so CI stays green.

### Proposed changes

Bumps `@pulumi/aws` from 7.25.0 to 7.43.0 (same bump as #2209) and fixes the TypeScript
compile errors that bump surfaces.

**Why the bump alone fails**

`@pulumi/aws` v7.30.0 changed optional inputs SDK-wide, moving `undefined` inside the
`Input<>` wrapper:

```diff
-    amiType?:       pulumi.Input<string>;
+    amiType?:       pulumi.Input<string | undefined>;
-    instanceTypes?: pulumi.Input<pulumi.Input<string>[]>;
+    instanceTypes?: pulumi.Input<pulumi.Input<string>[] | undefined>;
-    taints?:        pulumi.Input<pulumi.Input<inputs.eks.NodeGroupTaint>[]>;
+    taints?:        pulumi.Input<pulumi.Input<inputs.eks.NodeGroupTaint>[] | undefined>;
-    version?:       pulumi.Input<string>;
+    version?:       pulumi.Input<string | undefined>;
```

This is codegen-wide, not EKS-specific — `ec2/instance`, `ecs/service` and `rds/instance`
pick up the same shape in v7.30.0.

`Input<T> | undefined` is assignable once null-checked; `Input<T | undefined>` is not, because
the `undefined` survives into the `Promise`/`Output` branch. Since `ManagedNodeGroupOptions`
derives from `aws.eks.NodeGroupArgs`, `tsc` fails with 7 errors in `nodes/nodegroup.ts`
(lines 2002, 2079, 2159, 2274, 2360, 2372, 2387) — which is what fails `build_provider` on
#2209 today, in turn skipping the `test` job.

**The fix**

Widen the affected signatures in `nodes/instances.ts` and `nodes/nodegroup.ts` to accept the
new shape and guard the resolved values, rather than casting the `undefined` away.

One behaviour change beyond types, in `getRecommendedAMI`: `version` now resolves with
`version ?? clusterVersion`. Previously an `args.version` that was truthy as an `Output` but
resolved to `undefined` was passed straight into `ssmParameterName`, producing a malformed
SSM parameter path.

These changes are backwards-compatible — the source still compiles against 7.25.0.

**Verification**

- `tsc` — clean against both 7.25.0 and 7.43.0
- `yarn test` — 417 tests / 10 suites / 18 snapshots pass
- `yarn check-duplicate-deps` — clean

### Related issues

- Supersedes #2209 — same bump, plus the type fix that bump needs to compile.
- Related to #2367 — the advanced control plane config types only exist in `@pulumi/aws`
  7.42.0+, so this bump is a prerequisite for that. Split out of #2368 to keep the dependency
  change reviewable on its own.
